### PR TITLE
change command how to install HomeBrew

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,7 +27,7 @@ echo
 # install homebrew
 if ! command -v brew >/dev/null 2>&1; then
   # Install homebrew: https://brew.sh/
-  /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
   echo
 fi
 brew bundle


### PR DESCRIPTION
HomeBrewがRuby -> bashでのInstallに変わっていたことに伴う変更をしました。
参考: https://brew.sh/