### PR TITLE
Remove xcode dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ My dear dotfiles.
 * ☑️ Sign in Apple ID (System Preferences => Click "Sign in" => ...)
 * ☑️ Set password of login user (System Preferences => Users and Groups => ...)
 * ☑️ Install Developer Tools: `xcode-select --install`
-* ☑️Install Xcode from App Store for mas
 
 ## Boostrapping
 

--- a/bootstrap/main.sh
+++ b/bootstrap/main.sh
@@ -5,13 +5,6 @@
 
 set -eu
 
-if ! command -v xcodebuild 1>/dev/null; then
-  echo 'Xcode is not installed.'
-  echo 'mas requires Xcode. Please install the latest version of Xcode from App Store.'
-  echo 'For more info, see https://github.com/mas-cli/mas.'
-  exit 1
-fi
-
 if [ "$(xcode-select -p 1>/dev/null; echo $?)" != 0 ]; then
   echo 'Command line tool is not installed.'
   echo 'Invoked installation.'


### PR DESCRIPTION
Xcode is only needed in older versions of macOS?

https://github.com/mas-cli/mas/tree/4c044d8b649989e924e11252b2e063a81c60d866#%EF%B8%8F-older-macos-versions