### PR TITLE
docs: Improve Mac setup instructions and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ My dear dotfiles.
 
 ## Set up your new Mac
 
-* ☑️ Update macOS to the latest version (System Preferences => Software Update => ...)
-* ☑️ Set language and reboot (System Preferences => Language and Region => Click plus button => ...)
+### Initial Setup (usually done in setup wizard)
+Complete these during initial Mac setup or from System Preferences (reboot required if changed later):
+* ☑️ Update macOS to the latest version
+* ☑️ Set language
 * ☑️ Connect to internet
-* ☑️ Sign in Apple ID (System Preferences => Click "Sign in" => ...)
-* ☑️ Set password of login user (System Preferences => Users and Groups => ...)
+* ☑️ Sign in with Apple ID
+* ☑️ Set password for login user
+
+### Required Manual Steps
 * ☑️ Install Developer Tools: `xcode-select --install`
 * ☑️ Grant Full Disk Access to Terminal (System Preferences => Privacy & Security => Privacy => Full Disk Access => Add Terminal.app)
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ My dear dotfiles.
 
 ## Set up your new Mac
 
+* ☑️ Update macOS to the latest version (System Preferences => Software Update => ...)
 * ☑️ Set language and reboot (System Preferences => Language and Region => Click plus button => ...)
 * ☑️ Connect to internet
 * ☑️ Sign in Apple ID (System Preferences => Click "Sign in" => ...)
 * ☑️ Set password of login user (System Preferences => Users and Groups => ...)
 * ☑️ Install Developer Tools: `xcode-select --install`
+* ☑️ Grant Full Disk Access to Terminal (System Preferences => Privacy & Security => Privacy => Full Disk Access => Add Terminal.app)
 
 ## Boostrapping
 


### PR DESCRIPTION
## 概要
新しいMacのセットアップ時に気づいた改善点を反映

## 変更内容
- macOS updateを最初のステップとして追加
- Terminal.appにFull Disk Accessの権限付与が必要であることを明記
- セットアップ手順を「Initial Setup」と「Required Manual Steps」に整理
- 設定を後から変更した場合は再起動が必要である旨を追記
- System Preferencesへの詳細パスを削除してシンプルに

## テスト
- [ ] READMEの表示確認
- [ ] 手順の妥当性確認

## その他
新しいMacセットアップ時の実体験に基づく改善