### PR TITLE
docs: Add AGENTS.md symlink to AIRULES.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+AIRULES.md


### PR DESCRIPTION
目的

- ツールが `AGENTS.md` を期待するケースに対応するため、既存の `AIRULES.md` へのシンボリックリンクを追加します。

変更点

- 追加: `AGENTS.md`（シンボリックリンク、ターゲット: `AIRULES.md`）

背景

- 一部のエージェント/ツールが `AGENTS.md` を参照する前提があるため、ルールの単一ソース（`AIRULES.md`）を維持したまま互換性を確保します。

動作確認

- `ls -la` および `readlink` によりリンク先を確認しました。

影響範囲

- ドキュメントのみで、実行系への影響はありません。

備考

- Draft として作成します。

