### PR TITLE
Improve PS1 prompt for narrow terminals

### DIFF
--- a/.functions
+++ b/.functions
@@ -68,7 +68,7 @@ prompts() {
 
   if [ -n "$SSH_CLIENT" ]; then
     if [ "$PS1" = "${PS1/ssh/}" ]; then
-      # Insert [ssh] after the box symbol (within cyan info line)
+      # Insert [ssh] after the box symbol
       PS1="$(echo "${PS1}" | sed 's/┌─ /┌─ [ssh] /')"
     fi
   fi


### PR DESCRIPTION
## Summary
- マルチラインプロンプト化（情報行と入力行を分離）
- 記号（┌─）で視覚的に区別しやすく
- 空行でコマンド出力とプロンプトを区別

## 変更後のプロンプト
```
（空行）
┌─ localhost: dotfiles (master) <AWS:prd>
$
```

## Test plan
- [x] `source ~/.bash_profile` で新しいプロンプトを確認
- [x] gitリポジトリ内でブランチ名が表示されることを確認
- [x] AWS profile設定時に表示されることを確認
- [x] 狭い横幅のターミナルでも入力行が確保されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)