### PR TITLE
Switch git permissions to deny/ask-based approach

### DIFF
--- a/claude-user-config/settings.json
+++ b/claude-user-config/settings.json
@@ -58,7 +58,6 @@
       "Bash(gh pr diff *)",
       "Bash(gh pr ready *)",
       "Bash(docker compose ps *)",
-      "Bash(docker-compose ps *)",
       "Bash(terraform validate *)",
       "Bash(terraform fmt *)",
       "Bash(terraform plan *)",


### PR DESCRIPTION
## Summary

- git コマンドの権限管理を個別 allow リスト方式から deny/ask ベース方式に変更します
  - deny: force push, `reset --hard`, `clean -f/-fd`, `checkout .`, `restore .` など破壊的操作を禁止
  - ask: `push`, `merge`, `rebase`, `reset`, `clean`, `stash drop/clear`, `branch -D`, `config` など影響の大きい操作は毎回確認
  - allow: `Bash(git *)` で残りの git コマンドを一括許可（deny > ask > allow の評価順序を活用）
- 全 Bash ルールの記法を `:*` から空白 `*` に統一します
- force push は deny パターンに加え、`git push` 自体を ask にすることで二重防御しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)