### PR TITLE
Use default browser for previm instead of Safari

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -249,7 +249,7 @@ Plug 'glidenote/memolist.vim'
     let g:memolist_memo_suffix = "md"
 
 Plug 'previm/previm'
-    let g:previm_open_cmd="open -a Safari"
+    let g:previm_open_cmd="open"
     augroup PrevimSettings
         autocmd!
         autocmd BufNewFile,BufRead *.{md,mdwn,mkd,mkdn,mark*} set filetype=markdown


### PR DESCRIPTION
## 変更内容

previmでMarkdownをプレビューする際に開くブラウザを、Safari固定からシステムのデフォルトブラウザに変更します。

## 変更箇所

- `.vimrc`: `g:previm_open_cmd` を `open -a Safari` から `open` に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)