### PR TITLE
Make deploy.sh check an explicit action in symlink rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,10 @@ Read README.md for the project overview, repository structure, and how it works.
 **Files like `~/.bashrc`, `~/.bash_profile`, `~/.vimrc`, etc. in `$HOME`
 are symlinks pointing to files in this repository.**
 
+- Before searching for a file's location, check `scripts/deploy.sh` for symlink mappings first
 - Always edit the source files in THIS repository
 - Never directly edit files under `$HOME` (e.g., `~/.bashrc`, `~/.gitconfig`)
 - Never access `~/.bashrc` or similar — read from this repo instead
-- The canonical symlink mapping is defined in `scripts/deploy.sh`
 
 ## Key Commands
 


### PR DESCRIPTION
## Summary

- Rephrase the symlink architecture instruction from factual ("mapping is defined in deploy.sh") to action-oriented ("check deploy.sh first before searching for file locations")
- This makes AI agents more likely to reference deploy.sh at decision time rather than searching blindly for file locations

## Context

During a session, the AI searched for Claude Code settings files by globbing `~/.claude/` instead of first checking `scripts/deploy.sh` to find the symlink mapping. The existing rule stated the fact but didn't trigger as an action at the right moment.

## Test plan

- [ ] Verify AI agents check deploy.sh when looking for file locations in new sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)