### PR TITLE
Add PreCompact hook for transcript backup

### DIFF
--- a/claude/hooks/pre_compact_backup.py
+++ b/claude/hooks/pre_compact_backup.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""PreCompact hook: back up the transcript JSONL before compaction."""
+
+import json
+import os
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def main():
+    try:
+        input_data = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    transcript_path = input_data.get("transcript_path", "")
+    if not transcript_path or not os.path.exists(transcript_path):
+        sys.exit(0)
+
+    session_id = input_data.get("session_id", "unknown")
+    trigger = input_data.get("trigger", "unknown")
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    # Back up the transcript JSONL
+    backup_dir = Path.home() / ".claude" / "transcript-backups"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    backup_name = f"{session_id}_pre_compact_{trigger}_{timestamp}.jsonl"
+    backup_path = backup_dir / backup_name
+    shutil.copy2(transcript_path, backup_path)
+
+    # Record the backup path in the project's memory directory
+    transcript_p = Path(transcript_path)
+    # transcript_path is like ~/.claude/projects/<project>/<session>.jsonl
+    project_dir = transcript_p.parent
+    memory_dir = project_dir / "memory"
+    if memory_dir.is_dir():
+        snapshot_path = memory_dir / "compact-snapshot.md"
+        snapshot_path.write_text(
+            f"# Pre-compact transcript backup\n\n"
+            f"- Timestamp: {timestamp}\n"
+            f"- Trigger: {trigger}\n"
+            f"- Backup: {backup_path}\n"
+        )
+
+    print(f"Transcript backed up to {backup_path}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        # Never block compaction
+        sys.exit(0)

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -152,6 +152,17 @@
           }
         ]
       }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/pre_compact_backup.py"
+          }
+        ]
+      }
     ]
   },
   "statusLine": {


### PR DESCRIPTION
## Summary

- Add a PreCompact hook that backs up the full transcript JSONL to `~/.claude/transcript-backups/` before compaction
- Record the backup file path in the project's memory directory (`compact-snapshot.md`) so Claude can find it on demand
- Fires on both manual (`/compact`) and automatic compaction

## Motivation

When Claude Code compacts the conversation, detailed context (code snippets, error messages, step-by-step reasoning) is lost. This hook preserves the full transcript so it can be referenced later (e.g., during `/retrospective`).

## Test plan

- [ ] Run `./scripts/deploy.sh` and verify symlink for `pre_compact_backup.py`
- [ ] Run `/compact` in a Claude Code session
- [ ] Verify backup file appears in `~/.claude/transcript-backups/`
- [ ] Verify `compact-snapshot.md` is created in the project's memory directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
