### PR TITLE
Replace AWS Copilot CLI with GitHub Copilot CLI

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -160,7 +160,7 @@ brew "k9s"
 brew "kind"
 brew "helm"
 brew "helmfile"
-brew "copilot" # AWS Copilot
+cask "copilot-cli" # GitHub Copilot CLI
 brew "ecspresso"
 brew "ecschedule"
 brew "e1s"

--- a/Brewfile
+++ b/Brewfile
@@ -160,7 +160,7 @@ brew "k9s"
 brew "kind"
 brew "helm"
 brew "helmfile"
-cask "copilot-cli" # GitHub Copilot CLI
+cask "copilot-cli"
 brew "ecspresso"
 brew "ecschedule"
 brew "e1s"

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -237,8 +237,10 @@
       "Bash(mise settings set *)",
       "Skill(codex:adversarial-review *)",
       "Skill(codex:rescue *)",
+      "Bash(copilot -p)",
       "Bash(copilot -p *)",
-      "Bash(copilot update)"
+      "Bash(copilot update)",
+      "Bash(copilot update *)"
     ]
   },
   "hooks": {

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -162,6 +162,8 @@
       "Bash(claude mcp * --help)",
       "Bash(claude plugin --help)",
       "Bash(claude plugin * --help)",
+      "Bash(copilot --version)",
+      "Bash(copilot --help)",
       "Skill(pr-selfcheck)",
       "Skill(pr-selfcheck *)",
       "Skill(codex:setup)",
@@ -233,7 +235,9 @@
       "Bash(mise exec *)",
       "Bash(mise settings set *)",
       "Skill(codex:adversarial-review *)",
-      "Skill(codex:rescue *)"
+      "Skill(codex:rescue *)",
+      "Bash(copilot -p *)",
+      "Bash(copilot update)"
     ]
   },
   "hooks": {

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -164,6 +164,7 @@
       "Bash(claude plugin * --help)",
       "Bash(copilot --version)",
       "Bash(copilot --help)",
+      "Bash(copilot * --help)",
       "Skill(pr-selfcheck)",
       "Skill(pr-selfcheck *)",
       "Skill(codex:setup)",


### PR DESCRIPTION
## Summary

Replace AWS Copilot CLI (`brew "copilot"`) with GitHub Copilot CLI (`cask "copilot-cli"`) so that the `copilot` binary is backed by GitHub Copilot instead of the AWS deployment tool.

- Both tools install a binary named `copilot`, so the swap removes the PATH conflict
- GitHub Copilot plan is already held, making the CLI usable for local review tasks at the draft PR stage
- Claude Code allow rules updated: `copilot --version` / `copilot --help` added to allow; `copilot -p` / `copilot update` added to ask (agentic commands that can run shell commands)

Refs: https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli

## Verification

- `copilot --version` returns `GitHub Copilot CLI 1.0.32` (confirmed locally)
- `brew info copilot-cli` shows installed
