### PR TITLE
Fix claudecode.nvim invalid provider error

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -303,12 +303,9 @@ if has('nvim')
 lua << EOF
     if pcall(require, "claudecode") then
         require("claudecode").setup({
-            terminal = {
-                provider = "none",
-            },
             diff_opts = {
-                layout = "horizontal",
-                open_in_new_tab = true,
+                vertical_split = false,
+                open_in_current_tab = false,
             },
         })
     end


### PR DESCRIPTION
## Summary

Fix "invalid value for provider: none" warning from claudecode.nvim when launching Neovide from GUI.

- Remove `terminal.provider = "none"` from claudecode setup. `"none"` is not a valid value (valid: `"auto"`, `"snacks"`, `"native"`). Falls back to default `"auto"` which tries snacks then native.
- Fix `diff_opts` keys to match the current plugin API: `layout`/`open_in_new_tab` were not recognized keys. Replaced with `vertical_split = false` and `open_in_current_tab = false`.

References: claudecode.nvim terminal validation and valid diff_opts keys confirmed in the installed plugin source at `~/.local/share/nvim/plugged/claudecode.nvim/`.

## Verification

1. Launch Neovide from GUI (Finder/Dock)
2. Run `:messages` — confirm "invalid value for provider: none" warning is gone
