### PR TITLE
Add weekly dotfiles improvement routine

### DIFF
--- a/claude/routines/weekly-improvement.md
+++ b/claude/routines/weekly-improvement.md
@@ -7,18 +7,16 @@ This file contains all instructions for the routine.
 
 Before making any changes, check past routine PRs for feedback:
 
-1. List past routine PRs (branch prefix `improve/dotfiles-` matches the naming in Step 4):
-   `gh pr list --repo ikuwow/dotfiles --search 'head:improve/dotfiles' --state all --limit 20 --json number,title,state,mergedAt`
+1. List past routine PRs:
+   `gh pr list --repo ikuwow/dotfiles --label 'claude-routine' --state all --limit 20 --json number,title,state,mergedAt`
 2. For any closed (not merged) PRs, read the comments to understand why they were rejected:
    `gh pr view <number> --repo ikuwow/dotfiles --comments`
 3. Learn from this feedback. Avoid making similar changes that were previously rejected.
 
 ## Step 2: Understand the Repository
 
-1. Read `AGENTS.md` (or `CLAUDE.md`) to understand repository rules and conventions.
-2. Read `README.md` for the overall structure.
-3. Read `scripts/deploy.sh` to understand symlink mappings.
-4. Explore the codebase to find improvement opportunities.
+Read `AGENTS.md` to understand repository rules, conventions, and structure.
+Then explore the codebase to find improvement opportunities.
 
 ## Step 3: Find Improvements
 
@@ -39,11 +37,13 @@ Do NOT modify:
 
 If worthwhile improvements are found:
 
-1. Create a branch: `improve/dotfiles-YYYY-MM-DD` (use today's date)
-2. Make changes and commit with clear messages
-3. Follow `claude/rules/git-workflow.md` Steps 1-4 only (push + create draft PR).
+1. Ensure the `claude-routine` label exists:
+   `gh label create 'claude-routine' --repo ikuwow/dotfiles --description 'Created by Claude Code weekly routine' --color '6e40c9' --force`
+2. Create a branch: `improve/dotfiles-YYYY-MM-DD` (use today's date)
+3. Make changes and commit with clear messages
+4. Follow `claude/rules/git-workflow.md` Steps 1-4 only (push + create draft PR with `--label 'claude-routine'`).
    Skip Step 5 entirely (CI wait, self-review, and code reviews) — this is a draft for human review.
-4. Follow `claude/rules/pr-guidelines.md` for the PR body. It must include:
+5. Follow `claude/rules/pr-guidelines.md` for the PR body. It must include:
    - What was improved and why
    - How to verify each change
    - Reference to any past feedback that influenced decisions

--- a/claude/routines/weekly-improvement.md
+++ b/claude/routines/weekly-improvement.md
@@ -1,0 +1,58 @@
+# Weekly Dotfiles Improvement Routine
+
+You are improving the ikuwow/dotfiles repository as a weekly maintenance routine.
+This file contains all instructions for the routine.
+
+## Step 1: Check Past Feedback
+
+Before making any changes, check past routine PRs for feedback:
+
+1. List past routine PRs:
+   `gh pr list --repo ikuwow/dotfiles --search 'improve/dotfiles' --state all --limit 20`
+2. For any closed (not merged) PRs, read the comments to understand why they were rejected:
+   `gh pr view <number> --repo ikuwow/dotfiles --comments`
+3. Learn from this feedback. Avoid making similar changes that were previously rejected.
+
+## Step 2: Understand the Repository
+
+1. Read `AGENTS.md` (or `CLAUDE.md`) to understand repository rules and conventions.
+2. Read `README.md` for the overall structure.
+3. Read `scripts/deploy.sh` to understand symlink mappings.
+4. Explore the codebase to find improvement opportunities.
+
+## Step 3: Find Improvements
+
+Look for improvements across the entire dotfiles repository:
+
+- Shell scripts: shellcheck compliance, readability, error handling (`set -eu`)
+- Configuration files: outdated settings, consistency, organization
+- Claude Code config (`claude/`): rules, skills, hooks, settings
+- Security: exposed secrets, insecure defaults
+- Dead code or unused configurations
+- Documentation: only where genuinely missing or incorrect
+
+Do NOT modify:
+- `AIRULES.md` (global AI rules, maintained manually by the user)
+- `CLAUDE.md` / `AGENTS.md` (only fix clear errors)
+
+## Step 4: Create a PR
+
+If worthwhile improvements are found:
+
+1. Create a branch: `improve/dotfiles-YYYY-MM-DD` (use today's date)
+2. Make changes and commit with clear messages following `claude/rules/git-workflow.md`
+3. Push and create a draft PR following `claude/rules/git-workflow.md` and `claude/rules/pr-guidelines.md`
+4. PR body must include:
+   - What was improved and why
+   - How to verify each change
+   - Reference to any past feedback that influenced decisions
+
+If no worthwhile improvements are found, do not create a PR. End the session.
+
+## Guidelines
+
+- Make only changes you are confident about. Skip uncertain improvements.
+- Avoid breaking changes. Dotfiles are used daily — stability matters.
+- Keep changes small and focused. One PR per run with related fixes grouped together.
+- Follow all conventions in `AGENTS.md`.
+- Do NOT run `/pr-selfcheck` or code reviews — the PR is a draft for human review.

--- a/claude/routines/weekly-improvement.md
+++ b/claude/routines/weekly-improvement.md
@@ -7,8 +7,8 @@ This file contains all instructions for the routine.
 
 Before making any changes, check past routine PRs for feedback:
 
-1. List past routine PRs:
-   `gh pr list --repo ikuwow/dotfiles --search 'improve/dotfiles' --state all --limit 20`
+1. List past routine PRs (branch prefix `improve/dotfiles-` matches the naming in Step 4):
+   `gh pr list --repo ikuwow/dotfiles --search 'head:improve/dotfiles' --state all --limit 20 --json number,title,state,mergedAt`
 2. For any closed (not merged) PRs, read the comments to understand why they were rejected:
    `gh pr view <number> --repo ikuwow/dotfiles --comments`
 3. Learn from this feedback. Avoid making similar changes that were previously rejected.
@@ -40,9 +40,10 @@ Do NOT modify:
 If worthwhile improvements are found:
 
 1. Create a branch: `improve/dotfiles-YYYY-MM-DD` (use today's date)
-2. Make changes and commit with clear messages following `claude/rules/git-workflow.md`
-3. Push and create a draft PR following `claude/rules/git-workflow.md` and `claude/rules/pr-guidelines.md`
-4. PR body must include:
+2. Make changes and commit with clear messages
+3. Follow `claude/rules/git-workflow.md` Steps 1-4 only (push + create draft PR).
+   Skip Step 5 entirely (CI wait, self-review, and code reviews) — this is a draft for human review.
+4. Follow `claude/rules/pr-guidelines.md` for the PR body. It must include:
    - What was improved and why
    - How to verify each change
    - Reference to any past feedback that influenced decisions
@@ -55,4 +56,3 @@ If no worthwhile improvements are found, do not create a PR. End the session.
 - Avoid breaking changes. Dotfiles are used daily — stability matters.
 - Keep changes small and focused. One PR per run with related fixes grouped together.
 - Follow all conventions in `AGENTS.md`.
-- Do NOT run `/pr-selfcheck` or code reviews — the PR is a draft for human review.


### PR DESCRIPTION
# Add weekly dotfiles improvement routine

## Purpose

Add `claude/routines/weekly-improvement.md` — an instruction file for a Claude Code
Routine that runs every Saturday at 03:00 JST and creates improvement PRs for this
dotfiles repository.

Inspired by: https://zenn.dev/genda_jp/articles/f425cc7354f608

## Design

The routine instruction file lives in the repository so that:
- The instructions are version-controlled and reviewable
- `/schedule` only needs a one-line prompt referencing this file
- The instructions themselves can be improved via future PRs

The routine is not configured here — the user will run `/schedule` manually after
merging, pointing to this file.

## Scope

The routine covers the entire dotfiles repository:
- Shell scripts (shellcheck compliance, readability, error handling)
- Configuration files (consistency, organization)
- Claude Code config under `claude/` (rules, skills, hooks, settings)
- Dead code and unused configurations
- Security issues

## Feedback loop

The routine is instructed to check past PRs (merged vs. closed-without-merge) and
read rejection comments before proposing changes, avoiding repeated mistakes.

## How to set up the Routine after merging

Run `/schedule` in a Claude Code session with these settings:

- Cron: `0 18 * * 5` (UTC Friday 18:00 = JST Saturday 03:00)
- Repository: ikuwow/dotfiles
- Prompt: `Read and follow the instructions in claude/routines/weekly-improvement.md`

## Verification

- [x] `claude/routines/weekly-improvement.md` is readable and complete
- [ ] After merging: run `/schedule` to create the Routine with the settings above
- [ ] After creating the Routine: run `/schedule run` to verify it executes and produces a draft PR
