### PR TITLE
Convert pr-selfcheck skill to context: fork

### DIFF
--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -125,7 +125,10 @@ Once both reviews finish, review the combined results:
 1. Fix issues found by code reviews.
 2. Push fixes if any code was changed, then re-run
    `/pr-selfcheck` and `gh pr checks --watch` to confirm the PR
-   is still consistent and CI passes.
+   is still consistent and CI passes. Use the same two-mechanism
+   pattern as Phase 1 (Skill tool for `/pr-selfcheck`, Bash with
+   `run_in_background: true` for `gh pr checks --watch`, both in
+   one message).
 
 Code reviews are single-pass — do not re-run after fixes.
 `/pr-selfcheck` runs again in Phase 3 to catch inconsistencies

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -76,10 +76,18 @@ code reviews, then consolidate.
 
 ### Phase 1: PR self-review + CI (parallel)
 
-Launch both in the background (`run_in_background: true`):
+Launch both in a single assistant message so they execute concurrently.
+Each uses a different mechanism:
 
-- `/pr-selfcheck <PR number>` — PR presentation review.
-- `gh pr checks --watch` — CI monitoring.
+- `/pr-selfcheck <PR number>` — PR presentation review. Invoked through
+  the `Skill` tool. The skill is configured with `context: fork`, so it
+  runs in a forked subagent and returns its result as a tool result.
+  The `Skill` tool does not accept `run_in_background`; the assistant
+  continues to the next step in the same turn once the tool result
+  arrives.
+- `gh pr checks --watch` — CI monitoring. Invoked through the `Bash`
+  tool with `run_in_background: true`. Output is read later from the
+  background process.
 
 If either fails:
 - Fix self-review "Must Fix" / "Should Fix" items.

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -76,18 +76,10 @@ code reviews, then consolidate.
 
 ### Phase 1: PR self-review + CI (parallel)
 
-Launch both in a single assistant message so they execute concurrently.
-Each uses a different mechanism:
+Launch both in a single assistant message so they execute concurrently:
 
-- `/pr-selfcheck <PR number>` — PR presentation review. Invoked through
-  the `Skill` tool. The skill is configured with `context: fork`, so it
-  runs in a forked subagent and returns its result as a tool result.
-  The `Skill` tool does not accept `run_in_background`; the assistant
-  continues to the next step in the same turn once the tool result
-  arrives.
-- `gh pr checks --watch` — CI monitoring. Invoked through the `Bash`
-  tool with `run_in_background: true`. Output is read later from the
-  background process.
+- `/pr-selfcheck <PR number>` — PR presentation review.
+- `gh pr checks --watch` — CI monitoring. Run with `run_in_background: true`.
 
 If either fails:
 - Fix self-review "Must Fix" / "Should Fix" items.
@@ -125,10 +117,7 @@ Once both reviews finish, review the combined results:
 1. Fix issues found by code reviews.
 2. Push fixes if any code was changed, then re-run
    `/pr-selfcheck` and `gh pr checks --watch` to confirm the PR
-   is still consistent and CI passes. Use the same two-mechanism
-   pattern as Phase 1 (Skill tool for `/pr-selfcheck`, Bash with
-   `run_in_background: true` for `gh pr checks --watch`, both in
-   one message).
+   is still consistent and CI passes.
 
 Code reviews are single-pass — do not re-run after fixes.
 `/pr-selfcheck` runs again in Phase 3 to catch inconsistencies

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -1,6 +1,8 @@
 ---
 description: Perform a self-review of a PR before requesting human review. TRIGGER when user invokes /pr-selfcheck or when the git workflow reaches the self-review step after PR creation. Accepts a PR number as an argument.
 model: sonnet
+context: fork
+agent: general-purpose
 ---
 
 # PR Self-Check


### PR DESCRIPTION
## Purpose

Fixes the workflow halt described in #140. The `pr-selfcheck` skill ran inline in the main thread and ended with a `### Verdict` line that the assistant treated as a turn-ending final report — twice in a real session, the user had to manually push for the next phase.

Per the official Skill content lifecycle (https://code.claude.com/docs/en/skills#skill-content-lifecycle), a skill's rendered content enters the conversation as a single message and stays for the rest of the session. There is no built-in completion signal: the assistant has to decide on its own when the skill is "done," which made the `### Verdict` line look like a final report. Adding `context: fork` runs the skill in an isolated subagent and returns its output as a tool result — an explicit completion signal the main agent naturally continues from.

## Scope

- `claude/skills/pr-selfcheck/SKILL.md`: add `context: fork` and `agent: general-purpose` to the frontmatter.
  - `agent: general-purpose` matches the documented default for `context: fork` (per the docs, `agent` defaults to `general-purpose` when omitted). Declaring it explicitly documents intent. The skill needs Bash (`gh`), WebFetch, and Read — all available to `general-purpose`.
  - `model: sonnet` is preserved per the user's `subagent-model.md` rule (general-purpose for sonnet-appropriate tasks).
  - Skill body / Output Format are unchanged — the fix is structural, not textual.
- `claude/rules/git-workflow.md`: update Phase 1 launch instructions. The previous text incorrectly told the assistant to launch both `/pr-selfcheck` and `gh pr checks --watch` with `run_in_background: true`. The new text keeps it simple: just invoke `/pr-selfcheck` as a skill and run `gh pr checks --watch` with `run_in_background: true` in one message.

## Out of scope

- Other skills (`pr-review-toolkit:review-pr`, `codex:adversarial-review`) may have similar halt issues but are not addressed here. `pr-review-toolkit:review-pr` already spawns its own sub-agents internally; converting the wrapper would create a grandchild-subagent pattern that needs separate verification.
- Phase 2's `/codex:adversarial-review` still uses `run_in_background: true` wording. Out of scope per the issue.

## References

- Issue: #140
- Skill content lifecycle: https://code.claude.com/docs/en/skills#skill-content-lifecycle
- `context: fork` pattern: https://code.claude.com/docs/en/skills#run-skills-in-a-subagent

## Verification

Verified end-to-end in a fresh session that re-read the updated `SKILL.md`:

- `/pr-selfcheck 141` ran as a forked execution and returned its result as a `Skill` tool result (the runtime explicitly displayed `Skill "pr-selfcheck" completed (forked execution).`).
- The main agent did not halt at the `### Verdict` line; it continued to Phase 2 in the same turn without user prompting.
- Phase 1 parallel launch (Skill + Bash with `run_in_background: true`) executed concurrently as intended.

Note: in the same session that pushes the change, live change detection does not always pick up frontmatter changes — verification requires a fresh session.
