### PR TITLE
Remove codex:adversarial-review from git workflow

### DIFF
--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -76,7 +76,7 @@ Note: `.worktrees/` is covered by the global gitignore.
 ## 5. CI Wait & Review
 
 Three-phase review: pass all mechanical checks first, then run
-code reviews, then consolidate.
+the code review, then consolidate.
 
 ### Phase 1: PR self-review + CI (parallel)
 
@@ -92,38 +92,26 @@ If either fails:
 
 Note: `/pr-selfcheck` is a mechanical check, not a code review.
 Re-running it after fixes is expected. The "single-pass" policy
-applies only to code reviews in Phase 2.
+applies only to the code review in Phase 2.
 
-### Phase 2: Code reviews (parallel)
+### Phase 2: Code review
 
-Once Phase 1 passes, launch both:
+Once Phase 1 passes, launch:
 
-- `/codex:adversarial-review` — challenges design decisions via Codex.
-  Always run in the background (`run_in_background: true`) without
-  asking the user for the execution mode. Do not use `AskUserQuestion`
-  for foreground/background selection.
-  After receiving the review output, immediately provide your own
-  assessment of each finding (agree/disagree with reasoning) and
-  propose concrete next actions. Never output the review verbatim
-  and stop.
-  If it fails with `disable-model-invocation` error, skip and continue
-  with Phase 3. This is a known upstream issue
-  (openai/codex-plugin-cc#211, anthropics/claude-code#43809) — once
-  fixed, this command should work directly via the Skill tool.
 - `/pr-review-toolkit:review-pr` — multi-agent code review (CLAUDE.md
   compliance, bug detection, error handling, test coverage).
   Reports findings in the conversation, does not post PR comments.
 
 ### Phase 3: Consolidate and fix
 
-Once both reviews finish, review the combined results:
+Once the review finishes, review the results:
 
-1. Fix issues found by code reviews.
+1. Fix issues found by the code review.
 2. Push fixes if any code was changed, then re-run
    `/pr-selfcheck` and `gh pr checks --watch` to confirm the PR
    is still consistent and CI passes.
 
-Code reviews are single-pass — do not re-run after fixes.
+The code review is single-pass — do not re-run after fixes.
 `/pr-selfcheck` runs again in Phase 3 to catch inconsistencies
 introduced by review fix changes.
 


### PR DESCRIPTION
## Purpose

Drop `/codex:adversarial-review` from the standard PR workflow.

The command currently invokes `codex:rescue` internally and hangs for an
extended period (effectively blocking the workflow). There is no known
workaround at the moment, so the practical fix is to stop running it
until the upstream issue is resolved.

## Scope

- `claude/rules/git-workflow.md`
  - Remove the `/codex:adversarial-review` bullet from Phase 2.
  - Adjust surrounding wording from plural ("code reviews", "both
    reviews") to singular now that Phase 2 runs a single tool.
  - Phase / step structure is otherwise unchanged.

Out of scope:

- `claude/settings.json` retains the
  `Skill(codex:adversarial-review *)` allow rule. Leaving it in place
  is harmless and avoids extra churn when the command is re-enabled.
- No changes to `/pr-review-toolkit:review-pr` behavior.

## Sources / references

- Hang reproduces locally; related upstream issues for codex behaviour:
  - openai/codex-plugin-cc#211
  - anthropics/claude-code#43809
  These were the original justification for the
  `disable-model-invocation` skip path in the same section. The block
  is now removed entirely rather than skipped.

## Verification

- `grep -r 'adversarial-review' claude/rules/` returns no matches
  (confirmed locally).
- Phase 2 wording reads naturally as a single-review phase
  (Phase 1 → single code review → Phase 3 consolidation).
- pre-commit hooks pass on commit.
- This PR itself exercises the updated workflow: only
  `/pr-selfcheck` + `/pr-review-toolkit:review-pr` will run.
