### PR TITLE
Document GitHub PR/issue body line break rendering

### DIFF
--- a/claude/rules/pr-guidelines.md
+++ b/claude/rules/pr-guidelines.md
@@ -15,6 +15,16 @@ and when reviewing your own PR.
   restated in the body. Focus on context the diff cannot convey: why the
   change was made, trade-offs considered, and things to watch out for.
 
+## Body formatting (GitHub PR / issue)
+
+GitHub renders soft line breaks inside paragraphs as visible line breaks
+in issue / PR / comment bodies (unlike standard CommonMark, which folds
+them into spaces). When writing a PR or issue body, put each paragraph
+and each list item on a single source line, no matter how long. Do not
+insert soft line breaks inside a paragraph or list item — they will
+appear as visible line breaks in the rendered body and make the source
+hard to skim and quote in review comments.
+
 ## PR Body Checklist
 
 When writing a PR body, cover every applicable item:


### PR DESCRIPTION
## Purpose

Retrospective from a PR-writing session in `ikuwow/allmyinfra` (PR #498) flagged that I wrote a PR body with soft line breaks inside paragraphs, then had to rewrite it after Daisy pointed out that GitHub does not collapse those breaks the way standard CommonMark does. The agent had no rule to consult, so it defaulted to wrapping for source readability and produced a rendered body with stray mid-sentence line breaks. This change adds the missing rule.

## Scope

- Add a "Body formatting (GitHub PR / issue)" section to `claude/rules/pr-guidelines.md` directly above the existing PR Body Checklist. The new section states the GitHub-specific rendering behavior (soft breaks become visible breaks in issue/PR/comment bodies) and tells the agent to put each paragraph and each list item on a single source line when authoring PR/issue bodies.

Out of scope: changes to existing PR / issue bodies, changes to other Markdown surfaces (READMEs, in-repo docs) where standard CommonMark folding still applies, and any tooling-side enforcement.

## Sources

- Real session evidence: ikuwow/allmyinfra#498 review exchange where the soft-wrapped body had to be rewritten as one-line-per-paragraph.
- GitHub Flavored Markdown spec note on line breaks in user content fields: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax (GitHub treats newlines in comment / issue / PR fields as line breaks; standard CommonMark would fold them into spaces).

## Verification

- Diff inspection only — this is a documentation-only change to the rules file consumed by Claude Code.
- Manual: next time I draft a PR body in any project, the agent should follow the new section and emit each paragraph / list item on a single line.
