### PR TITLE
Generalize Phase 4 to finalize PR for review readiness

### DIFF
--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -75,8 +75,8 @@ Note: `.worktrees/` is covered by the global gitignore.
 
 ## 5. CI Wait & Review
 
-Three-phase review: pass all mechanical checks first, then run
-the code review, then consolidate.
+Four phases: pass all mechanical checks, run the code review,
+consolidate fixes, then finalize the PR for review readiness.
 
 ### Phase 1: PR self-review + CI (parallel)
 
@@ -114,6 +114,33 @@ Once the review finishes, review the results:
 The code review is single-pass — do not re-run after fixes.
 `/pr-selfcheck` runs again in Phase 3 to catch inconsistencies
 introduced by review fix changes.
+
+### Phase 4: Finalize PR for review readiness
+
+Bring the PR into a state where a human reviewer can act on it. This
+covers three things:
+
+1. Reflect actual verification in the PR body. Update the body to
+   describe what was confirmed, with evidence (HTTP status, Location
+   header, Lambda runtime value, log excerpt, command output summary,
+   etc.) so each claim is auditable later. If the body has checkbox
+   items, sync `[ ]` to `[x]` as each item's condition is confirmed;
+   if not, edit the Verification section text directly. Items still
+   pending stay as `[ ]` (or noted explicitly as pending).
+2. Confirm acceptance criteria are met. Cross-check the PR body and
+   any linked issue against the actual change. If something is unmet,
+   either address it or call it out as out-of-scope / follow-up.
+3. Mark the PR ready for review. Run `gh pr ready <number>` to take it
+   out of draft. Skip if the user asked to keep it as draft.
+
+Update incrementally as conditions are confirmed (e.g., after Phase 1
+CI passes, after apply / deploy succeeds, after post-deploy
+verification with `curl`, `aws logs tail`, etc.) — do not wait until
+the very end to do all of it at once.
+
+This step is not optional. Execute it autonomously instead of waiting
+for the user to remind you. Use the section 6 procedure
+(`gh pr edit --body-file`) for body edits.
 
 ## 6. Update a PR / issue (title / body)
 


### PR DESCRIPTION
## Purpose

Phase 4 of the git workflow previously assumed the PR template had checkbox items in the Verification section. Projects without that template style had no clear instruction for the final pre-review step, even though the underlying intent — make sure the PR is actually review-ready — applies universally.

This change generalizes Phase 4 from "Sync PR body checkboxes" to "Finalize PR for review readiness", with three concrete sub-steps that work regardless of whether the body uses checkboxes:

1. Reflect actual verification in the PR body, with evidence. Checkbox sync becomes a sub-case here.
2. Confirm acceptance criteria are met (cross-check body and linked issue against the actual change).
3. Run `gh pr ready` to take the PR out of draft. Step 4 already creates the PR as a draft, so the workflow now closes that loop.

## Scope

- Edits `claude/rules/git-workflow.md` only.
- Updates the Section 5 intro line to reflect the renamed Phase 4.
- Behavior across other phases (Phase 1–3) is unchanged.

## Sources

- Existing Phase 4 wording (introduced in 1fb41c0 "Fix git workflow") was the starting point. The "evidence in parentheses" guidance and "not optional / autonomous execution" stance are preserved.
- `gh pr ready`: https://cli.github.com/manual/gh_pr_ready

## Verification

- [x] `pre-commit` hooks pass on commit (trailing whitespace, EOF, etc.)
- [x] Diff matches the intended change: title rename, three numbered sub-steps, draft-release step added, Section 5 intro updated
- [ ] Manual: next time a PR is created via this workflow, confirm that Phase 4 instructions are actionable for both checkbox-based and free-text Verification sections
