### PR TITLE
Disallow hard-wrapping PR / issue body paragraphs

### DIFF
--- a/claude/rules/pr-guidelines.md
+++ b/claude/rules/pr-guidelines.md
@@ -14,6 +14,13 @@ and when reviewing your own PR.
 - Anything a reviewer can see by reading the diff does not need to be
   restated in the body. Focus on context the diff cannot convey: why the
   change was made, trade-offs considered, and things to watch out for.
+- Do not hard-wrap paragraphs or list items at a fixed column width.
+  GitHub Flavored Markdown renders soft line breaks inside a paragraph
+  as visible breaks (or runs them together awkwardly), so a body
+  wrapped at ~70 chars looks broken on the web. Write each paragraph
+  as a single line and let the browser wrap it. Use blank lines for
+  paragraph breaks. The same rule applies to issue bodies and PR /
+  issue comments.
 
 ## PR Body Checklist
 


### PR DESCRIPTION
## Purpose

GitHub Flavored Markdown does not collapse soft line breaks inside a paragraph the way some other Markdown renderers (e.g., classic Markdown, many editors) do. As a result, PR / issue bodies that have been hard-wrapped at a fixed column width — a habit carried over from terminal-friendly Markdown — render as visibly broken paragraphs on github.com.

This change adds a Writing Style rule in `pr-guidelines.md` telling AI agents (and the author) to keep each paragraph or list item on a single line and rely on the browser for wrapping. The rule explicitly extends to issue bodies and PR / issue comments, since the same renderer applies.

## Scope

- Edits `claude/rules/pr-guidelines.md` only.
- Adds a single bullet to the Writing Style section.
- No changes to PR Body Checklist or Review Criteria — the new rule is purely about source formatting, not content.

## Sources

- GitHub Flavored Markdown spec, "Soft line breaks" section: https://github.github.com/gfm/#soft-line-breaks — soft breaks are rendered as ` ` or `<br>` depending on context, never collapsed.
- Practical confirmation: in PR #145 the body was originally hard-wrapped at ~70 chars, and the rendered output on github.com showed the breaks mid-paragraph until the body was rewritten as single-line paragraphs.

## Verification

- [x] `pre-commit` hooks pass on commit (trailing whitespace, EOF)
- [x] Diff matches the intended change: one bullet added to Writing Style, nothing else touched
- [x] This PR body itself follows the new rule (paragraphs on a single line, blank lines between them)
