### PR TITLE
Add Phase 5 PR activity watch loop to git-workflow

### DIFF
--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -156,7 +156,7 @@ the user to re-engage.
    self-pace via `ScheduleWakeup`):
 
    ```
-   /loop Watch PR #<number>: poll `gh pr view <number> --json state,reviewDecision,latestReviews,statusCheckRollup,comments,updatedAt,mergedAt`. On new activity, react per the rules in git-workflow.md Phase 5. Exit when state becomes MERGED or CLOSED.
+   /loop Watch PR #<number>: poll `gh pr view <number> --json state,reviewDecision,latestReviews,statusCheckRollup,comments,updatedAt,mergedAt,headRefName` AND `gh api repos/<owner>/<repo>/pulls/<number>/comments` (inline review comments are not in `gh pr view --json` output and must be fetched separately). On new activity, react per the rules in git-workflow.md Phase 5. Exit when state becomes MERGED or CLOSED.
    ```
 
 2. Before any push (every iteration that would write to origin):
@@ -210,8 +210,9 @@ the user to re-engage.
    - If the user gives a new instruction that supersedes the watch,
      pause / cancel the loop and prioritize the user request.
 
-This step is the final stage of the workflow. It is best-effort by
-design — for event-driven reliability use GitHub Actions instead.
+This is the final phase of Step 5; Step 7 (Cleanup) still runs when
+the loop exits on `MERGED`. The watch is best-effort by design — for
+event-driven reliability use GitHub Actions instead.
 
 ## 6. Update a PR / issue (title / body)
 
@@ -251,6 +252,6 @@ After the PR is merged (or the task is fully done):
 2. Remove the worktree:
    `git worktree remove .worktrees/<branch>`
    - Skip this step if the project rules prohibit worktrees and the
-     branch was created via `git checkout -b` only. Just leave the
-     branch behind for the user to delete (or run `git branch -d
-     <branch>` if explicitly requested).
+     branch was created via `git checkout -b` only. Leave the branch
+     for the user to delete, or run `git branch -d <branch>` if
+     explicitly requested.

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -14,8 +14,9 @@ Follow each step in order. Skip steps that don't apply.
   leads to redundant copy-and-delete work.
 - Never modify commits that have already been pushed.
 - Implementation plans MUST include the full workflow from Step 1
-  through Step 5. Never produce a plan that ends at "edit the file"
-  without covering commit, push, PR creation, and CI review.
+  through Step 7 (cleanup). Never produce a plan that ends at "edit
+  the file" without covering commit, push, PR creation, CI review,
+  the post-ready watch loop, and cleanup.
 
 ## 1. Start Work
 
@@ -158,11 +159,19 @@ the user to re-engage.
    /loop Watch PR #<number>: poll `gh pr view <number> --json state,reviewDecision,latestReviews,statusCheckRollup,comments,updatedAt,mergedAt`. On new activity, react per the rules in git-workflow.md Phase 5. Exit when state becomes MERGED or CLOSED.
    ```
 
-2. Each iteration, check for new activity and act:
-   - Review with `CHANGES_REQUESTED` or new inline review comment
-     (human, Devin, Copilot, etc.): read the content, modify code,
-     push the fix. Reply via `gh pr comment` only when the comment is
-     a question rather than a fix request.
+2. Before any push (every iteration that would write to origin):
+   - Verify the current branch matches the PR's `headRefName`.
+   - `git fetch` and confirm local HEAD is still ahead of
+     `origin/<branch>` (no manual user push has happened in between).
+   - Skip the push if either check fails; surface the conflict to the
+     user instead of trying to reconcile silently.
+
+3. Each iteration, check for new activity and act:
+   - Review with `CHANGES_REQUESTED` or a new inline review comment
+     that is clearly a fix request (human, Devin, Copilot, etc.):
+     read the content, modify code, push the fix. When the intent is
+     ambiguous (could be question, nit, or discussion), reply via
+     `gh pr comment` instead of pushing code.
    - Review with `APPROVED` (no further action requested): report to
      the user in the next assistant turn, do not act.
    - CI failure (`statusCheckRollup` contains FAILURE): inspect with
@@ -170,12 +179,23 @@ the user to re-engage.
    - CI in progress (`PENDING` / `IN_PROGRESS`): no action, wait.
    - No change since last check: no action.
 
-3. Pacing guidance for `ScheduleWakeup`:
-   - Recent activity (within last hour): 2–3 minute interval (120–180s).
-   - Quiet: 20–30 minute interval (1200–1800s).
+4. Iteration cap for autonomous fix pushes:
+   - Stop pushing autonomous fixes after 3 fix commits in this
+     loop. Beyond that, switch to reply-only mode and notify the
+     user that the PR appears to need human attention. This
+     prevents runaway loops when an automated reviewer keeps
+     re-requesting changes on each push.
+
+5. Pacing guidance for `ScheduleWakeup` (Anthropic prompt cache has a
+   5-minute TTL — sleeping past 300s costs a full cache rebuild on
+   wake-up):
+   - Recent activity (within last hour): 120–270s. Stays inside the
+     cache TTL so the next iteration is cheap. Never pick exactly
+     300s — it pays the cache miss without amortizing the wait.
+   - Quiet: 1200–1800s. One cache miss buys a much longer wait.
    - Tool clamps to [60, 3600]s.
 
-4. Exit conditions:
+6. Exit conditions:
    - `state` becomes `MERGED` → execute Step 7 (Cleanup) inside the
      same loop iteration, then end the loop.
    - `state` becomes `CLOSED` without merge → end the loop, skip
@@ -183,7 +203,7 @@ the user to re-engage.
    - Session ends (PC sleep, Claude Code closed) → loop terminates
      silently. This is accepted as best-effort.
 
-5. Conflict handling:
+7. Conflict handling:
    - If the user pushes commits manually while the loop is running,
      just acknowledge in the next iteration and continue watching.
      Do not try to revert or duplicate the user's work.
@@ -230,3 +250,7 @@ After the PR is merged (or the task is fully done):
    `cd <repository root>`
 2. Remove the worktree:
    `git worktree remove .worktrees/<branch>`
+   - Skip this step if the project rules prohibit worktrees and the
+     branch was created via `git checkout -b` only. Just leave the
+     branch behind for the user to delete (or run `git branch -d
+     <branch>` if explicitly requested).

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -159,16 +159,16 @@ the user to re-engage.
    ```
 
 2. Each iteration, check for new activity and act:
-   - **Review with `CHANGES_REQUESTED`** or new inline review comment
+   - Review with `CHANGES_REQUESTED` or new inline review comment
      (human, Devin, Copilot, etc.): read the content, modify code,
      push the fix. Reply via `gh pr comment` only when the comment is
      a question rather than a fix request.
-   - **Review with `APPROVED`** (no further action requested): report
-     to the user in the next assistant turn, do not act.
-   - **CI failure** (`statusCheckRollup` contains FAILURE): inspect
-     with `gh run view --log-failed`, fix, push.
-   - **CI in progress** (`PENDING` / `IN_PROGRESS`): no action, wait.
-   - **No change since last check**: no action.
+   - Review with `APPROVED` (no further action requested): report to
+     the user in the next assistant turn, do not act.
+   - CI failure (`statusCheckRollup` contains FAILURE): inspect with
+     `gh run view --log-failed`, fix, push.
+   - CI in progress (`PENDING` / `IN_PROGRESS`): no action, wait.
+   - No change since last check: no action.
 
 3. Pacing guidance for `ScheduleWakeup`:
    - Recent activity (within last hour): 2–3 minute interval (120–180s).

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -156,8 +156,24 @@ the user to re-engage.
    self-pace via `ScheduleWakeup`):
 
    ```
-   /loop Watch PR #<number>: poll `gh pr view <number> --json state,reviewDecision,latestReviews,statusCheckRollup,comments,updatedAt,mergedAt,headRefName` AND `gh api repos/<owner>/<repo>/pulls/<number>/comments` (inline review comments are not in `gh pr view --json` output and must be fetched separately). On new activity, react per the rules in git-workflow.md Phase 5. Exit when state becomes MERGED or CLOSED.
+   /loop Watch PR #<number>: each iteration, run all polling commands listed in git-workflow.md Phase 5 step (1). On new activity, react per the rules in Phase 5. Exit when state becomes MERGED or CLOSED.
    ```
+
+   Polling commands (run all three every iteration so no signal is
+   missed — top-level fields, threads, and run history each carry
+   information the others lack):
+
+   - PR top-level state:
+     `gh pr view <number> --json state,reviewDecision,latestReviews,statusCheckRollup,comments,updatedAt,mergedAt,headRefName`
+   - Review threads with `isResolved` / `isOutdated` (REST
+     `/pulls/<num>/comments` does not expose resolution status, so
+     use GraphQL):
+     ```
+     gh api graphql -f query='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$num){reviewThreads(first:100){nodes{isResolved isOutdated comments(first:100){nodes{id author{login} body createdAt path line}}}}}}}' -f owner=<owner> -f repo=<repo> -F num=<number>
+     ```
+   - Workflow run history on the PR branch (catches CI cycles
+     `statusCheckRollup` doesn't show — e.g. older runs, re-run jobs):
+     `gh run list --branch <headRefName> --json databaseId,name,status,conclusion,createdAt,headSha,workflowName --limit 20`
 
 2. Before any push (every iteration that would write to origin):
    - Verify the current branch matches the PR's `headRefName`.
@@ -166,17 +182,24 @@ the user to re-engage.
    - Skip the push if either check fails; surface the conflict to the
      user instead of trying to reconcile silently.
 
-3. Each iteration, check for new activity and act:
-   - Review with `CHANGES_REQUESTED` or a new inline review comment
+3. Each iteration, compare against the previous iteration's snapshot
+   (in-session memory; full state tracking is out of scope) and act:
+   - Review with `CHANGES_REQUESTED`, or a new inline review comment
+     in a thread where `isResolved == false` and `isOutdated == false`
      that is clearly a fix request (human, Devin, Copilot, etc.):
      read the content, modify code, push the fix. When the intent is
-     ambiguous (could be question, nit, or discussion), reply via
-     `gh pr comment` instead of pushing code.
+     ambiguous (question, nit, discussion), reply via `gh pr comment`
+     instead of pushing code. Threads with `isResolved == true` or
+     `isOutdated == true` are already addressed or no longer
+     applicable — skip them so previously-fixed comments don't
+     re-trigger work.
    - Review with `APPROVED` (no further action requested): report to
      the user in the next assistant turn, do not act.
-   - CI failure (`statusCheckRollup` contains FAILURE): inspect with
-     `gh run view --log-failed`, fix, push.
-   - CI in progress (`PENDING` / `IN_PROGRESS`): no action, wait.
+   - CI / workflow failure (any `FAILURE` in `statusCheckRollup` or
+     a new `FAILURE` run from `gh run list`): inspect with
+     `gh run view --log-failed <databaseId>`, fix, push.
+   - CI in progress (any `PENDING` / `IN_PROGRESS` / `QUEUED`): no
+     action, wait.
    - No change since last check: no action.
 
 4. Iteration cap for autonomous fix pushes:

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -156,7 +156,7 @@ the user to re-engage.
    self-pace via `ScheduleWakeup`):
 
    ```
-   /loop Watch PR #<number>: each iteration, run all polling commands listed in git-workflow.md Phase 5 step (1). On new activity, react per the rules in Phase 5. Exit when state becomes MERGED or CLOSED.
+   /loop Watch PR #<number>: read `~/.claude/rules/git-workflow.md` Phase 5 step (1) and run each polling command listed there every iteration; react per the action / cap / pacing / exit / conflict rules in the rest of Phase 5; exit when state becomes MERGED or CLOSED.
    ```
 
    Polling commands (run all three every iteration so no signal is

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -75,8 +75,9 @@ Note: `.worktrees/` is covered by the global gitignore.
 
 ## 5. CI Wait & Review
 
-Four phases: pass all mechanical checks, run the code review,
-consolidate fixes, then finalize the PR for review readiness.
+Five phases: pass all mechanical checks, run the code review,
+consolidate fixes, finalize the PR for review readiness, then watch
+PR activity until merge.
 
 ### Phase 1: PR self-review + CI (parallel)
 
@@ -141,6 +142,56 @@ the very end to do all of it at once.
 This step is not optional. Execute it autonomously instead of waiting
 for the user to remind you. Use the section 6 procedure
 (`gh pr edit --body-file`) for body edits.
+
+### Phase 5: Watch PR activity until merge
+
+After Phase 4 marks the PR ready for review, start a `/loop` to watch
+the PR until it is merged or closed. Reviewers (human, Devin, Copilot)
+often act soon after ready, and CI may still be running — the watch
+loop catches activity and reacts autonomously instead of waiting for
+the user to re-engage.
+
+1. Start the watch loop in dynamic mode (no interval — let Claude
+   self-pace via `ScheduleWakeup`):
+
+   ```
+   /loop Watch PR #<number>: poll `gh pr view <number> --json state,reviewDecision,latestReviews,statusCheckRollup,comments,updatedAt,mergedAt`. On new activity, react per the rules in git-workflow.md Phase 5. Exit when state becomes MERGED or CLOSED.
+   ```
+
+2. Each iteration, check for new activity and act:
+   - **Review with `CHANGES_REQUESTED`** or new inline review comment
+     (human, Devin, Copilot, etc.): read the content, modify code,
+     push the fix. Reply via `gh pr comment` only when the comment is
+     a question rather than a fix request.
+   - **Review with `APPROVED`** (no further action requested): report
+     to the user in the next assistant turn, do not act.
+   - **CI failure** (`statusCheckRollup` contains FAILURE): inspect
+     with `gh run view --log-failed`, fix, push.
+   - **CI in progress** (`PENDING` / `IN_PROGRESS`): no action, wait.
+   - **No change since last check**: no action.
+
+3. Pacing guidance for `ScheduleWakeup`:
+   - Recent activity (within last hour): 2–3 minute interval (120–180s).
+   - Quiet: 20–30 minute interval (1200–1800s).
+   - Tool clamps to [60, 3600]s.
+
+4. Exit conditions:
+   - `state` becomes `MERGED` → execute Step 7 (Cleanup) inside the
+     same loop iteration, then end the loop.
+   - `state` becomes `CLOSED` without merge → end the loop, skip
+     cleanup (user may reopen).
+   - Session ends (PC sleep, Claude Code closed) → loop terminates
+     silently. This is accepted as best-effort.
+
+5. Conflict handling:
+   - If the user pushes commits manually while the loop is running,
+     just acknowledge in the next iteration and continue watching.
+     Do not try to revert or duplicate the user's work.
+   - If the user gives a new instruction that supersedes the watch,
+     pause / cancel the loop and prioritize the user request.
+
+This step is the final stage of the workflow. It is best-effort by
+design — for event-driven reliability use GitHub Actions instead.
 
 ## 6. Update a PR / issue (title / body)
 


### PR DESCRIPTION
## Purpose

Reviewers (human, Devin, Copilot) often act within minutes of ready-for-review, but `git-workflow.md` ends at Phase 4 — so reacting requires the user to manually re-engage Claude. Phase 5 adds a best-effort `/loop` watch that polls the PR and reacts autonomously until merge or close.

## Scope

`claude/rules/git-workflow.md` only.

- Step 5: "Four phases" → "Five phases".
- New `### Phase 5: Watch PR activity until merge` (placed before `## 6.` so existing "section 6 procedure" references stay valid). Phase 5 prescribes:
  - Polling per iteration: `gh pr view --json ...,headRefName` for top-level state, GraphQL `reviewThreads` (with `isResolved` / `isOutdated`) so resolved/outdated threads don't re-trigger fixes, and `gh run list --branch <headRefName>` for workflow run history beyond the latest `statusCheckRollup`.
  - Pre-push checks (branch matches `headRefName`, `git fetch` to detect manual user pushes).
  - Action rules: `CHANGES_REQUESTED` / clear fix request → push fix; `APPROVED` → report; CI failure → fix and push; ambiguous → reply via `gh pr comment`, don't push.
  - 3-fix-commit cap per loop to prevent runaway loops with automated reviewers.
  - Pacing keyed to the 5-minute prompt-cache TTL: 120–270s on activity, 1200–1800s when quiet, never 300s.
  - Exit on `MERGED` (runs Step 7) or `CLOSED` (skip cleanup). Session end is accepted as best-effort.
- Principles: implementation plans now must cover Step 1 through Step 7.
- Step 7: skip worktree removal on projects that prohibit worktrees.

`/loop` and `ScheduleWakeup` themselves are unchanged — Phase 5 only formalizes their use.

## Design notes

- Watch only after ready-for-review. Draft phases are too active for an autonomous watcher to be net-positive.
- Best-effort by design — PC sleep or Claude session close ends the loop. Persistent reactivity needs GitHub Actions or a VPS, out of scope here.
- The pacing numbers come from the `ScheduleWakeup` tool description: prompt cache has a 5-min TTL, so 300s is "worst of both" and quiet ticks should bunch into 1200s+.
- Three separate polling endpoints are required because each carries information the others lack: `gh pr view --json` misses inline review comments and resolution status; REST `/pulls/<n>/comments` lacks `isResolved`; `statusCheckRollup` only shows the latest snapshot per check, so older / re-run jobs need `gh run list`.
- Pre-push checks and the 3-fix cap close the runaway / race-with-manual-push gaps surfaced in this PR's code review.
- Cross-session state tracking and true event-driven design are out of scope (per discussion); within a single session the agent compares against its previous-iteration snapshot, and `isResolved` / `isOutdated` cover the cross-session "already addressed" cases for review threads.

## References

- `/loop` and `ScheduleWakeup` are Claude Code built-ins surfaced via the session's system reminder; no public docs page, so the system reminder is the authoritative source. `delaySeconds` is clamped to `[60, 3600]`; autonomous loops use the `<<autonomous-loop-dynamic>>` sentinel.
- `gh pr view --json` field set was picked from the field list emitted by `gh pr view --json` when the value is an unrecognized field — gh exits non-zero and prints all supported fields for that subcommand. Selected fields: `state`, `reviewDecision`, `latestReviews`, `statusCheckRollup`, `comments`, `updatedAt`, `mergedAt`, `headRefName`.
- GraphQL `reviewThreads` fields (`isResolved`, `isOutdated`, nested `comments`) are documented in GitHub's GraphQL API reference; chosen over REST `/pulls/<n>/comments` because that endpoint cannot expose thread resolution state.

## Verification

- [x] Phase 1–5 headings and list style match the existing phases.
- [x] "Five phases" matches the five `### Phase N` headings actually present.
- [x] "section 6 procedure" still points to `## 6. Update a PR / issue (title / body)` — no renumbering.
- [x] Pre-commit hooks pass.
- [x] All three polling commands run successfully against this PR (`gh pr view --json ...`, GraphQL `reviewThreads`, `gh run list --branch`); the GraphQL query returned 1 active and 2 outdated threads on commit 49bf69d as expected.
- [x] CI 6/6 green on `ffdca2a`: Socket Security ×2, bootstrap macos/ubuntu, python-doctest, shellcheck.

### Follow-up (post-merge)

- Dry-run the documented `/loop Watch PR #<num>: ...` invocation against a real Phase-4-completed PR in a separate session to confirm the polling commands and `ScheduleWakeup` behavior end-to-end. Out of scope here.
