### PR TITLE
Relax plan inclusion rule to checklist-only reference

### DIFF
--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -13,10 +13,15 @@ Follow each step in order. Skip steps that don't apply.
   worktree (or feature branch) first. Creating files before branching
   leads to redundant copy-and-delete work.
 - Never modify commits that have already been pushed.
-- Implementation plans MUST include the full workflow from Step 1
-  through Step 7 (cleanup). Never produce a plan that ends at "edit
-  the file" without covering commit, push, PR creation, CI review,
-  the post-ready watch loop, and cleanup.
+- Implementation plans MUST reference this workflow as a checklist
+  rather than restating its detailed steps. The full content is
+  already in system context, so plans MUST NOT duplicate it (and
+  MUST NOT instruct you to re-Read this file). Recommended phrasing:
+  "After implementation, follow git-workflow.md Steps 2–7 (commit /
+  push / PR creation / CI wait / Phase 5 watch loop / cleanup)."
+  Plans must still surface scope-specific deviations explicitly —
+  e.g., "skip Step 7 because the project rules prohibit worktrees"
+  or "stop after Step 4, this PR stays as draft".
 
 ## 1. Start Work
 

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -13,15 +13,23 @@ Follow each step in order. Skip steps that don't apply.
   worktree (or feature branch) first. Creating files before branching
   leads to redundant copy-and-delete work.
 - Never modify commits that have already been pushed.
-- Implementation plans MUST reference this workflow as a checklist
-  rather than restating its detailed steps. The full content is
-  already in system context, so plans MUST NOT duplicate it (and
-  MUST NOT instruct you to re-Read this file). Recommended phrasing:
-  "After implementation, follow git-workflow.md Steps 2–7 (commit /
-  push / PR creation / CI wait / Phase 5 watch loop / cleanup)."
-  Plans must still surface scope-specific deviations explicitly —
-  e.g., "skip Step 7 because the project rules prohibit worktrees"
-  or "stop after Step 4, this PR stays as draft".
+- Implementation plans MUST cover the full workflow as a bullet-list
+  checklist — from branch setup (Step 1, before implementation)
+  through cleanup (Step 7) — not just the post-edit steps. The
+  detailed procedures (mktemp usage, gh commands, polling commands,
+  etc.) live in this file and are already in system context, so plans
+  MUST NOT restate them and MUST NOT instruct you to re-Read this
+  file. Recommended bullet form:
+  - Step 1: branch creation (note worktree vs branch-only per project rules)
+  - Step 2: commit
+  - Step 3: push
+  - Step 4: draft PR creation
+  - Step 5: CI wait & review (Phases 1–5)
+  - Step 7: cleanup after merge
+  (Step 6 is a utility section; reference it only if the plan involves
+  editing an existing PR/issue body.) Plans must still surface
+  scope-specific deviations explicitly — e.g., "skip Step 7 because
+  the branch is kept" or "stop after Step 4, this PR stays as draft".
 
 ## 1. Start Work
 


### PR DESCRIPTION
## Purpose

Plans produced in plan mode were duplicating the full Step 1–7 content of `claude/rules/git-workflow.md`, even though the file is already loaded into system context for every session. This made approved plans long and noisy, and the restated commands (`mktemp`, `gh pr create --body-file`, the Phase 5 watch loop polling block, etc.) added no information that wasn't already available to the implementation phase.

Removing the rule entirely was considered, but discarded. After plan approval the plan becomes the primary attention target, and the system-context workflow can be deprioritised — increasing the risk of skipping later phases (Phase 5 watch loop, Step 7 cleanup, etc.).

## Change

Keep the `MUST` strength of the Principles bullet but flip what is being mandated:

- Old: plans `MUST include the full workflow from Step 1 through Step 7` — i.e., copy the detailed steps inline.
- New: plans `MUST cover the full workflow as a bullet-list checklist` from Step 1 (branch setup, before implementation) through Step 7 (cleanup), and `MUST NOT restate the detailed procedures` or instruct the agent to re-Read this file.

Step 1 stays explicitly in scope because branch creation precedes the implementation work, not after it. A "post-edit" checklist (Steps 2–7 only) was considered and rejected because it would push the branch decision out of the plan.

The new bullet also includes a recommended bullet-form example covering Steps 1–7, with a side note that Step 6 is a utility section to reference only when the plan involves editing an existing PR/issue body. Scope-specific deviations (`skip Step 7 because the branch is kept`, `stop after Step 4, this PR stays as draft`, etc.) must still be surfaced explicitly so plans document any divergence from the standard flow.

## Why "MUST NOT instruct you to re-Read"

Naming a file in a plan can prompt the implementing agent to issue a Read on it, which (a) wastes context and (b) often triggers a permission prompt for paths under `~/.claude/`. The workflow content is already in system context and does not need to be re-fetched.

## Scope

- `claude/rules/git-workflow.md` Principles section, single bullet
- No changes to `AIRULES.md` or other rule files (they only carry references to git-workflow.md, which remain valid)

## Verification

- Diff inspected before each commit; only the targeted bullet changed
- pre-commit hooks (trailing whitespace / EOF) passed on commit
- The rule change is documentation-only; no runtime behaviour to test in CI
