### PR TITLE
Add Stop hook to pause once on 断り書き phrases

### DIFF
--- a/claude/hooks/block_excuse_phrases.py
+++ b/claude/hooks/block_excuse_phrases.py
@@ -1,12 +1,19 @@
+#!/usr/bin/env python3
 """Stop hook: pause once when the assistant emits excuse-preamble phrases.
 
-AIRULES.md line 20 forbids 「正直」「実は」「本当のところ」 as 断り書き
-(preamble that softens or qualifies an opinion). The model knows the
-rule but slips. A literal substring match cannot disambiguate legitimate
-uses (名詞 like 「正直者」, 事実開示 like 「実は〜だった」), so this hook
-does not try. It pauses once per turn so the model re-evaluates, and on
-the second pass (stop_hook_active=true) always allows the stop —
-preventing infinite loops.
+AIRULES.md (the 「正直」「実は」「本当のところ」 ban under 応答の姿勢と判断)
+forbids these as 断り書き (preamble that softens or qualifies an opinion).
+The model knows the rule but slips. A literal substring match cannot
+disambiguate legitimate uses (名詞 like 「正直者」, 事実開示 like
+「実は〜だった」), so this hook does not try. It blocks at most once per
+Stop chain: the second invocation arrives with stop_hook_active=true and
+is allowed through, preventing infinite loops.
+
+I/O failures (stdin parse, missing transcript_path, transcript read) are
+swallowed and the hook exits 0 — a Stop hook that wedges the assistant
+is far worse than one that silently no-ops. A short stderr message is
+emitted on each fall-through so the operator can grep hook logs to
+distinguish "rule not violated" from "hook silently broken".
 
 Spec: https://code.claude.com/docs/en/hooks
 """
@@ -19,8 +26,8 @@ FORBIDDEN_PATTERN = re.compile(r"正直|実は|本当のところ")
 REASON = (
     "Your response contains one of 「正直」「実は」「本当のところ」.\n\n"
     "The string match alone cannot tell whether you used it as 断り書き "
-    "(preamble softening or qualifying an opinion, banned by AIRULES.md "
-    "line 20) or in a sense the rule does not target. Reconsider.\n\n"
+    "(preamble softening or qualifying an opinion, banned by AIRULES.md) "
+    "or in a sense the rule does not target. Reconsider.\n\n"
     "Why 断り書き usage is harmful: prefacing a statement with 「正直」 "
     "plants the doubt that everything else you have said was not honest. "
     "The damage is retroactive (it taints prior statements) and "
@@ -31,7 +38,9 @@ REASON = (
 
 
 def is_forbidden(text):
-    """Return True if text contains a 断り書き phrase from AIRULES.md line 20.
+    """Return True if text contains a 断り書き phrase listed in AIRULES.md.
+
+    Hits as 断り書き (the target use):
 
     >>> is_forbidden("正直それは下がると思う")
     True
@@ -39,6 +48,18 @@ def is_forbidden(text):
     True
     >>> is_forbidden("本当のところ判断が難しい")
     True
+
+    The regex deliberately matches legitimate uses too — these
+    intentional false positives are pinned so a future tightening of
+    the regex breaks the test:
+
+    >>> is_forbidden("彼は正直者だ")
+    True
+    >>> is_forbidden("実は昨日雨だった")
+    True
+
+    Negatives:
+
     >>> is_forbidden("commit を push しといた")
     False
     >>> is_forbidden("")
@@ -104,6 +125,24 @@ def collect_current_turn_assistant_text(events):
 
     >>> collect_current_turn_assistant_text([])
     ''
+
+    Malformed events are skipped silently — system events, assistant
+    messages with missing or null content, etc. — so the hook does not
+    crash on unfamiliar transcript shapes. Real transcript events also
+    carry uuid / timestamp / parentUuid / sessionId fields not shown
+    here; only the keys read above matter.
+
+    >>> events = [
+    ...     {"type": "system"},
+    ...     {"type": "assistant", "message": {}},
+    ...     {"type": "assistant", "message": {"content": None}},
+    ...     {"type": "user", "message": {"role": "user", "content": "hi"}},
+    ...     {"type": "assistant", "message": {"content": [
+    ...         {"type": "text", "text": "正直そう思う"}
+    ...     ]}},
+    ... ]
+    >>> collect_current_turn_assistant_text(events)
+    '正直そう思う'
     """
     texts = []
     for event in reversed(events):
@@ -128,7 +167,8 @@ def collect_current_turn_assistant_text(events):
 def main():
     try:
         data = json.load(sys.stdin)
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"block_excuse_phrases: stdin parse failed: {e}", file=sys.stderr)
         sys.exit(0)
 
     if data.get("stop_hook_active"):
@@ -136,12 +176,14 @@ def main():
 
     transcript_path = data.get("transcript_path", "")
     if not transcript_path:
+        print("block_excuse_phrases: no transcript_path in stdin", file=sys.stderr)
         sys.exit(0)
 
     try:
         with open(transcript_path, encoding="utf-8") as f:
             events = [json.loads(line) for line in f if line.strip()]
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"block_excuse_phrases: transcript read failed: {e}", file=sys.stderr)
         sys.exit(0)
 
     text = collect_current_turn_assistant_text(events)

--- a/claude/hooks/block_excuse_phrases.py
+++ b/claude/hooks/block_excuse_phrases.py
@@ -1,0 +1,154 @@
+"""Stop hook: pause once when the assistant emits excuse-preamble phrases.
+
+AIRULES.md line 20 forbids 「正直」「実は」「本当のところ」 as 断り書き
+(preamble that softens or qualifies an opinion). The model knows the
+rule but slips. A literal substring match cannot disambiguate legitimate
+uses (名詞 like 「正直者」, 事実開示 like 「実は〜だった」), so this hook
+does not try. It pauses once per turn so the model re-evaluates, and on
+the second pass (stop_hook_active=true) always allows the stop —
+preventing infinite loops.
+
+Spec: https://code.claude.com/docs/en/hooks
+"""
+import json
+import re
+import sys
+
+FORBIDDEN_PATTERN = re.compile(r"正直|実は|本当のところ")
+
+REASON = (
+    "Your response contains one of 「正直」「実は」「本当のところ」.\n\n"
+    "The string match alone cannot tell whether you used it as 断り書き "
+    "(preamble softening or qualifying an opinion, banned by AIRULES.md "
+    "line 20) or in a sense the rule does not target. Reconsider.\n\n"
+    "Why 断り書き usage is harmful: prefacing a statement with 「正直」 "
+    "plants the doubt that everything else you have said was not honest. "
+    "The damage is retroactive (it taints prior statements) and "
+    "prospective (it taints future ones), and it cannot be unplanted. "
+    "「実は」 and 「本当のところ」 carry the same structural harm.\n\n"
+    "Judge your own usage and rewrite if it was 断り書き."
+)
+
+
+def is_forbidden(text):
+    """Return True if text contains a 断り書き phrase from AIRULES.md line 20.
+
+    >>> is_forbidden("正直それは下がると思う")
+    True
+    >>> is_forbidden("実は昨日指摘された")
+    True
+    >>> is_forbidden("本当のところ判断が難しい")
+    True
+    >>> is_forbidden("commit を push しといた")
+    False
+    >>> is_forbidden("")
+    False
+    """
+    return bool(FORBIDDEN_PATTERN.search(text))
+
+
+def collect_current_turn_assistant_text(events):
+    """Concatenate assistant text emitted since the last real user message.
+
+    Walks events backward. Stops at a real user message. user events
+    whose content is purely tool_result blocks are tool-call re-entries
+    and are skipped, not treated as turn boundaries.
+
+    Single-turn capture:
+
+    >>> events = [
+    ...     {"type": "user", "message": {"role": "user", "content": "hi"}},
+    ...     {"type": "assistant", "message": {"content": [
+    ...         {"type": "text", "text": "正直そう思う"}
+    ...     ]}},
+    ... ]
+    >>> collect_current_turn_assistant_text(events)
+    '正直そう思う'
+
+    Tool-call re-entry does not end the turn; both text blocks are
+    captured (in reverse-walk order):
+
+    >>> events = [
+    ...     {"type": "user", "message": {"role": "user", "content": "x"}},
+    ...     {"type": "assistant", "message": {"content": [
+    ...         {"type": "text", "text": "first"}
+    ...     ]}},
+    ...     {"type": "assistant", "message": {"content": [
+    ...         {"type": "tool_use", "name": "Bash"}
+    ...     ]}},
+    ...     {"type": "user", "message": {"role": "user", "content": [
+    ...         {"type": "tool_result", "content": "ok"}
+    ...     ]}},
+    ...     {"type": "assistant", "message": {"content": [
+    ...         {"type": "text", "text": "second"}
+    ...     ]}},
+    ... ]
+    >>> collect_current_turn_assistant_text(events)
+    'second\\nfirst'
+
+    A real user message ends the scan; older turns are not captured:
+
+    >>> events = [
+    ...     {"type": "assistant", "message": {"content": [
+    ...         {"type": "text", "text": "old"}
+    ...     ]}},
+    ...     {"type": "user", "message": {"role": "user", "content": "new turn"}},
+    ...     {"type": "assistant", "message": {"content": [
+    ...         {"type": "text", "text": "current"}
+    ...     ]}},
+    ... ]
+    >>> collect_current_turn_assistant_text(events)
+    'current'
+
+    Empty input:
+
+    >>> collect_current_turn_assistant_text([])
+    ''
+    """
+    texts = []
+    for event in reversed(events):
+        if event.get("type") == "user":
+            content = event.get("message", {}).get("content")
+            if isinstance(content, str):
+                break
+            if isinstance(content, list) and not all(
+                isinstance(c, dict) and c.get("type") == "tool_result"
+                for c in content
+            ):
+                break
+            continue
+        if event.get("type") != "assistant":
+            continue
+        for block in event.get("message", {}).get("content", []) or []:
+            if isinstance(block, dict) and block.get("type") == "text":
+                texts.append(block.get("text", ""))
+    return "\n".join(texts)
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    if data.get("stop_hook_active"):
+        sys.exit(0)
+
+    transcript_path = data.get("transcript_path", "")
+    if not transcript_path:
+        sys.exit(0)
+
+    try:
+        with open(transcript_path, encoding="utf-8") as f:
+            events = [json.loads(line) for line in f if line.strip()]
+    except (OSError, json.JSONDecodeError):
+        sys.exit(0)
+
+    text = collect_current_turn_assistant_text(events)
+    if is_forbidden(text):
+        print(json.dumps({"decision": "block", "reason": REASON}))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -295,6 +295,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python3 ~/.claude/hooks/block_excuse_phrases.py"
+          },
+          {
+            "type": "command",
             "command": "noti --title 'Claude Code' --message 'Done! Yay!'"
           }
         ]


### PR DESCRIPTION
## Purpose

AIRULES.md (応答の姿勢と判断 section) already forbids 「正直」「実は」「本当のところ」 as 断り書き — preamble that softens or qualifies an opinion. The rule has existed for some time, but the model continues to slip into the habit — including once in the immediately preceding session, which prompted this countermeasure. A retrospective surfaced that "follow the rule more carefully" is not a structural fix, so this PR adds a Stop hook that intercepts the slip mechanically.

## Design

### Reconsideration trigger, not prohibition

The hook does not try to disambiguate legitimate uses of the literal strings (e.g., 名詞 like 「正直者」, factual disclosure phrasing). A simple regex (`正直|実は|本当のところ`) can't distinguish 断り書き from non-断り書き, and trying to encode that distinction in the hook would either over-block legitimate text or leak escape hatches the model can lean on. Instead, the hook treats any string match as a "stop and reconsider" trigger: it blocks the first pass with a reason explaining why this class of preamble damages trust, and on the second pass it always allows the stop via `stop_hook_active`.

The reason text deliberately omits hook-mechanic excuses ("the second pass will go through" / "name uses are exempt"). It explains the structural harm and asks the model to judge its own usage.

### `stop_hook_active` and infinite-loop prevention

The hook reads `stop_hook_active` from stdin JSON and exits 0 immediately when it is true. This is the documented "Stop hook runs forever" troubleshooting pattern at https://code.claude.com/docs/en/hooks-guide.md . Without this guard, a model that genuinely needs to use the string (a quote, a code example referencing the rule, etc.) would loop forever.

### Pure functions + doctest

`is_forbidden(text)` and `collect_current_turn_assistant_text(events)` are pure and verified by doctest. The repository's `python-doctest` GitHub Actions check runs these on every push, so the tests are CI-verified, not just local:

```
$ python3 -m doctest claude/hooks/block_excuse_phrases.py -v 2>&1 | tail -3
16 tests in 4 items.
16 passed.
Test passed.
```

The `main()` entrypoint handles I/O (stdin JSON, transcript JSONL read, stdout JSON write, `stop_hook_active` branch) and is verified at runtime when the hook fires in a new session.

### Fail-open with stderr breadcrumbs

Each I/O fall-through in `main()` (stdin parse, missing transcript_path, transcript read) emits a short stderr line prefixed with `block_excuse_phrases:` before exiting 0. The hook stays fail-open from Claude Code's perspective — a broken hook never wedges the assistant — but `~/.claude/logs/` retains a trace, so the operator can distinguish "rule not violated" from "hook silently broken".

## Files

The PR touches two files:

- New: `claude/hooks/block_excuse_phrases.py` — the hook script itself.
- Modified: `claude/settings.json` — register the script as a `hooks.Stop` command alongside the existing `noti` notification (4-line array insertion under `hooks.Stop[0].hooks`). The hook entry is placed before `noti` so the block decision is computed before the desktop notification fires.

## Verification

- doctest: 16 tests pass locally and in CI (python-doctest job)
- pre-commit: trailing whitespace / EOF / JSON syntax checks pass on commit
- CI all green on this branch (Socket / bootstrap / python-doctest / shellcheck)
- Runtime trigger: observed in a new session after the hook is installed locally via `scripts/deploy.sh` (claude/ is symlinked to ~/.claude/, so changes take effect immediately on next session). No CI path exercises Stop hooks; the integration with Claude Code is not unit-testable from CI.

## Out of scope

- Other AIRULES rules (no Markdown emphasis, etc.) are not enforced by hooks in this PR; they can be added incrementally if the same slip pattern emerges.
- The pattern list mirrors the AIRULES 断り書き ban exactly; if that rule list expands, the regex needs the same edit.
