### PR TITLE
Poll transcript on Stop hook to handle pure-text flush race

### DIFF
--- a/claude/hooks/block_excuse_phrases.py
+++ b/claude/hooks/block_excuse_phrases.py
@@ -9,19 +9,31 @@ disambiguate legitimate uses (名詞 like 「正直者」, 事実開示 like
 Stop chain: the second invocation arrives with stop_hook_active=true and
 is allowed through, preventing infinite loops.
 
-I/O failures (stdin parse, missing transcript_path, transcript read) are
-swallowed and the hook exits 0 — a Stop hook that wedges the assistant
-is far worse than one that silently no-ops. A short stderr message is
-emitted on each fall-through so the operator can grep hook logs to
-distinguish "rule not violated" from "hook silently broken".
+I/O failures (stdin parse, missing transcript_path, transcript read,
+poll timeout) are swallowed and the hook exits 0 — a Stop hook that
+wedges the assistant is far worse than one that silently no-ops. A
+short stderr message is emitted on each fall-through so the operator
+can grep hook logs to distinguish "rule not violated" from "hook
+silently broken".
+
+For pure-text turns (no tool calls), Claude Code can invoke the Stop
+hook before the assistant event is flushed to the transcript JSONL.
+When the initial read returns no current-turn assistant text, the
+hook polls the transcript at 50ms intervals up to 500ms before
+giving up fail-open. The upper bound was chosen with ~4x headroom
+over an empirical 5-sample distribution clustered between 54-118ms.
 
 Spec: https://code.claude.com/docs/en/hooks
 """
 import json
 import re
 import sys
+import time
 
 FORBIDDEN_PATTERN = re.compile(r"正直|実は|本当のところ")
+
+POLL_INTERVAL_S = 0.05
+POLL_MAX_TOTAL_S = 0.5
 
 REASON = (
     "Your response contains one of 「正直」「実は」「本当のところ」.\n\n"
@@ -187,6 +199,28 @@ def main():
         sys.exit(0)
 
     text = collect_current_turn_assistant_text(events)
+
+    if not text:
+        poll_start = time.monotonic()
+        for _ in range(int(POLL_MAX_TOTAL_S / POLL_INTERVAL_S)):
+            time.sleep(POLL_INTERVAL_S)
+            try:
+                with open(transcript_path, encoding="utf-8") as f:
+                    events = [json.loads(line) for line in f if line.strip()]
+            except (OSError, json.JSONDecodeError):
+                continue
+            text = collect_current_turn_assistant_text(events)
+            if text:
+                break
+
+        if not text:
+            elapsed_ms = int((time.monotonic() - poll_start) * 1000)
+            print(
+                f"block_excuse_phrases: poll timeout after {elapsed_ms}ms",
+                file=sys.stderr,
+            )
+            sys.exit(0)
+
     if is_forbidden(text):
         print(json.dumps({"decision": "block", "reason": REASON}))
     sys.exit(0)

--- a/claude/hooks/block_excuse_phrases.py
+++ b/claude/hooks/block_excuse_phrases.py
@@ -12,16 +12,18 @@ is allowed through, preventing infinite loops.
 I/O failures (stdin parse, missing transcript_path, transcript read,
 poll timeout) are swallowed and the hook exits 0 — a Stop hook that
 wedges the assistant is far worse than one that silently no-ops. A
-short stderr message is emitted on each fall-through so the operator
-can grep hook logs to distinguish "rule not violated" from "hook
-silently broken".
+short stderr message is emitted on each terminal fall-through so the
+operator can grep hook logs to distinguish "rule not violated" from
+"hook silently broken". Transient read failures inside the poll loop
+are retried silently; the last one is surfaced via the timeout
+breadcrumb if the loop exhausts.
 
 For pure-text turns (no tool calls), Claude Code can invoke the Stop
 hook before the assistant event is flushed to the transcript JSONL.
 When the initial read returns no current-turn assistant text, the
-hook polls the transcript at 50ms intervals up to 500ms before
-giving up fail-open. The upper bound was chosen with ~4x headroom
-over an empirical 5-sample distribution clustered between 54-118ms.
+hook polls the transcript at POLL_INTERVAL_S intervals up to
+POLL_MAX_ITERATIONS iterations before giving up fail-open. See PR
+#153 for the empirical basis of these values.
 
 Spec: https://code.claude.com/docs/en/hooks
 """
@@ -33,7 +35,7 @@ import time
 FORBIDDEN_PATTERN = re.compile(r"正直|実は|本当のところ")
 
 POLL_INTERVAL_S = 0.05
-POLL_MAX_TOTAL_S = 0.5
+POLL_MAX_ITERATIONS = 10
 
 REASON = (
     "Your response contains one of 「正直」「実は」「本当のところ」.\n\n"
@@ -202,12 +204,14 @@ def main():
 
     if not text:
         poll_start = time.monotonic()
-        for _ in range(int(POLL_MAX_TOTAL_S / POLL_INTERVAL_S)):
+        last_err = None
+        for _ in range(POLL_MAX_ITERATIONS):
             time.sleep(POLL_INTERVAL_S)
             try:
                 with open(transcript_path, encoding="utf-8") as f:
                     events = [json.loads(line) for line in f if line.strip()]
-            except (OSError, json.JSONDecodeError):
+            except (OSError, json.JSONDecodeError) as e:
+                last_err = e
                 continue
             text = collect_current_turn_assistant_text(events)
             if text:
@@ -215,8 +219,10 @@ def main():
 
         if not text:
             elapsed_ms = int((time.monotonic() - poll_start) * 1000)
+            err_suffix = f" last_err={last_err!r}" if last_err else ""
             print(
-                f"block_excuse_phrases: poll timeout after {elapsed_ms}ms",
+                f"block_excuse_phrases: poll timeout after {elapsed_ms}ms "
+                f"events={len(events)} transcript={transcript_path}{err_suffix}",
                 file=sys.stderr,
             )
             sys.exit(0)


### PR DESCRIPTION
## Purpose

PR #152 (https://github.com/ikuwow/dotfiles/pull/152) added the 断り書き Stop hook (`block_excuse_phrases.py`), but the regex match misses pure-text turns. Investigation in this session showed Claude Code can invoke the Stop hook before the assistant event is flushed to the transcript JSONL, so `collect_current_turn_assistant_text` reads stale data and returns an empty string. Tool-using turns are unaffected because tool execution forces an I/O sync point.

This PR closes the gap with a bounded poll-retry inside the hook.

## Approach

After the initial transcript read, if the current-turn assistant text is empty, the hook polls the transcript at 50ms intervals up to 500ms (10 iterations) before giving up fail-open. As soon as text appears, the regex check runs as before. On timeout, the hook emits a stderr breadcrumb (`block_excuse_phrases: poll timeout after Nms`) and exits 0, matching the existing fail-open pattern for the other I/O failure paths.

The polling does not change any pure function in the module — `is_forbidden(text)` and `collect_current_turn_assistant_text(events)` are unchanged. Only `main()` gains the retry loop and two module-level constants `POLL_INTERVAL_S` / `POLL_MAX_ITERATIONS`.

## Empirical data

The thresholds come from an in-session experiment that instrumented the same hook with polling and detailed logging. Across five pure-text turns in one Claude Code session:

| sample | iter where text appeared | elapsed_ms |
| --- | --- | --- |
| 1 | 1 | 54 |
| 2 | 2 | 118 |
| 3 | 2 | 114 |
| 4 | 2 | 112 |
| 5 | 2 | 115 |

All five turns flushed within 120ms, with zero timeouts. 500ms gives roughly 4x headroom over the maximum observed value, which keeps response latency unaffected in practice while staying robust to slower disks or scheduler jitter. The samples also strongly suggest that Claude Code does not wait for the Stop hook to return before flushing — flushing appears to happen in parallel with hook execution.

## Verification

- doctest: `python3 -m doctest claude/hooks/block_excuse_phrases.py -v` reports `16 tests in 4 items. 16 passed.`
- Forbidden text smoke (saved transcript): hook outputs `decision:block` JSON and exits 0.
- Empty file (timeout case): hook prints `block_excuse_phrases: poll timeout after 535ms events=0 transcript=/tmp/test_empty.jsonl` to stderr and exits 0 with no JSON output. Actual elapsed slightly exceeds 500ms because of OS sleep granularity (`time.sleep(0.05)` returns marginally late); within tolerance.
- `stop_hook_active=true` payload: silent exit 0, no polling.
- Missing transcript_path: stderr breadcrumb, exit 0.
- Non-existent file: stderr breadcrumb, exit 0 (initial read failure does not enter the poll loop).
- pre-commit on the changed file: trailing whitespace / EOF / large file checks all pass.
- Live runtime confirmation: while the branch was checked out (deployed via symlink from `claude/hooks/`), pure-text replies that included 「正直」 or 「実は」 as 断り書き preambles were caught by the hook on the first stop, with the correction applied via the standard block-and-rewrite flow. This reproduced the original bug condition (pure-text turn, no tool calls) and demonstrated the fix end to end before merge.

## Out of scope

- Reporting the underlying flush-timing behavior to Anthropic (`anthropics/claude-code`) is recommended as a follow-up but kept separate from this code change.
- Reducing the verbose user-facing "Stop hook feedback" notification surfaced on every block is tracked separately in #154.
