### PR TITLE
Guard hook commands against missing files

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -259,7 +259,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ~/.claude/hooks/block_cd_chaining.py"
+            "command": "f=~/.claude/hooks/block_cd_chaining.py; if [ -f \"$f\" ] && command -v python3 >/dev/null; then python3 \"$f\"; fi"
           }
         ]
       }
@@ -270,11 +270,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ~/.claude/hooks/approve_git_gh_commands.py"
+            "command": "f=~/.claude/hooks/approve_git_gh_commands.py; if [ -f \"$f\" ] && command -v python3 >/dev/null; then python3 \"$f\"; fi"
           },
           {
             "type": "command",
-            "command": "python3 ~/.claude/hooks/approve_gh_graphql_readonly.py"
+            "command": "f=~/.claude/hooks/approve_gh_graphql_readonly.py; if [ -f \"$f\" ] && command -v python3 >/dev/null; then python3 \"$f\"; fi"
           }
         ]
       }
@@ -285,7 +285,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "noti --title 'Claude Code' --message 'Requires response.'"
+            "command": "if command -v noti >/dev/null; then noti --title 'Claude Code' --message 'Requires response.'; fi"
           }
         ]
       }
@@ -296,11 +296,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ~/.claude/hooks/block_excuse_phrases.py"
+            "command": "f=~/.claude/hooks/block_excuse_phrases.py; if [ -f \"$f\" ] && command -v python3 >/dev/null; then python3 \"$f\"; fi"
           },
           {
             "type": "command",
-            "command": "noti --title 'Claude Code' --message 'Done! Yay!'"
+            "command": "if command -v noti >/dev/null; then noti --title 'Claude Code' --message 'Done! Yay!'; fi"
           }
         ]
       }


### PR DESCRIPTION
## Why

`python3 ~/.claude/hooks/foo.py` invoked from a Stop hook returns exit code 2 when the script symlink is missing (e.g. `deploy.sh` not re-run after a hook is added). Claude Code treats Stop-hook exit 2 as a blocking error and forces continuation, producing an infinite loop. Spec: https://code.claude.com/docs/en/hooks

## What

Wrap each of the 6 hook commands in `claude/settings.json` with an inline `if`-guard that runs the body only when the script and interpreter are both present, otherwise the shell exits 0:

- python: `f=~/.claude/hooks/<name>.py; if [ -f "$f" ] && command -v python3 >/dev/null; then python3 "$f"; fi`
- noti: `if command -v noti >/dev/null; then noti ...; fi`

The guarded path preserves the script's exit code, so a future intentional `sys.exit(2)` block still works.

Rejected: `~/dotfiles/...` direct reference (couples settings to repo path), wrapper script (same symlink-miss failure), `|| true` (would silently swallow intentional exit 2).

## Verification

Shell guard exercised directly with three cases — missing file → exit 0, normal script → exit 0, `sys.exit(2)` → exit 2. JSON validates with `jq`. pre-commit and CI (bootstrap × 2, python-doctest, shellcheck, Socket) all green.
