### PR TITLE
Tighten Verification rigor in pr-guidelines

### DIFF
--- a/claude/rules/pr-guidelines.md
+++ b/claude/rules/pr-guidelines.md
@@ -71,12 +71,20 @@ When writing a PR body, cover every applicable item:
    - Do NOT use auto-close keywords (`Closes`, `Fixes`, `Resolves`).
 
 5. Verification
-   - Describe only what was actually verified under "confirmed" items.
-   - Do not claim verification that was not performed.
-   - When the change affects environments that CI cannot replicate
-     (e.g., Claude Code web, external services), include manual test
-     steps the reviewer can follow to verify in the real environment
-     before merging.
+   - Attempt every verification within reach before drafting this
+     section: shell commands, API calls, file inspection, mocked
+     failure modes, simulated missing-config tests. Punting verifiable
+     items to "Pending" or "User to verify" without first attempting
+     is itself the violation — the common failure mode is overstating
+     what is "untestable" and underestimating what shell-level
+     reproduction can cover.
+   - List only items actually verified, with evidence (command output,
+     exit code, log excerpt).
+   - Items that genuinely require interactive UI, user-only
+     credentials, target environments unreachable from a shell, or
+     the live session itself go under a separate "User to verify"
+     subsection with reproduction steps and a one-line reason why the
+     author could not verify them.
 
 ## Review Criteria
 
@@ -126,6 +134,10 @@ Used by `/pr-selfcheck` to evaluate a PR after creation.
      point?
 
 8. Verification completeness
+   - Did the author attempt the verifications they could reach
+     (shell, API, mocked failures), or punt them to "Pending" /
+     "User to verify"? Items reachable from a shell or API belong
+     in the verified list.
    - Is every changed code path covered by CI, manual test steps in the
      PR body, or another verification mechanism?
    - Are there paths that only run in a specific target environment

--- a/claude/rules/pr-guidelines.md
+++ b/claude/rules/pr-guidelines.md
@@ -73,18 +73,19 @@ When writing a PR body, cover every applicable item:
 5. Verification
    - Attempt every verification within reach before drafting this
      section: shell commands, API calls, file inspection, mocked
-     failure modes, simulated missing-config tests. Punting verifiable
-     items to "Pending" or "User to verify" without first attempting
-     is itself the violation — the common failure mode is overstating
-     what is "untestable" and underestimating what shell-level
-     reproduction can cover.
+     failure modes, simulated missing-config tests. Punting reachable
+     items to "Pending" or "User to verify" (see below) is itself the
+     violation — overstating what is "untestable" is the common
+     failure mode.
    - List only items actually verified, with evidence (command output,
      exit code, log excerpt).
    - Items that genuinely require interactive UI, user-only
      credentials, target environments unreachable from a shell, or
      the live session itself go under a separate "User to verify"
      subsection with reproduction steps and a one-line reason why the
-     author could not verify them.
+     author could not verify them. Scope still applies (§2): items
+     that depend on changes outside this PR's diff belong in the
+     parent issue, not here.
 
 ## Review Criteria
 


### PR DESCRIPTION
## Purpose

Rewrite of #157, narrowed to the Verification section. Shifts the default verification stance from "describe what was checked" to "attempt every reachable check before admitting Pending".

## Why

#157 has broader scope; #159 already merged the Writing Style and Review Criteria 7 pieces. This PR extracts the remaining Verification rigor (Body Checklist 5 rewrite plus one Review Criteria 8 entry), with the verbose "common failure mode" sentence folded into the first bullet's tail clause. #157 will be closed once this is merged.

## Scope

- claude/rules/pr-guidelines.md only.
- PR Body Checklist 5 (Verification) — full rewrite.
- Review Criteria 8 — one bullet added at the top.
- Writing Style and Review Criteria 1–7 untouched.

## Verification

- Diff inspected: changes confined to PR Body Checklist 5 and Review Criteria 8; everything else byte-identical to main.
- pre-commit hooks passed at commit time (Trim Trailing Whitespace, Fix End of Files, Check JSON, Check Yaml, Check for added large files).
- CI passed: shellcheck, python-doctest, bootstrap (macos-latest, ubuntu-latest), Socket Security (Project Report, Pull Request Alerts).
- Content-only doc change in a rules document; no runtime behavior to verify.
