### PR TITLE
Add Anthropic-built plugins to setup

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -320,20 +320,13 @@
     "skill-creator@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
     "hookify@claude-plugins-official": true,
-    "security-guidance@claude-plugins-official": true,
-    "superpowers@superpowers-marketplace": true
+    "security-guidance@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "openai-codex": {
       "source": {
         "source": "github",
         "repo": "openai/codex-plugin-cc"
-      }
-    },
-    "superpowers-marketplace": {
-      "source": {
-        "source": "github",
-        "repo": "obra/superpowers-marketplace"
       }
     }
   },

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -314,13 +314,26 @@
   "enabledPlugins": {
     "gopls-lsp@claude-plugins-official": true,
     "codex@openai-codex": true,
-    "pr-review-toolkit@claude-plugins-official": true
+    "pr-review-toolkit@claude-plugins-official": true,
+    "session-report@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true,
+    "claude-code-setup@claude-plugins-official": true,
+    "hookify@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true,
+    "superpowers@superpowers-marketplace": true
   },
   "extraKnownMarketplaces": {
     "openai-codex": {
       "source": {
         "source": "github",
         "repo": "openai/codex-plugin-cc"
+      }
+    },
+    "superpowers-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "obra/superpowers-marketplace"
       }
     }
   },

--- a/scripts/claude-code-setup.sh
+++ b/scripts/claude-code-setup.sh
@@ -41,5 +41,3 @@ claude plugin install skill-creator@claude-plugins-official
 claude plugin install claude-code-setup@claude-plugins-official
 claude plugin install hookify@claude-plugins-official
 claude plugin install security-guidance@claude-plugins-official
-claude plugin marketplace add obra/superpowers-marketplace
-claude plugin install superpowers@superpowers-marketplace

--- a/scripts/claude-code-setup.sh
+++ b/scripts/claude-code-setup.sh
@@ -34,3 +34,12 @@ mcp_add Context7 '{"command":"npx","args":["-y","@upstash/context7-mcp"]}'
 claude plugin marketplace add openai/codex-plugin-cc
 claude plugin install codex@openai-codex
 claude plugin install pr-review-toolkit@claude-plugins-official
+claude plugin install gopls-lsp@claude-plugins-official
+claude plugin install session-report@claude-plugins-official
+claude plugin install claude-md-management@claude-plugins-official
+claude plugin install skill-creator@claude-plugins-official
+claude plugin install claude-code-setup@claude-plugins-official
+claude plugin install hookify@claude-plugins-official
+claude plugin install security-guidance@claude-plugins-official
+claude plugin marketplace add obra/superpowers-marketplace
+claude plugin install superpowers@superpowers-marketplace


### PR DESCRIPTION
## Purpose

Restore a richer set of Claude Code plugins declaratively when bootstrapping a new machine via `scripts/claude-code-setup.sh`. Until now the script installed only `codex` and `pr-review-toolkit`; everything else (including `gopls-lsp`, which was already enabled in `settings.json`) had to be re-installed manually after a clean checkout.

## Scope

`scripts/claude-code-setup.sh` — add seven `claude plugin install` lines, all from the Anthropic-managed `claude-plugins-official` marketplace:

- Six new Anthropic-built plugins: `session-report`, `claude-md-management`, `skill-creator`, `claude-code-setup` (the plugin, not this shell script), `hookify`, `security-guidance`
- One catch-up: `gopls-lsp` install, which was already declared in `settings.json`'s `enabledPlugins` but absent from the script — the script and `settings.json` are now consistent

`claude/settings.json` — mirror the six new plugins in `enabledPlugins`. `gopls-lsp` itself is unchanged in `settings.json` (it was already there). `extraKnownMarketplaces` is unchanged (no new third-party marketplace).

Out of scope:
- An unrelated `inputNeededNotifEnabled` toggle that Claude Code auto-writes into `settings.json` is intentionally excluded from this commit.
- Third-party plugins are intentionally excluded from this PR. An earlier commit on this branch added Superpowers (`obra/superpowers-marketplace`); the follow-up commit reverts it to keep the declarative install set inside the Anthropic-official trust boundary.

## References

- Anthropic official marketplace catalog: https://github.com/anthropics/claude-plugins-official/blob/main/.claude-plugin/marketplace.json
- Plugin discover & install docs: https://code.claude.com/docs/en/discover-plugins
- `claude plugin install` is empirically idempotent: re-running on already-installed plugins emits `✔ Plugin "<name>" is already installed (scope: user)` and exits 0. The script runs under `set -eu`, so any non-zero exit (typo, removed plugin, network failure) aborts loudly — there is no silent-failure path on the new lines.

## Verification

Verified before pushing:

- `bash -n scripts/claude-code-setup.sh` — syntax OK
- `shellcheck scripts/claude-code-setup.sh` — clean
- `jq empty claude/settings.json` — valid JSON
- `pre-commit run --files claude/settings.json scripts/claude-code-setup.sh` — all hooks pass (Trim Trailing Whitespace, Fix End of Files, Check JSON, Check for added large files)
- `bash scripts/claude-code-setup.sh` end-to-end on the author's machine — the nine plugins already present at user scope reported "already installed", exit 0
- `claude plugin list` after the run — nine plugins enabled at user scope (`codex`, `gopls-lsp`, `pr-review-toolkit`, `session-report`, `claude-md-management`, `skill-creator`, `claude-code-setup`, `hookify`, `security-guidance`)
- `claude plugin marketplace remove superpowers-marketplace` — local Superpowers plugin and its marketplace cleaned up so the author's machine matches the declared state in this PR
