### PR TITLE
Enable built-in sandbox for OS-level filesystem and network isolation

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -253,6 +253,36 @@
       "Bash(copilot update *)"
     ]
   },
+  "sandbox": {
+    "enabled": true,
+    "filesystem": {
+      "denyRead": [
+        "~/.ssh",
+        "~/.gnupg",
+        "~/.aws/credentials",
+        "~/.aws/config",
+        "~/.config/gh/hosts.yml",
+        "~/.netrc",
+        "~/.docker/config.json",
+        "~/.zsh_history",
+        "~/.bash_history"
+      ]
+    },
+    "network": {
+      "allowedDomains": [
+        "github.com",
+        "raw.githubusercontent.com",
+        "objects.githubusercontent.com",
+        "api.github.com",
+        "registry.npmjs.org",
+        "proxy.golang.org",
+        "sum.golang.org",
+        "pypi.org",
+        "files.pythonhosted.org"
+      ]
+    },
+    "excludedCommands": ["docker *"]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -260,8 +260,10 @@
         "~/.ssh",
         "~/.gnupg",
         "~/.aws/credentials",
-        "~/.aws/config",
         "~/.config/gh/hosts.yml",
+        "~/.config/gcloud/credentials.db",
+        "~/.config/gcloud/access_tokens.db",
+        "~/.config/gcloud/legacy_credentials",
         "~/.netrc",
         "~/.docker/config.json",
         "~/.zsh_history",
@@ -271,17 +273,15 @@
     "network": {
       "allowedDomains": [
         "github.com",
-        "raw.githubusercontent.com",
-        "objects.githubusercontent.com",
-        "api.github.com",
+        "*.github.com",
+        "*.githubusercontent.com",
         "registry.npmjs.org",
         "proxy.golang.org",
         "sum.golang.org",
         "pypi.org",
         "files.pythonhosted.org"
       ]
-    },
-    "excludedCommands": ["docker *"]
+    }
   },
   "hooks": {
     "PreToolUse": [


### PR DESCRIPTION
## Why

Enable Claude Code's built-in sandbox to add an OS-level filesystem and network boundary on top of the auto mode LLM classifier. The classifier alone has known false negatives, and credentials such as `~/.ssh` and `~/.aws/credentials` are currently accessible at the same process privilege as the agent.

This is the first slice of a larger security plan kept locally in `ikuwowfiles/claude-code-security-setup.md`. Audit logging hooks and decision-tree blockers are intentionally deferred to follow-up PRs to keep this change reviewable.

## Scope

In: a single `sandbox` key added to `claude/settings.json`. No hooks, no scripts, no `claude/audit/` directory.

Deliberately out of scope:
- Audit logging hooks (PreToolUse / PostToolUse / PermissionDenied loggers)
- Force-push deterministic block in a hook (already covered by the existing `permissions.deny` rules for `git push --force` etc.)
- `failIfUnavailable` / `allowUnsandboxedCommands: false` — leaving the `dangerouslyDisableSandbox` escape hatch open so Claude can fall back to the normal permission-approval flow when something legitimate hits a sandbox boundary

## Configuration choices

### `filesystem.denyRead`

Covers credential files for both AWS and GCP, plus shell histories that may contain accidentally typed secrets. Specific files instead of whole directories, to avoid breaking subprocess access to non-credential config:

- AWS: `~/.aws/credentials` only, not `~/.aws/config` (config holds profile/region/SSO definitions; deny-ing it broke `AWS_PROFILE=<name> aws ...` profile resolution)
- GitHub: `~/.config/gh/hosts.yml` only — only this file holds the PAT
- GCP: `~/.config/gcloud/credentials.db`, `access_tokens.db`, `legacy_credentials/` — `gcloud` is used per global rules, so these need parity with the AWS deny entries
- Plus `~/.ssh`, `~/.gnupg`, `~/.netrc`, `~/.docker/config.json`, `~/.{zsh,bash}_history`
- Excluded on purpose: `~/.gitconfig` — it is configuration, not credential, and git/gh subprocesses must read it to commit

### `network.allowedDomains`

Broad GitHub allowance plus minimum dev-infra: `github.com`, `*.github.com`, `*.githubusercontent.com`, `registry.npmjs.org`, `proxy.golang.org`, `sum.golang.org`, `pypi.org`, `files.pythonhosted.org`.

Caveats this list does not solve, just to be honest about what the network boundary buys:

- The proxy does not perform TLS inspection (per https://code.claude.com/docs/en/sandboxing Security Limitations). Allowing `*.github.com` permits exfiltration via Gist / raw / release-asset upload over a permitted hostname. The allowlist mainly stops "obvious" exfiltration to attacker-controlled domains, not determined exfiltration through trusted hosts.
- `github.io` is intentionally excluded — it is a user-pages host where anyone can publish arbitrary content, so a generic allow would broaden the exfil surface for no meaningful gain.
- The list is expected to grow reactively as legitimate prompts hit it. The wildcard form (`*.github.com` plus the apex `github.com`) is written defensively because the official docs do not specify whether wildcard matches the apex; pairing both is harmless.

### `excludedCommands` is intentionally not set

Originally included `["docker *"]` per the official Tip note, but removed: commands in `excludedCommands` run fully unsandboxed without prompting, and `docker run -v ~:/host ...` or `--network host` would silently bypass the entire `denyRead` / `allowedDomains` scheme. Letting docker hit the `dangerouslyDisableSandbox` escape hatch instead routes each invocation through the normal permission flow with a visible prompt, which is appropriate for a command with that blast radius.

## Sources

- Sandbox configuration schema and behavior: https://code.claude.com/docs/en/sandboxing
- Permission modes (auto, plan, default, acceptEdits): https://code.claude.com/docs/en/permission-modes

## Verification

Verified locally before pushing:

- `jq '.sandbox' claude/settings.json` parses cleanly and produces the intended structure
- `jq 'keys'` confirms only one new top-level key (`sandbox`) was added
- `git diff` is contained to the new `sandbox` block; nothing else in the file moved
- pre-commit hooks (trailing whitespace, end-of-file, JSON validity) all pass

### User to verify

These verifications all require the sandbox to actually be active in a Claude Code session. The shell where this PR was prepared does not have the new settings loaded yet (Claude Code reads `settings.json` on next start), so OS-level enforcement cannot be exercised from this PR's environment.

- `/sandbox` slash command opens the auto-allow vs. regular permissions menu
- Write inside cwd succeeds; write outside cwd (e.g., `echo test > ~/sandbox-test.txt`) is blocked
- `cat ~/.ssh/id_ed25519` is blocked
- Routine subprocesses still work, or trigger the `dangerouslyDisableSandbox` prompt cleanly:
  - `aws sts get-caller-identity` with `AWS_PROFILE=stg-ro` (config readable, credentials denied for direct read but profile resolution succeeds)
  - `gcloud auth list`
  - `gh pr list`
  - `git pull` / `git push` / `git commit`
  - `docker compose ps` (now goes through the escape-hatch prompt instead of running silently)
- `WebFetch` to a non-allowlisted domain (e.g., `https://example.com`) is blocked
- Wildcard form: `gh api` against `api.github.com` works under `*.github.com`

If any routine subprocess breaks unexpectedly, follow up by relaxing the `denyRead` entry or expanding `allowedDomains` in a small fix PR.

## Notes

The local plan document (`ikuwowfiles/claude-code-security-setup.md`) contains a few inaccurate statements that surfaced during research and remain in the doc untouched:

- `claude --enable-auto-mode` should be `--permission-mode auto`
- "False Negative Rate 17%" is not present in the publicly available `auto-mode` blog post; treat as unverified
- Hook event field name `reason` is not in the public sample JSON for `PermissionDenied`; the actual schema uses `permissionDecisionReason` / `message`

These will be fixed when the audit-logging follow-up is implemented.
