### PR TITLE
Stop tracking .npmrc; move settings to NPM_CONFIG_* env vars

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -71,6 +71,11 @@ export XDG_CONFIG_HOME=~/.config # Some tools hardcode this path; do not change 
 export XDG_DATA_HOME=~/.local/share
 export QUOTING_STYLE=literal # for GNU ls
 
+# npm
+export NPM_CONFIG_FUND=false
+export NPM_CONFIG_MIN_RELEASE_AGE=7
+export NPM_CONFIG_IGNORE_SCRIPTS=true
+
 # AWS Profile Switcher
 if [ -f ~/.aws/current_profile ]; then
   AWS_PROFILE="$(cat ~/.aws/current_profile)"

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-fund=false
-min-release-age=7
-ignore-scripts=true

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -40,7 +40,6 @@ link .tmux.conf     "$HOME/.tmux.conf"
 # Version / package managers
 link .tool-versions           "$HOME/.tool-versions"
 link .gemrc                   "$HOME/.gemrc"
-link .npmrc                   "$HOME/.npmrc"
 link .default-gems            "$HOME/.default-gems"
 link .default-npm-packages    "$HOME/.default-npm-packages"
 link .default-python-packages "$HOME/.default-python-packages"


### PR DESCRIPTION
## Purpose

`npm login` writes `//registry.npmjs.org/:_authToken=npm_...` to the user config file. Because `~/.npmrc` was symlinked to the tracked `.npmrc`, every login forced a manual cleanup step to avoid leaking the token via commit. This switches to a no-symlink layout so the token never lands in this repository's working tree.

The previous `.npmrc` only carried three behavior tweaks (`fund=false`, `min-release-age=7`, `ignore-scripts=true`). All three have direct `NPM_CONFIG_*` env var equivalents, so moving them to `.bash_profile` is fully equivalent — no semantic change for npm.

## Scope

- `.bash_profile`: add three `NPM_CONFIG_*` exports under "Universal environment".
- `scripts/deploy.sh`: drop the `link .npmrc "$HOME/.npmrc"` line.
- `.npmrc`: removed from the repository.

Out of scope:

- `.gitignore` was intentionally left untouched. The file no longer exists in this repo, so a defensive `.npmrc` ignore would only guard against an unlikely future scenario.
- Existing `~/.npmrc` symlink on the local machine is removed manually (not handled by `deploy.sh`, which only adds links).

## Sources

- npm config env var convention (uppercase `NPM_CONFIG_*`, underscores → hyphens, case-insensitive values): https://docs.npmjs.com/cli/v11/using-npm/config
- npm `${NPM_TOKEN}` interpolation pattern (background, not used here): https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow

## Verification

Confirmed: env var → npm config equivalence is exact.

Run with the three exports set and `--userconfig=/dev/null` to isolate from any existing user config:

```
$ NPM_CONFIG_FUND=false NPM_CONFIG_MIN_RELEASE_AGE=7 NPM_CONFIG_IGNORE_SCRIPTS=true \
    npm config get fund min-release-age ignore-scripts --userconfig=/dev/null
fund=false
min-release-age=7
ignore-scripts=true
```

`npm config list --long` attributes them to the env source explicitly:

```
; fund = true ; overridden by env
; ignore-scripts = false ; overridden by env
; "env" config from environment
```

`min-release-age` does not appear in the override list because it has no built-in default; the `npm config get` output above confirms it is honored.

GitHub Actions CI all passed: `bootstrap (macos-latest)`, `bootstrap (ubuntu-latest)`, `python-doctest`, `shellcheck`, `Socket Security: Project Report`, `Socket Security: Pull Request Alerts`. Local pre-commit hooks (trailing whitespace, end-of-file fixer, JSON/YAML check, large file guard) passed on commit.

### User to verify

- Post-merge on the local machine: `rm ~/.npmrc && ./scripts/deploy.sh && exec $SHELL -l`, then check `npm config get fund min-release-age ignore-scripts` returns the three values from the new `.bash_profile`. Not run inside the PR because it requires replacing the live `~/.npmrc` symlink and reloading the interactive shell.
