### PR TITLE
Add check-symlinks + verify-deploy pre-commit hooks; repoint stale symlinks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,12 @@ repos:
       - id: check-json
       - id: check-yaml
       - id: check-added-large-files
+      - id: check-symlinks
+  - repo: local
+    hooks:
+      - id: verify-deploy
+        name: Verify deploy.sh symlinks match verify_deploy.sh
+        entry: scripts/verify_deploy.sh
+        language: script
+        pass_filenames: false
+        files: ^scripts/(deploy|verify_deploy)\.sh$

--- a/.sshrc.d/.config/git
+++ b/.sshrc.d/.config/git
@@ -1,1 +1,1 @@
-../../.config/git
+../../xdg-config/git

--- a/.sshrc.d/.tmux.conf
+++ b/.sshrc.d/.tmux.conf
@@ -1,1 +1,1 @@
-../.tmux.conf
+../xdg-config/tmux/tmux.conf

--- a/.sshrc.d/.vimrc
+++ b/.sshrc.d/.vimrc
@@ -1,1 +1,1 @@
-../.vimrc
+../xdg-config/vim/vimrc

--- a/.vim/ginit.vim
+++ b/.vim/ginit.vim
@@ -1,1 +1,1 @@
-../../.gvimrc
+../xdg-config/vim/gvimrc

--- a/.vim/init.vim
+++ b/.vim/init.vim
@@ -1,1 +1,1 @@
-../.vimrc
+../xdg-config/vim/vimrc

--- a/xdg-config/kyrat/tmux.conf
+++ b/xdg-config/kyrat/tmux.conf
@@ -1,1 +1,1 @@
-../../.tmux.conf
+../tmux/tmux.conf

--- a/xdg-config/kyrat/vimrc
+++ b/xdg-config/kyrat/vimrc
@@ -1,1 +1,1 @@
-../../.vimrc
+../vim/vimrc


### PR DESCRIPTION
## Summary

Add two pre-commit hooks that catch failure modes which currently only surface in CI, and repair the broken symlinks the first hook would otherwise flag.

## Why

Retrospective on #168 surfaced two issues that the bootstrap CI workflow caught but a local commit did not:

- A relative symlink that no longer resolved after a `git mv` (caught only when listing the destination directory by hand).
- `scripts/verify_deploy.sh` had hardcoded checks against files removed by the same PR; the mismatch caused the bootstrap CI to fail and required a third commit. There is no local mechanism today that catches a `deploy.sh`/`verify_deploy.sh` mismatch before push.

This PR adds local enforcement for both, then cleans up the broken symlinks revealed when the new check ran against the existing tree.

## Changes

Commit 1 — repoint seven tracked symlinks to where their targets live now. Six pointed at repo-root files moved by #168 into `xdg-config/`; one pointed at `.config/` from before #112 renamed it to `xdg-config/`.

Commit 2 — add the two hooks:

- `check-symlinks` (built-in `pre-commit-hooks`): fails when any staged symlink does not resolve. Would have caught the seven cases above at commit time.
- `verify-deploy` (local hook): runs `scripts/verify_deploy.sh` whenever `scripts/deploy.sh` or `scripts/verify_deploy.sh` is staged. Would have caught the verify_deploy.sh oversight in #168 before push instead of after CI.

## Scope

The local `verify-deploy` hook depends on `~/` already reflecting `deploy.sh`'s current output (the script asserts symlinks under `$HOME`). On a dev machine this holds after running `./scripts/deploy.sh` once on the working tree, which is the normal cadence when editing these files. None of the existing CI workflows run pre-commit, so this restriction is local-only.

## Verification

- `pre-commit run --all-files` after commit 1: every hook including the two new ones exits clean.
- Each retargeted symlink resolves on the dev machine, confirmed via `test -e` and `ls -L` immediately after the relink.

## Test plan

- [x] Local: `pre-commit run --all-files` exits 0 with both new hooks active
- [x] Local: each of the 7 repointed symlinks passes `test -e`
- [x] CI: `Lint` (shellcheck + python-doctest) and `Bootstrap` (ubuntu + macos) workflows pass on the PR branch
- [x] CI: Socket Security scans pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
