### PR TITLE
Fix plugin install on fresh Claude Code environments

### DIFF
--- a/scripts/claude-code-setup.sh
+++ b/scripts/claude-code-setup.sh
@@ -30,10 +30,7 @@ mcp_add deepwiki '{"type":"http","url":"https://mcp.deepwiki.com/mcp"}'
 mcp_add Context7 '{"command":"npx","args":["-y","@upstash/context7-mcp"]}'
 
 # --- Plugins ---
-# marketplace add and plugin install are both idempotent.
-# claude-plugins-official is built-in, but on Claude Code web the cache is
-# not populated until `marketplace add` is run, so install would fail with
-# "Plugin not found in marketplace" without this line.
+# Ensure marketplaces exist (required on fresh environments like Claude Code web).
 claude plugin marketplace add anthropics/claude-plugins-official
 claude plugin marketplace add openai/codex-plugin-cc
 claude plugin install codex@openai-codex

--- a/scripts/claude-code-setup.sh
+++ b/scripts/claude-code-setup.sh
@@ -30,7 +30,11 @@ mcp_add deepwiki '{"type":"http","url":"https://mcp.deepwiki.com/mcp"}'
 mcp_add Context7 '{"command":"npx","args":["-y","@upstash/context7-mcp"]}'
 
 # --- Plugins ---
-# marketplace add and plugin install are both idempotent
+# marketplace add and plugin install are both idempotent.
+# claude-plugins-official is built-in, but on Claude Code web the cache is
+# not populated until `marketplace add` is run, so install would fail with
+# "Plugin not found in marketplace" without this line.
+claude plugin marketplace add anthropics/claude-plugins-official
 claude plugin marketplace add openai/codex-plugin-cc
 claude plugin install codex@openai-codex
 claude plugin install pr-review-toolkit@claude-plugins-official

--- a/scripts/claude-code-setup.sh
+++ b/scripts/claude-code-setup.sh
@@ -31,9 +31,7 @@ mcp_add Context7 '{"command":"npx","args":["-y","@upstash/context7-mcp"]}'
 
 # --- Plugins ---
 # marketplace add and plugin install are both idempotent
-claude plugin marketplace update claude-plugins-official
 claude plugin marketplace add openai/codex-plugin-cc
-
 claude plugin install codex@openai-codex
 claude plugin install pr-review-toolkit@claude-plugins-official
 claude plugin install gopls-lsp@claude-plugins-official


### PR DESCRIPTION
## Summary

Replace `claude plugin marketplace update claude-plugins-official` with `claude plugin marketplace add anthropics/claude-plugins-official` in `scripts/claude-code-setup.sh`, so the script works on fresh Claude Code environments where the marketplace cache is not yet populated.

## Background

`claude-plugins-official` is treated as a built-in marketplace, but on fresh installations its plugin cache is empty. `marketplace update` only works when the marketplace is already registered with a populated cache, so on a fresh Claude Code web environment it fails with one of:

- `Marketplace 'claude-plugins-official' not found`, or
- `Plugin '...' not found in marketplace 'claude-plugins-official'` (after another `marketplace add` happens to trigger the registration but not the cache fetch).

`claude plugin marketplace add anthropics/claude-plugins-official` populates the cache on first run, and reports `already on disk` as a no-op on environments where it is already registered, so it is safe to run on regular local environments as well.

## Verification

- [x] Local (already registered): `claude plugin marketplace add anthropics/claude-plugins-official` exits with `already on disk` and exit code 0.
- [x] Claude Code web: running the bootstrap script completes and all plugins install successfully (verified interactively during this debugging session).
