### PR TITLE
Limit no-hard-wrap rule to GitHub PR/issue UI surfaces

### DIFF
--- a/claude/rules/pr-guidelines.md
+++ b/claude/rules/pr-guidelines.md
@@ -37,13 +37,31 @@ lives in the diff, the issue, or a linked source.
   behavior changes, new capabilities, removed limitations, etc. —
   rather than listing implementation details (resources added, files
   touched).
-- Do not hard-wrap paragraphs or list items at a fixed column width.
-  GitHub Flavored Markdown renders soft line breaks inside a paragraph
-  as visible breaks (or runs them together awkwardly), so a body
-  wrapped at ~70 chars looks broken on the web. Write each paragraph
-  as a single line and let the browser wrap it. Use blank lines for
-  paragraph breaks. The same rule applies to issue bodies and PR /
-  issue comments.
+- Inside GitHub PR / issue bodies and PR / issue comments only — that
+  is, Markdown posted through the GitHub web UI — do not hard-wrap
+  paragraphs or list items. Write each paragraph as a single line and
+  let the browser wrap it; use blank lines for paragraph breaks. GitHub
+  Flavored Markdown renders soft line breaks inside a paragraph as
+  visible breaks (or runs lines together awkwardly) only in these
+  contexts, so a body wrapped at ~70 chars looks broken on the web.
+  Plain Markdown files (READMEs, ADRs, this guidelines file itself,
+  and any other in-repo documentation) follow standard Markdown
+  rendering — single line breaks inside a paragraph are ignored — so
+  they may be hard-wrapped for file-side readability.
+- DO / DON'T example for a paragraph in a PR / issue body:
+
+  DO (single line, the browser wraps it):
+
+  ````
+  Fix the broken X path so Y stops emitting spurious diffs.
+  ````
+
+  DON'T (paragraph hard-wrapped at column width):
+
+  ````
+  Fix the broken X path so Y stops emitting
+  spurious diffs.
+  ````
 
 ## PR Body Checklist
 


### PR DESCRIPTION
## Why

The previous wording at L40-46 started with "Do not hard-wrap paragraphs..." as a general statement and only tagged "same rule applies to issue bodies and PR / issue comments" as a closing clause. Read in isolation that reads as a Markdown-wide convention, which contradicts the fact that this guidelines file, `AIRULES.md`, and other in-repo Markdown are all hard-wrapped. The mismatch between rule wording and intent has produced recurring AI mistakes where PR bodies get hard-wrapped (the actual target the rule meant to forbid) because the agent reads the surrounding hard-wrapped guideline file as the canonical "house style".

## What

- Reframe the rule so GitHub PR/issue bodies and PR/issue comments appear as the explicit subject of the first sentence, not as a tail clause. The scope is now read-correctly even when the bullet is read alone.
- Add an explicit exemption for plain Markdown files (READMEs, ADRs, this guidelines file itself), citing standard Markdown's "single line breaks ignored" rendering as the reason these files can stay hard-wrapped.
- Add a DO / DON'T paragraph example using fenced code blocks so the visual contrast is concrete, not just verbally described.

## Out of scope

- `AIRULES.md` is not touched. It does not reference the no-hard-wrap rule directly; the chain is `AIRULES.md` → `git-workflow.md` (Step 4 says to follow the PR Body Checklist, implicitly = this file) → `pr-guidelines.md`. So updating only this file is sufficient — no follow-up to `AIRULES.md` or `git-workflow.md` is required.
- Hook-based enforcement (PreToolUse on `gh pr (create|edit) --body-file`) is not added in this PR. The plan is to land A (rule rewrite, this PR) and B (DO/DON'T example, this PR) first; only if recurrence persists do we move on to C (workflow checkpoint in `git-workflow.md`) and finally a hook.

## Verification

- [x] `git diff` reviewed: only `claude/rules/pr-guidelines.md` is modified. The change replaces the original L40-46 bullet (counted in the pre-change file) with a longer reframed bullet plus a new DO/DON'T-example bullet — total +25 / -7 lines.
- [x] pre-commit hooks pass on commit (Trim Trailing Whitespace, Fix End of Files, Check for added large files all green; JSON / YAML / symlink hooks correctly skip — no relevant files).
- [x] The new wording places `Inside GitHub PR / issue bodies and PR / issue comments only` as the leading clause of the rule, before the prohibition itself.
- [x] DO / DON'T example uses 4-backtick fences so the inner block does not collide with any 3-backtick fence the file may sit inside when rendered.
- [x] CI pass: bootstrap (macos-latest, ubuntu-latest), python-doctest, shellcheck, Socket Security all green on the latest push.
- [x] Cross-check that no other rule file references `pr-guidelines.md` directly: `grep` of `AIRULES.md` and `claude/rules/git-workflow.md` confirms only `git-workflow.md` Step 4 alludes to "PR Body Checklist" without an explicit path link, and `AIRULES.md` only links to `git-workflow.md`. So no other file edits are needed.
- [ ] Effectiveness at reducing recurrence: cannot be measured in-line; re-evaluate after the next 5 AI-drafted PR bodies (whether the agent still hard-wraps paragraphs in PR bodies despite this revised rule).
