### PR TITLE
Prefer gh CLI over GitHub MCP server for coding tasks

### DIFF
--- a/AIRULES.md
+++ b/AIRULES.md
@@ -58,7 +58,7 @@
 
 - Web 検索より MCP サーバー等の外部情報ツールを優先する
 - 通常の Web サイトよりもプレーンテキスト・Markdown ファイルの取得を優先する
-- GitHub の場合は `gh` コマンドや `raw.githubusercontent.com` を優先する
+- GitHub の操作はコーディングタスクの場合 `gh` コマンドを使う。gh で実現できない場合のみ `raw.githubusercontent.com` や GitHub MCP サーバー（`mcp__*_GitHub_MCP_Server__*` ツール群）等を使ってよい
 
 ---
 

--- a/AIRULES.md
+++ b/AIRULES.md
@@ -58,7 +58,7 @@
 
 - Web 検索より MCP サーバー等の外部情報ツールを優先する
 - 通常の Web サイトよりもプレーンテキスト・Markdown ファイルの取得を優先する
-- GitHub の操作はコーディングタスクの場合 `gh` コマンドを使う。gh で実現できない場合のみ `raw.githubusercontent.com` や GitHub MCP サーバー（`mcp__*_GitHub_MCP_Server__*` ツール群）等を使ってよい
+- GitHub の操作はコーディングタスクの場合 `gh` コマンドを使う。gh が使えない環境や gh で実現できない操作の場合のみ `raw.githubusercontent.com` や GitHub MCP サーバー（`mcp__*_GitHub_MCP_Server__*` ツール群）等を使ってよい
 
 ---
 


### PR DESCRIPTION
## Summary

Tighten the AIRULES.md rule about GitHub-related tool selection so coding agents (Claude Code, Codex CLI, etc.) reach for `gh` first and only fall back to `raw.githubusercontent.com` or the GitHub MCP server when `gh` is unavailable in the environment or cannot perform the operation.

## Why

In Claude Code sessions, the GitHub MCP server tools (`mcp__*_GitHub_MCP_Server__*`) sometimes get used for operations that `gh` already covers. The existing rule said `gh` and `raw.githubusercontent.com` are "preferred" alongside each other, which left room for the MCP server to be a peer choice. Splitting `gh` out as the sole first choice and demoting the others to fallbacks makes the intent explicit.

Practical reason: `gh` invocations flow through the Bash permission hooks in this repo (e.g., `approve_safe_commands.py`), keeping authorization predictable. MCP tools bypass those hooks.

The fallback condition covers both capability gaps (an operation `gh` cannot perform) and environment gaps (e.g., `gh` is not installed, not authenticated, or no network).

## Scope

- AIRULES.md L61 のみの 1 行差し替え
- 「コーディングタスクの場合」と適用条件を限定しているため、claude.ai chat の非コーディング文脈には影響しない
- 階層構造（symlink、ファイル分割）には手を入れない
- Codex CLI 向けの分離は本 PR の対象外（必要なら follow-up）

## Verification

Verified locally:

- `git diff main -- AIRULES.md` shows exactly a single-line replacement at L61
- `grep -n "GitHub MCP" AIRULES.md` returns the new bullet at L61
- `readlink ~/.claude/CLAUDE.md` and `readlink ~/.codex/AGENTS.md` still point at `dotfiles/AIRULES.md` (symlink structure unchanged)
- pre-commit hooks passed on commit (trailing whitespace / EOF / large files / broken symlinks / deploy.sh consistency)
- CI on this PR: all checks pass (shellcheck, python-doctest, bootstrap on macOS / Ubuntu, Socket Security)

User-facing checks:

- [ ] 次回の Claude Code セッションで、GitHub 操作時に `gh` が第一選択として扱われ、`gh` で実現できない操作や `gh` が使えない環境では `raw.githubusercontent.com` / MCP server に fallback することを確認
