### PR TITLE
Fix shell function exit bug, harden scripts

### DIFF
--- a/.functions
+++ b/.functions
@@ -22,7 +22,7 @@ short_git_ps1() {
   [ -z "$branch" ] && return
 
   max_len=20
-  if [ ${#branch} -le $max_len ]; then
+  if [ "${#branch}" -le "$max_len" ]; then
     echo " ($branch)"
     return
   fi
@@ -116,7 +116,7 @@ if [ ! "$(command -v aps)" ]; then
   aps() {
     if [ ! "$(command -v fzf)" ]; then
       echo "Error: ${FUNCNAME} requires fzf executable."
-      exit 1
+      return 1
     fi
     query="$1"
 
@@ -182,7 +182,7 @@ EOF
     if [ -n "$SSO_ACCOUNT_ID" ]; then
       echo "SSO detected. Checking SSO session..."
       SSO_ACCOUNT="$(aws sts get-caller-identity --query "Account")"
-      if [ ${#SSO_ACCOUNT} != 14 ]; then
+      if [ "${#SSO_ACCOUNT}" -ne 14 ]; then
         aws sso login
       fi
     fi
@@ -193,7 +193,7 @@ if [ ! "$(command -v gps)" ]; then
   gps() {
     if [ ! "$(command -v fzf)" ]; then
       echo "Error: ${FUNCNAME} requires fzf executable."
-      exit 1
+      return 1
     fi
     query="$1"
 

--- a/Brewfile
+++ b/Brewfile
@@ -206,7 +206,6 @@ mas "Focus", id: 777233759
 mas "Control Panel for Twitter", id: 1668516167
 mas "one sec", id: 1532875441
 mas "Xcode", id: 497799835
-mas "WireGuard", id: 1451685025
 mas "Apple Configurator", id: 1037126344
 mas "Wappalyzer", id: 1520333300
 mas "Center", id: 1332483673

--- a/bin/ssm
+++ b/bin/ssm
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
 
 function start-session() {
   local target="$1"
   aws ssm start-session --target "$target"
 }
 
-target="$1"
+target="${1:-}"
 
 if [ -z "$target" ]; then
   echo "Usage: ssm <instance-id/Name-tag>"
@@ -26,7 +26,7 @@ INSTANCE_IDS=$(aws ec2 describe-instances \
 
 readarray -t INSTANCE_IDS_ARRAY <<< "$INSTANCE_IDS"
 
-if [ ${#INSTANCE_IDS_ARRAY[@]} -eq 1 ]; then
+if [ "${#INSTANCE_IDS_ARRAY[@]}" -eq 1 ]; then
   if [ -z "${INSTANCE_IDS_ARRAY[0]}" ]; then
     echo "No instances found with the given Name tag value."
     exit 1
@@ -35,7 +35,7 @@ if [ ${#INSTANCE_IDS_ARRAY[@]} -eq 1 ]; then
   echo "EC2 instance found: ${INSTANCE_IDS_ARRAY[0]}"
   start-session "${INSTANCE_IDS_ARRAY[0]}"
   exit 0
-elif [ ${#INSTANCE_IDS_ARRAY[@]} -gt 1 ]; then
+elif [ "${#INSTANCE_IDS_ARRAY[@]}" -gt 1 ]; then
   echo "Error: Target ${target} exists in multiple instances!"
   exit 1
 else

--- a/bootstrap/main.sh
+++ b/bootstrap/main.sh
@@ -23,7 +23,7 @@ if [ "$os" = "Linux" ]; then
   exit 0
 fi
 
-if [ "$(xcode-select -p 1>/dev/null; echo $?)" != 0 ]; then
+if ! xcode-select -p >/dev/null 2>&1; then
   echo 'Command line tool is not installed.'
   echo 'Invoked installation.'
   echo 'Please follow prompt window.'

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
 
 function condkillall() {
   local -r process="$1"


### PR DESCRIPTION
## Purpose

Weekly routine: fix a bug in shell functions and improve error handling consistency across scripts.

## Changes

The `aps()` and `gps()` functions in `.functions` used `exit 1` to bail out when `fzf` is missing. Since these are shell functions (not scripts), `exit 1` terminates the user's entire shell session instead of just returning from the function. This changes them to `return 1`.

Other changes tighten quoting and error handling for consistency with the rest of the codebase:

- `.functions`: quote `${#branch}` and `${#SSO_ACCOUNT}` inside `[ ]` tests; use `-ne` (numeric) instead of `!=` (string) for the SSO account length check
- `bootstrap/main.sh`: replace `"$(xcode-select -p 1>/dev/null; echo $?)" != 0` with idiomatic `! xcode-select -p >/dev/null 2>&1` (also suppresses stderr noise)
- `bin/ssm`: `set -e` to `set -eu`, `${1:-}` for unset-safe parameter, quote `${#INSTANCE_IDS_ARRAY[@]}`
- `scripts/configure.sh`: `set -e` to `set -eu`
- `Brewfile`: remove duplicate WireGuard entry (already listed on line 28)

## Verification

- All changes are behavior-preserving on the success path. The `exit 1` to `return 1` fix only changes behavior when `fzf` is absent (previously killed the shell; now returns an error).
- `set -eu` additions are safe: `bin/ssm` uses `${1:-}` for the optional positional parameter, and `scripts/configure.sh` only uses local variables and hardcoded values.
- `bootstrap/main.sh` xcode-select check produces identical branching logic; the new form additionally suppresses stderr.
- Brewfile duplicate removal: WireGuard remains on line 28; only the redundant copy on the former line 209 is removed.
- [ ] CI shellcheck validation (runs in GitHub Actions)

## Past feedback

PR #138 (first routine run) was merged without comments. No rejected PRs or negative feedback to incorporate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYUNhZe64Ay4FSnw9Zjumn)_