### PR TITLE
Add prepare-commit-msg hook for AI-drafted commit subjects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         run: |
           shellcheck -- **/*.sh
           find bin/ -type f ! -name '*.md' -exec shellcheck {} +
+          find xdg-config/git/hooks/ -type f -exec shellcheck {} +
           shellcheck --exclude SC2148 .bash_profile .bashrc
   python-doctest:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ dotfiles/
 └── ... (other dotfiles)
 ```
 
+### AI-Assisted Commit Messages
+
+Running `git commit` interactively (no `-m`) opens the editor with an AI-drafted subject line prefilled. The hook calls `claude --model haiku` with the staged diff piped on stdin and the last 10 commit subjects as a style reference, so the suggestion matches the repository's existing tone and language.
+
+The hook is a no-op for `git commit -m ...`, merges, squashes, amends, when `claude` is not on PATH, when the staged diff exceeds 200 KB, and when invoked with `GIT_AI_COMMIT_MSG=0`. On any failure it exits silently and leaves the original buffer untouched, so `git commit` is never blocked.
+
+Defined in `xdg-config/git/hooks/prepare-commit-msg` and wired by `core.hooksPath = ~/.config/git/hooks` in `xdg-config/git/config`. For an interactive alternative that commits in one shot via `codex`, see `bin/git-ai-commit.sh` (aliased as `git aic`).
+
 ### Machine-Local Overrides
 
 To define settings that apply only to a specific machine (not tracked by this repository),

--- a/scripts/verify_deploy.sh
+++ b/scripts/verify_deploy.sh
@@ -46,6 +46,13 @@ check_symlink "${XDG_CONFIG_HOME:-$HOME/.config}/nvim"
 check_symlink "${XDG_CONFIG_HOME:-$HOME/.config}/tmux"
 check_symlink "${XDG_CONFIG_HOME:-$HOME/.config}/vim"
 check_symlink "${XDG_CONFIG_HOME:-$HOME/.config}/ideavim"
+# Global git hook reached via xdg-config/git/ → ~/.config/git/ symlink
+if [ -x "${XDG_CONFIG_HOME:-$HOME/.config}/git/hooks/prepare-commit-msg" ]; then
+  echo "OK: ~/.config/git/hooks/prepare-commit-msg is executable"
+else
+  echo "FAIL: ~/.config/git/hooks/prepare-commit-msg missing or not executable"
+  errors=$((errors + 1))
+fi
 
 echo ""
 echo "=== bin (auto-discovered) ==="

--- a/xdg-config/git/config
+++ b/xdg-config/git/config
@@ -4,6 +4,7 @@
 [core]
     editor = nvim
     quotepath = false
+    hooksPath = ~/.config/git/hooks
 [color]
     ui = true
 [grep]

--- a/xdg-config/git/hooks/prepare-commit-msg
+++ b/xdg-config/git/hooks/prepare-commit-msg
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Drafts an AI-generated subject line into the commit message buffer
+# for interactive commits only (no -m, no merge/squash/amend/template).
+# Always exits 0 so a hook failure never blocks git commit.
+
+set -eu
+
+MSG_FILE="$1"
+MSG_SOURCE="${2:-}"
+
+# Skip non-interactive sources: message, template, merge, squash, commit.
+# Only an empty $2 means "user invoked git commit interactively".
+if [ -n "$MSG_SOURCE" ]; then
+  exit 0
+fi
+
+# Opt-out: GIT_AI_COMMIT_MSG=0 disables for this invocation. Default is on.
+if [ "${GIT_AI_COMMIT_MSG:-1}" = "0" ]; then
+  exit 0
+fi
+
+# Require claude on PATH.
+if ! command -v claude >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Nothing staged -> nothing to summarize (git will abort anyway).
+if git diff --cached --quiet; then
+  exit 0
+fi
+
+# Skip oversized diffs (haiku context + latency concerns).
+DIFF_BYTES=$(git diff --cached | wc -c | tr -d ' ')
+if [ "$DIFF_BYTES" -gt 200000 ]; then
+  echo "prepare-commit-msg: staged diff is ${DIFF_BYTES} bytes, skipping AI draft" >&2
+  exit 0
+fi
+
+# Recent subjects as style + language reference (fails gracefully on first commit).
+RECENT=$(git log -n 10 --pretty=format:'%s' 2>/dev/null || true)
+
+PROMPT="Generate a single-line git commit subject for the staged diff piped on stdin.
+
+Rules:
+- One line only. No body. No trailing newline.
+- Match the style and language of the recent commit subjects shown below
+  (English-only repo -> English; Japanese-mixed repo -> use that style).
+- 'verb: description' or 'Verb description' - follow the existing pattern.
+- No surrounding quotes, no markdown, no preamble. Output ONLY the subject.
+
+--- recent commit subjects (style + language reference) ---
+$RECENT
+--- end ---"
+
+# Prefer GNU timeout if available; fall back to no timeout.
+TIMEOUT_BIN=""
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="gtimeout"
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="timeout"
+fi
+
+set +e
+if [ -n "$TIMEOUT_BIN" ]; then
+  GENERATED=$(git diff --cached | "$TIMEOUT_BIN" 25s claude --model haiku -p "$PROMPT" 2>/dev/null)
+  RC=$?
+else
+  GENERATED=$(git diff --cached | claude --model haiku -p "$PROMPT" 2>/dev/null)
+  RC=$?
+fi
+set -e
+
+if [ "$RC" -ne 0 ] || [ -z "$GENERATED" ]; then
+  echo "prepare-commit-msg: claude draft skipped (rc=$RC)" >&2
+  exit 0
+fi
+
+# First non-empty line only (defensive — model may emit extras).
+SUBJECT=$(printf '%s\n' "$GENERATED" | awk 'NF{print; exit}')
+if [ -z "$SUBJECT" ]; then
+  exit 0
+fi
+
+# Atomic write: SUBJECT + blank line, then original buffer (template comments).
+TMP=$(mktemp "${MSG_FILE}.aimsg.XXXXXX")
+{
+  printf '%s\n\n' "$SUBJECT"
+  cat "$MSG_FILE"
+} >"$TMP"
+mv "$TMP" "$MSG_FILE"
+
+exit 0


### PR DESCRIPTION
## Purpose

Speed up interactive commits by prefilling the editor buffer with an AI-drafted subject line. Reduces the friction of "stop, think of a good subject, type it" without changing the manual workflow — the user still sees and edits the line in the editor before saving. Complements the existing `git aic` (`bin/git-ai-commit.sh`, codex-based) which is explicit / interactive / one-shot; this hook is passive / transparent / always-on (opt-out).

## Scope

In:

- New global git hook at `xdg-config/git/hooks/prepare-commit-msg` (bash, 92 lines). Runs only on interactive `git commit` (no `-m`, no merge/squash/amend/template). Always exits 0 — never blocks commit.
- `xdg-config/git/config`: `core.hooksPath = ~/.config/git/hooks` added declaratively to the `[core]` section. No `git config --global` shell logic.
- `scripts/verify_deploy.sh`: asserts the new hook is present and executable.
- `.github/workflows/ci.yml`: extended shellcheck to cover `xdg-config/git/hooks/` (extension-less files not matched by `**/*.sh`).
- `README.md`: new "AI-Assisted Commit Messages" subsection describing behavior, opt-out, and the relationship to `git aic`.

Out:

- Commit message body generation (subject only).
- Replacing `bin/git-ai-commit.sh` (`git aic`) — kept as the explicit alternative.
- Comparison against `codex exec` / gemini CLI for latency — deferred follow-up (see Notes).

## Sources

- `git-help(5)` for the `prepare-commit-msg` hook contract (args: msg-file, source, sha).
- `git-config(1)` for `core.hooksPath`.
- `claude --help` output on this host: confirms `-p / --print` and `--model <alias>` flags; `haiku` alias works.

## Verification

- [x] `bash -n xdg-config/git/hooks/prepare-commit-msg` clean.
- [x] `shellcheck --exclude=SC1090,SC1091,SC2039,SC3010,SC3060,SC3028 xdg-config/git/hooks/prepare-commit-msg` clean.
- [x] `claude --model haiku -p 'reply with exactly: ok'` → `ok` (alias confirmed).
- [x] Wall-clock latency: 9.6s on a short prompt, 9.75s on a ~500 byte real diff. Hook timeout set to 25s to absorb the startup overhead with margin.
- [x] After `./scripts/deploy.sh`: `~/.config/git/hooks/prepare-commit-msg` resolves through the existing `~/.config/git → xdg-config/git` symlink, is executable, and `git config --global --get core.hooksPath` returns `~/.config/git/hooks` from outside the dotfiles repo.
- [x] `./scripts/verify_deploy.sh` passes including the new hook check.
- [x] Happy path in `/tmp/hook-test` (fresh repo, `EDITOR='cat >&2; false' git commit`): hook produced subject `Add hello.py with greet function` and prepended it to the buffer (commit landed with that exact subject).
- [x] `git commit -m 'manual subject' --allow-empty` → bypasses hook in 0.021s (no claude call, no API cost when AI agents commit with `-m`).
- [x] `GIT_AI_COMMIT_MSG=0 EDITOR=true git commit --allow-empty` → opt-out works, 0.016s.
- [x] `git commit --amend --no-edit` → `$2 == commit` skip, 0.007s.
- [x] Staging a 414 KB file (`base64` of 300 KB random) → stderr emits `prepare-commit-msg: staged diff is 420502 bytes, skipping AI draft`, hook exits in 0.031s.
- [ ] One real-world commit on a non-dotfiles repo after merge to confirm no surprises.

Skip conditions not explicitly e2e-tested but covered by the same `[ -n "$MSG_SOURCE" ]` early-exit path that `-m` and `--amend` already exercise: `merge`, `squash`, `template`. The `command -v claude` and silent `claude` failure paths are bracketed by `set +e` / `set -e` and were not toggled in e2e — verification deferred to real-world use.

## Notes

- Pre-flight measurement showed `claude --model haiku -p` has a ~10s startup overhead that dominates total latency even for trivial prompts. `--bare` mode would skip CLAUDE.md / hooks / plugins and could lower this materially, but it requires `ANTHROPIC_API_KEY` and is incompatible with OAuth login. Follow-up (out of scope here): benchmark `codex exec` and gemini CLI on the same prompt to decide whether to swap backends.
- A pre-existing `~/.gitconfig` on a future host would shadow `~/.config/git/config` and silently disable the hook. Not mitigated in this PR; if it bites, add a `git config --global --get core.hooksPath` assertion to `verify_deploy.sh`.
