### PR TITLE
prepare-commit-msg: use Anthropic API for AI commit message draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ dotfiles/
 
 ### AI-Assisted Commit Messages
 
-`xdg-config/git/hooks/prepare-commit-msg` drafts a commit message via the Anthropic Messages API (`claude-haiku-4-5`) when `git commit` opens the editor. Set `GIT_AI_COMMIT_ANTHROPIC_API_KEY` to an Anthropic API key to enable it — without the env var the hook is a no-op and `git commit` opens the editor with the usual empty template. Per-repo opt-in: run `install-aimsg-hook.sh` inside the target repo. Disable per-invocation with `GIT_AI_COMMIT_MSG=0 git commit`, or remove `"$(git rev-parse --git-path hooks)/prepare-commit-msg"` to uninstall. The scoped variable name (not the canonical `ANTHROPIC_API_KEY`) avoids overriding the `claude` CLI's Claude Max OAuth for unrelated invocations. Requires `curl` and `jq` on PATH. See the script header for skip conditions and design notes.
+`xdg-config/git/hooks/prepare-commit-msg` drafts a commit message via the Anthropic Messages API (`claude-haiku-4-5`) when `git commit` opens the editor. Set `GIT_AI_COMMIT_ANTHROPIC_API_KEY` to enable; the hook is a no-op without it. Per-repo opt-in via `install-aimsg-hook.sh`. Disable per-invocation with `GIT_AI_COMMIT_MSG=0 git commit`. Requires `curl` and `jq`.
 
 ### Machine-Local Overrides
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ dotfiles/
 
 `xdg-config/git/hooks/prepare-commit-msg` drafts a commit message via `claude --model haiku` when `git commit` opens the editor. Per-repo opt-in: run `install-aimsg-hook.sh` inside the target repo. Disable per-invocation with `GIT_AI_COMMIT_MSG=0 git commit`, or remove `"$(git rev-parse --git-path hooks)/prepare-commit-msg"` to uninstall. See the script header for skip conditions and design notes.
 
+For faster drafts (~2-4s vs ~10s on the OAuth-routed `claude` path), set `GIT_AI_COMMIT_ANTHROPIC_API_KEY` to an Anthropic API key — the hook then calls `api.anthropic.com` directly via `curl` using `claude-haiku-4-5`. The scoped variable name (not the canonical `ANTHROPIC_API_KEY`) avoids overriding the `claude` CLI's Claude Max OAuth for unrelated invocations. On any API failure (network, auth, timeout), the hook prints a one-line stderr warning and falls back to the `claude -p` path automatically. Requires `curl` and `jq` on PATH.
+
 ### Machine-Local Overrides
 
 To define settings that apply only to a specific machine (not tracked by this repository),

--- a/README.md
+++ b/README.md
@@ -99,9 +99,7 @@ dotfiles/
 
 ### AI-Assisted Commit Messages
 
-`xdg-config/git/hooks/prepare-commit-msg` drafts a commit message via `claude --model haiku` when `git commit` opens the editor. Per-repo opt-in: run `install-aimsg-hook.sh` inside the target repo. Disable per-invocation with `GIT_AI_COMMIT_MSG=0 git commit`, or remove `"$(git rev-parse --git-path hooks)/prepare-commit-msg"` to uninstall. See the script header for skip conditions and design notes.
-
-For faster drafts (~2-4s vs ~10s on the OAuth-routed `claude` path), set `GIT_AI_COMMIT_ANTHROPIC_API_KEY` to an Anthropic API key — the hook then calls `api.anthropic.com` directly via `curl` using `claude-haiku-4-5`. The scoped variable name (not the canonical `ANTHROPIC_API_KEY`) avoids overriding the `claude` CLI's Claude Max OAuth for unrelated invocations. On any API failure (network, auth, timeout), the hook prints a one-line stderr warning and falls back to the `claude -p` path automatically. Requires `curl` and `jq` on PATH.
+`xdg-config/git/hooks/prepare-commit-msg` drafts a commit message via the Anthropic Messages API (`claude-haiku-4-5`) when `git commit` opens the editor. Set `GIT_AI_COMMIT_ANTHROPIC_API_KEY` to an Anthropic API key to enable it — without the env var the hook is a no-op and `git commit` opens the editor with the usual empty template. Per-repo opt-in: run `install-aimsg-hook.sh` inside the target repo. Disable per-invocation with `GIT_AI_COMMIT_MSG=0 git commit`, or remove `"$(git rev-parse --git-path hooks)/prepare-commit-msg"` to uninstall. The scoped variable name (not the canonical `ANTHROPIC_API_KEY`) avoids overriding the `claude` CLI's Claude Max OAuth for unrelated invocations. Requires `curl` and `jq` on PATH. See the script header for skip conditions and design notes.
 
 ### Machine-Local Overrides
 

--- a/xdg-config/git/hooks/prepare-commit-msg
+++ b/xdg-config/git/hooks/prepare-commit-msg
@@ -56,62 +56,81 @@ MSG=""
 
 # Fast path: call Anthropic Messages API directly via curl. Saves the
 # claude CLI startup (~1s) and OAuth subscription-tier routing overhead
-# (~3s on this user's host vs ~600ms public Haiku TTFT). Falls back to
-# claude -p on any failure so the commit is never blocked.
+# (~3s on this user's host vs ~600ms public Haiku TTFT — see #178 for
+# the hyperfine breakdown). Falls back to claude -p on any failure so
+# the commit is never blocked.
 if [ -n "${GIT_AI_COMMIT_ANTHROPIC_API_KEY:-}" ]; then
-  echo "prepare-commit-msg: drafting commit message via Anthropic API (claude-haiku-4-5)..." >&2
+  if ! command -v jq >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
+    # Honour the "never block commit" contract even when the host is missing
+    # the API-path tools: skip silently to the claude fallback instead of
+    # letting set -e kill the script at the first jq/curl invocation.
+    echo "prepare-commit-msg: API key set but jq or curl not on PATH, falling back to claude -p" >&2
+  else
+    echo "prepare-commit-msg: drafting commit message via Anthropic API (claude-haiku-4-5)..." >&2
 
-  USER_CONTENT="$PROMPT
+    USER_CONTENT="$PROMPT
 
 --- staged diff ---
 $DIFF
 --- end diff ---"
 
-  # jq --arg handles quotes / backslashes / newlines in the diff safely.
-  REQUEST=$(jq -n \
-    --arg model "claude-haiku-4-5" \
-    --argjson max_tokens 1024 \
-    --arg system "$CLAUDE_SYSTEM_PROMPT" \
-    --arg user "$USER_CONTENT" \
-    '{model:$model, max_tokens:$max_tokens, system:$system, messages:[{role:"user", content:$user}]}')
+    # jq --arg / --argjson keep quotes, backslashes, newlines, and control
+    # chars from the diff out of trouble — no manual JSON escaping needed.
+    REQUEST=$(jq -n \
+      --arg model "claude-haiku-4-5" \
+      --argjson max_tokens 1024 \
+      --arg system "$CLAUDE_SYSTEM_PROMPT" \
+      --arg user "$USER_CONTENT" \
+      '{model:$model, max_tokens:$max_tokens, system:$system, messages:[{role:"user", content:$user}]}')
 
-  # --fail-with-body: non-zero rc on HTTP >=400 AND still print body so we can
-  # log Anthropic's error envelope in the fallback warning.
-  # --max-time 8: 5s target is for success case; 8s tolerates slow networks
-  # before triggering fallback (a too-tight curl timeout that fell back to
-  # claude would push the worst case past the unoptimized baseline).
-  # --data-binary @-: pipe body via stdin to avoid ARG_MAX on large diffs.
-  #
-  # `|| CURL_RC=$?` is required because bash DOES fire set -e on `VAR=$(...)`
-  # when the substitution exits non-zero — the POSIX carve-out is shell-
-  # dependent and doesn't apply here. The `||` provides a successful outer
-  # exit so set -e stays quiet while we capture the rc for branching.
-  RESP=""
-  CURL_RC=0
-  RESP=$(printf '%s' "$REQUEST" | curl --silent --show-error --fail-with-body \
-    --max-time 8 --connect-timeout 3 \
-    -X POST https://api.anthropic.com/v1/messages \
-    -H "x-api-key: $GIT_AI_COMMIT_ANTHROPIC_API_KEY" \
-    -H "anthropic-version: 2023-06-01" \
-    -H "content-type: application/json" \
-    --data-binary @- 2>&1) || CURL_RC=$?
+    # --fail-with-body: non-zero rc on HTTP >=400 AND still print body, so the
+    # fallback warning can quote Anthropic's error envelope verbatim.
+    # --max-time 8 / --connect-timeout 3: budget chosen to comfortably contain
+    # success (Haiku TTFT ~600ms-1.2s plus completion) while still failing
+    # fast enough that the fallback-to-claude worst case stays bounded.
+    # --data-binary @-: stream the body via stdin to dodge ARG_MAX on large diffs.
+    # stderr is intentionally NOT merged into stdout — curl's own warnings
+    # (TLS retries etc.) would otherwise pollute $RESP and break jq parsing
+    # on responses that were otherwise successful.
+    #
+    # `|| CURL_RC=$?` keeps set -e quiet on curl failure while still capturing
+    # the rc for branching. Verified on macOS bash 3.2.57 and 5.3.9: plain
+    # `VAR=$(failing_cmd)` triggers set -e (no implicit POSIX carve-out for
+    # the assignment-with-substitution form). Reproduce with:
+    #   bash -c 'set -e; X=$(false); echo got-here'   # exits 1, no output.
+    RESP=""
+    CURL_RC=0
+    RESP=$(printf '%s' "$REQUEST" | curl --silent --show-error --fail-with-body \
+      --max-time 8 --connect-timeout 3 \
+      -X POST https://api.anthropic.com/v1/messages \
+      -H "x-api-key: $GIT_AI_COMMIT_ANTHROPIC_API_KEY" \
+      -H "anthropic-version: 2023-06-01" \
+      -H "content-type: application/json" \
+      --data-binary @-) || CURL_RC=$?
 
-  REASON=""
-  if [ "$CURL_RC" -ne 0 ]; then
-    REASON="curl rc=$CURL_RC: $(printf '%s' "$RESP" | head -c 200 | tr '\n' ' ')"
-  else
-    # Anthropic error envelope: {"type":"error","error":{"type":"...","message":"..."}}
-    TYPE=$(printf '%s' "$RESP" | jq -r '.type // empty' 2>/dev/null || true)
-    if [ "$TYPE" = "error" ]; then
-      REASON="API error: $(printf '%s' "$RESP" | jq -r '.error.message // "unknown"' 2>/dev/null || true)"
+    # Always seed REASON so the fallback warning never reads "API call failed ()".
+    REASON="unknown failure"
+    if [ "$CURL_RC" -ne 0 ]; then
+      REASON="curl rc=$CURL_RC: $(printf '%s' "$RESP" | head -c 500 | tr '\n' ' ')"
     else
-      MSG=$(printf '%s' "$RESP" | jq -r '.content[0].text // empty' 2>/dev/null || true)
-      if [ -z "$MSG" ]; then REASON="empty content in response"; fi
+      # Success envelope: {"type":"message", "content":[{"type":"text","text":"..."}], ...}
+      # Error envelope:   {"type":"error",   "error":{"type":"...","message":"..."}, ...}
+      # jq stderr is left visible (no 2>/dev/null) so genuine parse bugs surface
+      # in the terminal; `|| true` is set -e safety, not error suppression.
+      TYPE=$(printf '%s' "$RESP" | jq -r '.type // empty') || TYPE=""
+      if [ "$TYPE" = "error" ]; then
+        REASON="API error: $(printf '%s' "$RESP" | jq -r '.error.message // "unknown"' || echo unknown)"
+      else
+        MSG=$(printf '%s' "$RESP" | jq -r '.content[0].text // empty') || MSG=""
+        if [ -z "$MSG" ]; then
+          REASON="unexpected response shape: $(printf '%s' "$RESP" | head -c 500 | tr '\n' ' ')"
+        fi
+      fi
     fi
-  fi
 
-  if [ -z "$MSG" ]; then
-    echo "prepare-commit-msg: API call failed ($REASON), falling back to claude -p" >&2
+    if [ -z "$MSG" ]; then
+      echo "prepare-commit-msg: API call failed ($REASON), falling back to claude -p" >&2
+    fi
   fi
 fi
 
@@ -122,9 +141,9 @@ if [ -z "$MSG" ]; then
 
   echo "prepare-commit-msg: drafting commit message via claude haiku..." >&2
 
-  # `|| RC=$?` keeps set -e quiet on claude failure (timeout, auth, etc.) while
-  # still capturing the rc for the error-message branch below. Bash fires
-  # set -e on `VAR=$(failing_cmd)` despite the often-cited POSIX carve-out.
+  # `|| RC=$?` keeps set -e quiet on claude failure (timeout, auth, etc.)
+  # while still capturing the rc for the diagnostic below. See the longer
+  # comment on the API curl call above for the bash set -e verification.
   RC=0
   MSG=$(printf '%s' "$DIFF" | timeout 25s claude \
     --model haiku \

--- a/xdg-config/git/hooks/prepare-commit-msg
+++ b/xdg-config/git/hooks/prepare-commit-msg
@@ -1,32 +1,25 @@
 #!/usr/bin/env bash
-# Drafts an AI commit message (subject + optional body) into the commit
-# buffer for interactive commits by calling the Anthropic Messages API
-# directly via curl. No-op unless GIT_AI_COMMIT_ANTHROPIC_API_KEY is set
-# (and not disabled via GIT_AI_COMMIT_MSG=0) — without the env var
-# git opens the usual empty editor template.
-#
-# Any API-side failure (network, auth, timeout, missing jq/curl, malformed
-# response) propagates under set -eu, so git aborts the commit with bash's
-# error message instead of silently dropping the AI draft.
-#
-# Per-repo install (no core.hooksPath) so this hook never shadows another
-# repo's .git/hooks/. See README.md "AI-Assisted Commit Messages" and
-# bin/install-aimsg-hook.sh.
+# AI-draft a commit message via the Anthropic Messages API. No-op unless
+# GIT_AI_COMMIT_ANTHROPIC_API_KEY is set; any API failure propagates
+# under set -eu so git aborts the commit. See README.md.
 
 set -eu
 
 MSG_FILE="$1"
 MSG_SOURCE="${2:-}"
 
-# $2 is empty only for interactive `git commit` (no -m/--amend/merge/squash/template).
+# Skip non-interactive commits (-m, --amend, merge, squash, template).
 if [ -n "$MSG_SOURCE" ]; then exit 0; fi
 if [ "${GIT_AI_COMMIT_MSG:-1}" = "0" ]; then exit 0; fi
-if [ -z "${GIT_AI_COMMIT_ANTHROPIC_API_KEY:-}" ]; then exit 0; fi
+if [ -z "${GIT_AI_COMMIT_ANTHROPIC_API_KEY:-}" ]; then
+  echo "prepare-commit-msg: GIT_AI_COMMIT_ANTHROPIC_API_KEY not set, skipping AI draft" >&2
+  exit 0
+fi
 
 DIFF=$(git diff --cached)
 if [ -z "$DIFF" ]; then exit 0; fi
 
-# || true: git log fails on the very first commit; empty RECENT is fine.
+# git log fails on the very first commit; empty RECENT is fine.
 RECENT=$(git log -n 10 --pretty=format:'%s' 2>/dev/null || true)
 
 PROMPT="Draft a git commit message for the staged diff.
@@ -56,8 +49,7 @@ $DIFF
 MODEL="claude-haiku-4-5"
 echo "prepare-commit-msg: drafting commit message via Anthropic API ($MODEL)..." >&2
 
-# jq --arg / --argjson keep quotes, backslashes, newlines, and control
-# chars from the diff out of trouble — no manual JSON escaping needed.
+# jq --arg / --argjson avoids manual JSON escaping for control chars in the diff.
 REQUEST=$(jq -n \
   --arg model "$MODEL" \
   --argjson max_tokens 1024 \
@@ -65,10 +57,8 @@ REQUEST=$(jq -n \
   --arg user "$USER_CONTENT" \
   '{model:$model, max_tokens:$max_tokens, system:$system, messages:[{role:"user", content:$user}]}')
 
-# --fail-with-body: non-zero rc on HTTP >=400 AND still print body, so the
-# stderr line from curl --show-error includes Anthropic's error envelope.
-# --max-time 8 / --connect-timeout 3: bound the worst case for interactive use.
-# --data-binary @-: stream the body via stdin to dodge ARG_MAX on large diffs.
+# --fail-with-body: non-zero rc on HTTP >=400, body still printed for stderr.
+# --data-binary @-: stream stdin to dodge ARG_MAX on large diffs.
 RESP=$(printf '%s' "$REQUEST" | curl --silent --show-error --fail-with-body \
   --max-time 8 --connect-timeout 3 \
   -X POST https://api.anthropic.com/v1/messages \
@@ -77,12 +67,11 @@ RESP=$(printf '%s' "$REQUEST" | curl --silent --show-error --fail-with-body \
   -H "content-type: application/json" \
   --data-binary @-)
 
-# `jq -e` makes null / missing field exit non-zero so set -eu kills the
-# script (and git aborts the commit) instead of writing "null" to the buffer.
+# jq -e: null/missing field exits non-zero so set -eu kills the hook
+# instead of writing "null" to the buffer.
 MSG=$(printf '%s' "$RESP" | jq -er '.content[0].text')
 
-# Strip a single layer of wrapping quotes/backticks from the first line —
-# Haiku occasionally wraps its output despite the system prompt.
+# Strip a single layer of wrapping quotes/backticks — Haiku occasionally wraps output.
 FIRST=$(printf '%s\n' "$MSG" | head -n 1)
 case "$FIRST" in
   \"*\"|\'*\'|\`*\`)
@@ -96,8 +85,6 @@ case "$FIRST" in
     ;;
 esac
 
-# Atomic write via temp + rename. Failures here propagate under set -eu
-# and git aborts the commit.
 TMP=$(mktemp "${MSG_FILE}.aimsg.XXXXXX")
 {
   printf '%s\n\n' "$MSG"

--- a/xdg-config/git/hooks/prepare-commit-msg
+++ b/xdg-config/git/hooks/prepare-commit-msg
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # Drafts an AI commit message (subject + optional body) into the commit
-# buffer for interactive commits. claude failures skip the AI draft
-# silently; any other unexpected failure (mktemp / cat / mv) propagates
-# under set -eu and git aborts the commit with bash's error message —
-# the user sees what went wrong instead of a silent half-fix.
+# buffer for interactive commits by calling the Anthropic Messages API
+# directly via curl. No-op unless GIT_AI_COMMIT_ANTHROPIC_API_KEY is set —
+# without the env var git opens the usual empty editor template.
+#
+# Any API-side failure (network, auth, timeout, missing jq/curl, malformed
+# response) propagates under set -eu, so git aborts the commit with bash's
+# error message instead of silently dropping the AI draft.
 #
 # Per-repo install (no core.hooksPath) so this hook never shadows another
 # repo's .git/hooks/. See README.md "AI-Assisted Commit Messages" and
@@ -16,17 +19,9 @@ MSG_SOURCE="${2:-}"
 
 # $2 is empty only for interactive `git commit` (no -m/--amend/merge/squash/template).
 if [ -n "$MSG_SOURCE" ]; then exit 0; fi
-
 if [ "${GIT_AI_COMMIT_MSG:-1}" = "0" ]; then exit 0; fi
+if [ -z "${GIT_AI_COMMIT_ANTHROPIC_API_KEY:-}" ]; then exit 0; fi
 
-# Detect which backends are available; exit only if neither path can run.
-# Fast path: GIT_AI_COMMIT_ANTHROPIC_API_KEY -> direct Anthropic API via curl.
-# Fallback: `claude` CLI -p (also used when the API call fails mid-flow).
-if command -v claude >/dev/null 2>&1; then HAS_CLAUDE=1; else HAS_CLAUDE=0; fi
-if [ "$HAS_CLAUDE" = "0" ] && [ -z "${GIT_AI_COMMIT_ANTHROPIC_API_KEY:-}" ]; then exit 0; fi
-
-# Snapshot the staged diff once so the empty check and both backends
-# see the same content (avoids racing with concurrent git add / reset).
 DIFF=$(git diff --cached)
 if [ -z "$DIFF" ]; then exit 0; fi
 
@@ -49,116 +44,43 @@ No markdown, no quotes, no preamble. Output ONLY the commit message.
 $RECENT
 --- end ---"
 
-# System prompt shared by both backends so output shape matches.
-CLAUDE_SYSTEM_PROMPT="You write git commit messages. Output the message only — no preamble, no markdown, no quotes, no trailers."
+SYSTEM_PROMPT="You write git commit messages. Output the message only — no preamble, no markdown, no quotes, no trailers."
 
-MSG=""
-
-# Fast path: call Anthropic Messages API directly via curl. Saves the
-# claude CLI startup (~1s) and OAuth subscription-tier routing overhead
-# (~3s on this user's host vs ~600ms public Haiku TTFT — see #178 for
-# the hyperfine breakdown). Falls back to claude -p on any failure so
-# the commit is never blocked.
-if [ -n "${GIT_AI_COMMIT_ANTHROPIC_API_KEY:-}" ]; then
-  if ! command -v jq >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
-    # Honour the "never block commit" contract even when the host is missing
-    # the API-path tools: skip silently to the claude fallback instead of
-    # letting set -e kill the script at the first jq/curl invocation.
-    echo "prepare-commit-msg: API key set but jq or curl not on PATH, falling back to claude -p" >&2
-  else
-    echo "prepare-commit-msg: drafting commit message via Anthropic API (claude-haiku-4-5)..." >&2
-
-    USER_CONTENT="$PROMPT
+USER_CONTENT="$PROMPT
 
 --- staged diff ---
 $DIFF
 --- end diff ---"
 
-    # jq --arg / --argjson keep quotes, backslashes, newlines, and control
-    # chars from the diff out of trouble — no manual JSON escaping needed.
-    REQUEST=$(jq -n \
-      --arg model "claude-haiku-4-5" \
-      --argjson max_tokens 1024 \
-      --arg system "$CLAUDE_SYSTEM_PROMPT" \
-      --arg user "$USER_CONTENT" \
-      '{model:$model, max_tokens:$max_tokens, system:$system, messages:[{role:"user", content:$user}]}')
+echo "prepare-commit-msg: drafting commit message via Anthropic API (claude-haiku-4-5)..." >&2
 
-    # --fail-with-body: non-zero rc on HTTP >=400 AND still print body, so the
-    # fallback warning can quote Anthropic's error envelope verbatim.
-    # --max-time 8 / --connect-timeout 3: budget chosen to comfortably contain
-    # success (Haiku TTFT ~600ms-1.2s plus completion) while still failing
-    # fast enough that the fallback-to-claude worst case stays bounded.
-    # --data-binary @-: stream the body via stdin to dodge ARG_MAX on large diffs.
-    # stderr is intentionally NOT merged into stdout — curl's own warnings
-    # (TLS retries etc.) would otherwise pollute $RESP and break jq parsing
-    # on responses that were otherwise successful.
-    #
-    # `|| CURL_RC=$?` keeps set -e quiet on curl failure while still capturing
-    # the rc for branching. Verified on macOS bash 3.2.57 and 5.3.9: plain
-    # `VAR=$(failing_cmd)` triggers set -e (no implicit POSIX carve-out for
-    # the assignment-with-substitution form). Reproduce with:
-    #   bash -c 'set -e; X=$(false); echo got-here'   # exits 1, no output.
-    RESP=""
-    CURL_RC=0
-    RESP=$(printf '%s' "$REQUEST" | curl --silent --show-error --fail-with-body \
-      --max-time 8 --connect-timeout 3 \
-      -X POST https://api.anthropic.com/v1/messages \
-      -H "x-api-key: $GIT_AI_COMMIT_ANTHROPIC_API_KEY" \
-      -H "anthropic-version: 2023-06-01" \
-      -H "content-type: application/json" \
-      --data-binary @-) || CURL_RC=$?
+# jq --arg / --argjson keep quotes, backslashes, newlines, and control
+# chars from the diff out of trouble — no manual JSON escaping needed.
+REQUEST=$(jq -n \
+  --arg model "claude-haiku-4-5" \
+  --argjson max_tokens 1024 \
+  --arg system "$SYSTEM_PROMPT" \
+  --arg user "$USER_CONTENT" \
+  '{model:$model, max_tokens:$max_tokens, system:$system, messages:[{role:"user", content:$user}]}')
 
-    # Always seed REASON so the fallback warning never reads "API call failed ()".
-    REASON="unknown failure"
-    if [ "$CURL_RC" -ne 0 ]; then
-      REASON="curl rc=$CURL_RC: $(printf '%s' "$RESP" | head -c 500 | tr '\n' ' ')"
-    else
-      # Success envelope: {"type":"message", "content":[{"type":"text","text":"..."}], ...}
-      # Error envelope:   {"type":"error",   "error":{"type":"...","message":"..."}, ...}
-      # jq stderr is left visible (no 2>/dev/null) so genuine parse bugs surface
-      # in the terminal; `|| true` is set -e safety, not error suppression.
-      TYPE=$(printf '%s' "$RESP" | jq -r '.type // empty') || TYPE=""
-      if [ "$TYPE" = "error" ]; then
-        REASON="API error: $(printf '%s' "$RESP" | jq -r '.error.message // "unknown"' || echo unknown)"
-      else
-        MSG=$(printf '%s' "$RESP" | jq -r '.content[0].text // empty') || MSG=""
-        if [ -z "$MSG" ]; then
-          REASON="unexpected response shape: $(printf '%s' "$RESP" | head -c 500 | tr '\n' ' ')"
-        fi
-      fi
-    fi
+# --fail-with-body: non-zero rc on HTTP >=400 AND still print body, so the
+# stderr line from curl --show-error includes Anthropic's error envelope.
+# --max-time 8 / --connect-timeout 3: bound the worst case for interactive use.
+# --data-binary @-: stream the body via stdin to dodge ARG_MAX on large diffs.
+RESP=$(printf '%s' "$REQUEST" | curl --silent --show-error --fail-with-body \
+  --max-time 8 --connect-timeout 3 \
+  -X POST https://api.anthropic.com/v1/messages \
+  -H "x-api-key: $GIT_AI_COMMIT_ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  --data-binary @-)
 
-    if [ -z "$MSG" ]; then
-      echo "prepare-commit-msg: API call failed ($REASON), falling back to claude -p" >&2
-    fi
-  fi
-fi
-
-# Fallback path: invoke `claude` CLI. Same flags as before — see #177 for
-# why each one matters (MCP / plugin / CLAUDE.md auto-discovery suppression).
-if [ -z "$MSG" ]; then
-  if [ "$HAS_CLAUDE" = "0" ]; then exit 0; fi
-
-  echo "prepare-commit-msg: drafting commit message via claude haiku..." >&2
-
-  # `|| RC=$?` keeps set -e quiet on claude failure (timeout, auth, etc.)
-  # while still capturing the rc for the diagnostic below. See the longer
-  # comment on the API curl call above for the bash set -e verification.
-  RC=0
-  MSG=$(printf '%s' "$DIFF" | timeout 25s claude \
-    --model haiku \
-    --no-session-persistence \
-    --strict-mcp-config --mcp-config='{"mcpServers":{}}' \
-    --system-prompt "$CLAUDE_SYSTEM_PROMPT" \
-    -p "$PROMPT") || RC=$?
-  if [ "$RC" -ne 0 ] || [ -z "$MSG" ]; then
-    echo "prepare-commit-msg: claude failed rc=$RC, skipping AI draft" >&2
-    exit 0
-  fi
-fi
+# `jq -e` makes null / missing field exit non-zero so set -eu kills the
+# script (and git aborts the commit) instead of writing "null" to the buffer.
+MSG=$(printf '%s' "$RESP" | jq -er '.content[0].text')
 
 # Strip a single layer of wrapping quotes/backticks from the first line —
-# common claude output shapes that would otherwise land literally in the buffer.
+# Haiku occasionally wraps its output despite the system prompt.
 FIRST=$(printf '%s\n' "$MSG" | head -n 1)
 case "$FIRST" in
   \"*\"|\'*\'|\`*\`)
@@ -173,7 +95,7 @@ case "$FIRST" in
 esac
 
 # Atomic write via temp + rename. Failures here propagate under set -eu
-# and git aborts the commit with bash's error — no silent half-fix.
+# and git aborts the commit.
 TMP=$(mktemp "${MSG_FILE}.aimsg.XXXXXX")
 {
   printf '%s\n\n' "$MSG"

--- a/xdg-config/git/hooks/prepare-commit-msg
+++ b/xdg-config/git/hooks/prepare-commit-msg
@@ -19,9 +19,13 @@ if [ -n "$MSG_SOURCE" ]; then exit 0; fi
 
 if [ "${GIT_AI_COMMIT_MSG:-1}" = "0" ]; then exit 0; fi
 
-if ! command -v claude >/dev/null 2>&1; then exit 0; fi
+# Detect which backends are available; exit only if neither path can run.
+# Fast path: GIT_AI_COMMIT_ANTHROPIC_API_KEY -> direct Anthropic API via curl.
+# Fallback: `claude` CLI -p (also used when the API call fails mid-flow).
+if command -v claude >/dev/null 2>&1; then HAS_CLAUDE=1; else HAS_CLAUDE=0; fi
+if [ "$HAS_CLAUDE" = "0" ] && [ -z "${GIT_AI_COMMIT_ANTHROPIC_API_KEY:-}" ]; then exit 0; fi
 
-# Snapshot the staged diff once so the empty check and the claude call
+# Snapshot the staged diff once so the empty check and both backends
 # see the same content (avoids racing with concurrent git add / reset).
 DIFF=$(git diff --cached)
 if [ -z "$DIFF" ]; then exit 0; fi
@@ -29,7 +33,7 @@ if [ -z "$DIFF" ]; then exit 0; fi
 # || true: git log fails on the very first commit; empty RECENT is fine.
 RECENT=$(git log -n 10 --pretty=format:'%s' 2>/dev/null || true)
 
-PROMPT="Draft a git commit message for the staged diff piped on stdin.
+PROMPT="Draft a git commit message for the staged diff.
 
 Format:
 - First line: short subject (~50 chars, imperative mood).
@@ -45,27 +49,93 @@ No markdown, no quotes, no preamble. Output ONLY the commit message.
 $RECENT
 --- end ---"
 
-# Startup-overhead flags: --no-session-persistence skips session disk writes,
-# --strict-mcp-config + --mcp-config={empty} prevents loading the user's MCP
-# servers (the dominant startup cost), --system-prompt replaces the default
-# system prompt so claude does NOT auto-discover CLAUDE.md.
-# Requires `timeout` on PATH (GNU coreutils).
+# System prompt shared by both backends so output shape matches.
 CLAUDE_SYSTEM_PROMPT="You write git commit messages. Output the message only — no preamble, no markdown, no quotes, no trailers."
 
-echo "prepare-commit-msg: drafting commit message via claude haiku..." >&2
+MSG=""
 
-# VAR=$(...) assignment swallows the substitution's non-zero exit under
-# set -e (POSIX), so $? on the next line captures the pipe RC.
-MSG=$(printf '%s' "$DIFF" | timeout 25s claude \
-  --model haiku \
-  --no-session-persistence \
-  --strict-mcp-config --mcp-config='{"mcpServers":{}}' \
-  --system-prompt "$CLAUDE_SYSTEM_PROMPT" \
-  -p "$PROMPT")
-RC=$?
-if [ "$RC" -ne 0 ] || [ -z "$MSG" ]; then
-  echo "prepare-commit-msg: claude failed rc=$RC, skipping AI draft" >&2
-  exit 0
+# Fast path: call Anthropic Messages API directly via curl. Saves the
+# claude CLI startup (~1s) and OAuth subscription-tier routing overhead
+# (~3s on this user's host vs ~600ms public Haiku TTFT). Falls back to
+# claude -p on any failure so the commit is never blocked.
+if [ -n "${GIT_AI_COMMIT_ANTHROPIC_API_KEY:-}" ]; then
+  echo "prepare-commit-msg: drafting commit message via Anthropic API (claude-haiku-4-5)..." >&2
+
+  USER_CONTENT="$PROMPT
+
+--- staged diff ---
+$DIFF
+--- end diff ---"
+
+  # jq --arg handles quotes / backslashes / newlines in the diff safely.
+  REQUEST=$(jq -n \
+    --arg model "claude-haiku-4-5" \
+    --argjson max_tokens 1024 \
+    --arg system "$CLAUDE_SYSTEM_PROMPT" \
+    --arg user "$USER_CONTENT" \
+    '{model:$model, max_tokens:$max_tokens, system:$system, messages:[{role:"user", content:$user}]}')
+
+  # --fail-with-body: non-zero rc on HTTP >=400 AND still print body so we can
+  # log Anthropic's error envelope in the fallback warning.
+  # --max-time 8: 5s target is for success case; 8s tolerates slow networks
+  # before triggering fallback (a too-tight curl timeout that fell back to
+  # claude would push the worst case past the unoptimized baseline).
+  # --data-binary @-: pipe body via stdin to avoid ARG_MAX on large diffs.
+  #
+  # `|| CURL_RC=$?` is required because bash DOES fire set -e on `VAR=$(...)`
+  # when the substitution exits non-zero — the POSIX carve-out is shell-
+  # dependent and doesn't apply here. The `||` provides a successful outer
+  # exit so set -e stays quiet while we capture the rc for branching.
+  RESP=""
+  CURL_RC=0
+  RESP=$(printf '%s' "$REQUEST" | curl --silent --show-error --fail-with-body \
+    --max-time 8 --connect-timeout 3 \
+    -X POST https://api.anthropic.com/v1/messages \
+    -H "x-api-key: $GIT_AI_COMMIT_ANTHROPIC_API_KEY" \
+    -H "anthropic-version: 2023-06-01" \
+    -H "content-type: application/json" \
+    --data-binary @- 2>&1) || CURL_RC=$?
+
+  REASON=""
+  if [ "$CURL_RC" -ne 0 ]; then
+    REASON="curl rc=$CURL_RC: $(printf '%s' "$RESP" | head -c 200 | tr '\n' ' ')"
+  else
+    # Anthropic error envelope: {"type":"error","error":{"type":"...","message":"..."}}
+    TYPE=$(printf '%s' "$RESP" | jq -r '.type // empty' 2>/dev/null || true)
+    if [ "$TYPE" = "error" ]; then
+      REASON="API error: $(printf '%s' "$RESP" | jq -r '.error.message // "unknown"' 2>/dev/null || true)"
+    else
+      MSG=$(printf '%s' "$RESP" | jq -r '.content[0].text // empty' 2>/dev/null || true)
+      if [ -z "$MSG" ]; then REASON="empty content in response"; fi
+    fi
+  fi
+
+  if [ -z "$MSG" ]; then
+    echo "prepare-commit-msg: API call failed ($REASON), falling back to claude -p" >&2
+  fi
+fi
+
+# Fallback path: invoke `claude` CLI. Same flags as before — see #177 for
+# why each one matters (MCP / plugin / CLAUDE.md auto-discovery suppression).
+if [ -z "$MSG" ]; then
+  if [ "$HAS_CLAUDE" = "0" ]; then exit 0; fi
+
+  echo "prepare-commit-msg: drafting commit message via claude haiku..." >&2
+
+  # `|| RC=$?` keeps set -e quiet on claude failure (timeout, auth, etc.) while
+  # still capturing the rc for the error-message branch below. Bash fires
+  # set -e on `VAR=$(failing_cmd)` despite the often-cited POSIX carve-out.
+  RC=0
+  MSG=$(printf '%s' "$DIFF" | timeout 25s claude \
+    --model haiku \
+    --no-session-persistence \
+    --strict-mcp-config --mcp-config='{"mcpServers":{}}' \
+    --system-prompt "$CLAUDE_SYSTEM_PROMPT" \
+    -p "$PROMPT") || RC=$?
+  if [ "$RC" -ne 0 ] || [ -z "$MSG" ]; then
+    echo "prepare-commit-msg: claude failed rc=$RC, skipping AI draft" >&2
+    exit 0
+  fi
 fi
 
 # Strip a single layer of wrapping quotes/backticks from the first line —

--- a/xdg-config/git/hooks/prepare-commit-msg
+++ b/xdg-config/git/hooks/prepare-commit-msg
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Drafts an AI commit message (subject + optional body) into the commit
 # buffer for interactive commits by calling the Anthropic Messages API
-# directly via curl. No-op unless GIT_AI_COMMIT_ANTHROPIC_API_KEY is set —
-# without the env var git opens the usual empty editor template.
+# directly via curl. No-op unless GIT_AI_COMMIT_ANTHROPIC_API_KEY is set
+# (and not disabled via GIT_AI_COMMIT_MSG=0) — without the env var
+# git opens the usual empty editor template.
 #
 # Any API-side failure (network, auth, timeout, missing jq/curl, malformed
 # response) propagates under set -eu, so git aborts the commit with bash's
@@ -52,12 +53,13 @@ USER_CONTENT="$PROMPT
 $DIFF
 --- end diff ---"
 
-echo "prepare-commit-msg: drafting commit message via Anthropic API (claude-haiku-4-5)..." >&2
+MODEL="claude-haiku-4-5"
+echo "prepare-commit-msg: drafting commit message via Anthropic API ($MODEL)..." >&2
 
 # jq --arg / --argjson keep quotes, backslashes, newlines, and control
 # chars from the diff out of trouble — no manual JSON escaping needed.
 REQUEST=$(jq -n \
-  --arg model "claude-haiku-4-5" \
+  --arg model "$MODEL" \
   --argjson max_tokens 1024 \
   --arg system "$SYSTEM_PROMPT" \
   --arg user "$USER_CONTENT" \

--- a/xdg-config/git/hooks/prepare-commit-msg
+++ b/xdg-config/git/hooks/prepare-commit-msg
@@ -49,7 +49,6 @@ $DIFF
 MODEL="claude-haiku-4-5"
 echo "prepare-commit-msg: drafting commit message via Anthropic API ($MODEL)..." >&2
 
-# jq --arg / --argjson avoids manual JSON escaping for control chars in the diff.
 REQUEST=$(jq -n \
   --arg model "$MODEL" \
   --argjson max_tokens 1024 \
@@ -57,8 +56,6 @@ REQUEST=$(jq -n \
   --arg user "$USER_CONTENT" \
   '{model:$model, max_tokens:$max_tokens, system:$system, messages:[{role:"user", content:$user}]}')
 
-# --fail-with-body: non-zero rc on HTTP >=400, body still printed for stderr.
-# --data-binary @-: stream stdin to dodge ARG_MAX on large diffs.
 RESP=$(printf '%s' "$REQUEST" | curl --silent --show-error --fail-with-body \
   --max-time 8 --connect-timeout 3 \
   -X POST https://api.anthropic.com/v1/messages \
@@ -67,8 +64,8 @@ RESP=$(printf '%s' "$REQUEST" | curl --silent --show-error --fail-with-body \
   -H "content-type: application/json" \
   --data-binary @-)
 
-# jq -e: null/missing field exits non-zero so set -eu kills the hook
-# instead of writing "null" to the buffer.
+# -er instead of -r: a null/missing field exits non-zero so set -eu kills
+# the hook instead of writing "null" to the commit buffer.
 MSG=$(printf '%s' "$RESP" | jq -er '.content[0].text')
 
 # Strip a single layer of wrapping quotes/backticks — Haiku occasionally wraps output.


### PR DESCRIPTION
## Purpose

Simplify `prepare-commit-msg` by dropping the `claude` CLI path entirely and keeping only the direct Anthropic API draft introduced earlier in this PR. The user's actual usage has settled on always exporting an API key, so the fallback layer (and the `|| RC=$?` / `HAS_CLAUDE` / two-tier warning plumbing it required) no longer earns its keep.

Behavior after this change:

- `GIT_AI_COMMIT_ANTHROPIC_API_KEY` unset → hook emits a one-line stderr warning (`GIT_AI_COMMIT_ANTHROPIC_API_KEY not set, skipping AI draft`) and exits 0; `git commit` opens the usual empty editor template.
- env var set → POST to `api.anthropic.com/v1/messages` with `claude-haiku-4-5`. On success the response text is written into the commit buffer.
- Any API-side failure (curl non-zero rc, `--fail-with-body` 4xx/5xx, malformed response with `jq -e` exit, missing `jq` / `curl` on PATH) propagates under `set -eu` and git aborts the commit with bash's error message — no silent half-fix.

Refs #178 (no auto-close keyword per repo PR guidelines).

## Scope

In:

- `xdg-config/git/hooks/prepare-commit-msg`: remove the `command -v claude` detection, `HAS_CLAUDE` flag, claude CLI invocation, the `command -v jq` / `command -v curl` guard, and the `|| CURL_RC=$?` / `REASON` / API-error / fallback-warning plumbing. The API call now uses straight `RESP=$(printf '%s' "$REQUEST" | curl ...)` and `MSG=$(printf '%s' "$RESP" | jq -er '.content[0].text')`; failures fall through to `set -eu`. Add a one-line stderr warning when the env var is unset so the no-op path is visible. Header and inline comments compressed to one-line WHY notes — kept the `jq -er` rationale (null/missing must kill the hook, not write `"null"` to the buffer), the `git log || true` "first commit is fine" note, and the wrapping-quote strip for Haiku output; dropped everything else that just restates upstream `jq` / `curl` man pages. The model id is now a single `MODEL` local shared between the stderr progress line and the jq request. Result: 154 → 90 lines.
- `README.md` AI-Assisted Commit Messages section: shrunk to a single short paragraph stating the env-var trigger, the no-op default, the install / disable knobs, and the `curl` / `jq` requirement. The previous "two backends, fast path falls back to claude" framing and the scoped-variable rationale are removed.

Out:

- `bin/install-aimsg-hook.sh`: unchanged (never referenced `claude` directly).
- A `GIT_AI_COMMIT_MODEL` override knob: still not added — `claude-haiku-4-5` stays hardcoded for simplicity.
- Backwards-compat shim or deprecation period: this is a personal dotfiles repo and the env-var-absent path now matches what would happen without the hook installed at all (plus the new visibility warning).
- Re-adding any guard for missing `jq` / `curl`: their absence now propagates under `set -eu` and aborts the commit. Acceptable per `AGENTS.md` "Personal Tool Defaults" (jq / curl are part of the bootstrapped host environment).
- Test harness — per `AGENTS.md` "Personal Tool Defaults", short shell utilities don't need bats/shunit2.

## Sources

- [Anthropic Messages API reference](https://platform.claude.com/docs/en/api/messages): request shape (`model`, `max_tokens`, `system`, `messages`), response shape (`.content[0].text`), `anthropic-version: 2023-06-01` header, and the `claude-haiku-4-5` model alias used here.
- [`curl(1)` `--fail-with-body`](https://curl.se/docs/manpage.html#--fail-with-body): non-zero rc on HTTP >=400 while still printing the body, so `curl --show-error` surfaces the Anthropic error envelope on stderr before `set -eu` kills the hook.

## Verification

Mechanical (confirmed locally on the head commit):

- [x] `bash -n xdg-config/git/hooks/prepare-commit-msg` — clean.
- [x] `shellcheck --exclude=SC1090,SC1091,SC2039,SC3010,SC3060,SC3028 xdg-config/git/hooks/prepare-commit-msg` — clean (matches CI exclude list at `.github/workflows/ci.yml:7`).
- [x] CI green on the head commit (shellcheck / python-doctest / bootstrap macos&ubuntu / Socket Security: Project Report / Socket Security: Pull Request Alerts — all pass).

End-to-end (`mktemp -d` repo with the hook symlinked into `.git/hooks/`, `GIT_EDITOR=true` to inspect the commit buffer state without spawning vim):

- [x] env unset — `unset GIT_AI_COMMIT_ANTHROPIC_API_KEY; GIT_EDITOR=true git commit`: stderr showed `prepare-commit-msg: GIT_AI_COMMIT_ANTHROPIC_API_KEY not set, skipping AI draft`, then git aborted with `Aborting commit due to empty commit message`, overall rc=1. Confirms the no-op path leaves the buffer untouched (so the real editor would open the standard empty template) and is visible to the user.
- [x] valid key — user ran a real `git commit` from a shell with a working `GIT_AI_COMMIT_ANTHROPIC_API_KEY` exported and confirmed the AI draft landed in the commit buffer. (The Claude Code session inherits env at launch time and cannot see a key exported into a new shell mid-session, so this case was verified by the user out-of-band rather than from the agent shell.)
- [x] invalid key — `GIT_AI_COMMIT_ANTHROPIC_API_KEY=sk-ant-invalid-test GIT_EDITOR=true git commit`: stderr showed the "drafting commit message via Anthropic API (claude-haiku-4-5)" progress line followed by `curl: (22) The requested URL returned error: 401`, and git aborted (rc=1). Confirms `curl --fail-with-body --show-error` surfaces the failure on stderr and `set -eu` kills the hook before any partial buffer is written.
- [x] kill switch — `GIT_AI_COMMIT_MSG=0 GIT_AI_COMMIT_ANTHROPIC_API_KEY=sk-ant-invalid-test GIT_EDITOR=true git commit`: hook returned silently at the `GIT_AI_COMMIT_MSG=0` short-circuit before any API call (and before the env-unset warning would have fired), git then aborted on the empty buffer. Confirms the kill switch wins over both the API path and the missing-key warning.
- [x] amend — staged a second file and ran `GIT_AI_COMMIT_ANTHROPIC_API_KEY=sk-ant-invalid-test git commit --amend --no-edit`: `MSG_SOURCE=commit` short-circuited the hook with no API call, amend succeeded (rc=0). Confirms the source check still wins over the API path.
- [x] empty diff — `GIT_AI_COMMIT_ANTHROPIC_API_KEY=sk-ant-invalid-test GIT_EDITOR=true git commit --allow-empty` with nothing staged: hook exited silently at the diff check, git then aborted on the empty buffer. Confirms the empty-diff guard fires before the API call.
