### PR TITLE
Disable Claude Code auto-updater notification

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -382,6 +382,9 @@
       ]
     }
   },
+  "env": {
+    "DISABLE_AUTOUPDATER": "1"
+  },
   "autoUpdatesChannel": "stable",
   "theme": "auto",
   "remoteControlAtStartup": true,


### PR DESCRIPTION
## Summary

Suppress the "Update available! Run: `brew upgrade claude-code`" notification that Claude Code shows at session start. Switch to a manual weekly `brew upgrade claude-code` cadence.

## Why

In the last 30 days the Homebrew cask was bumped 14 times (median interval ~1–2 days, longest gap 3–4 days). Even on the `stable` channel — documented as "about one week old" — the update prompt was firing on essentially every session for me, so the practical cadence felt closer to the cask release rate than to a weekly check.

The official settings page documents only two knobs for this behavior — `DISABLE_AUTOUPDATER` (on/off) and `autoUpdatesChannel` (stable/latest). There is no frequency control, so the realistic options are leave it on or turn it off entirely. Picking off.

Reference: https://code.claude.com/docs/en/settings

## Change

Add a top-level `env` block to `claude/settings.json` setting `DISABLE_AUTOUPDATER=1`. Per the docs, this is the supported way to disable the auto-updater (and the accompanying notification).

`autoUpdatesChannel: "stable"` is left in place — it has no effect while the updater is disabled, but is preserved so re-enabling later doesn't require restoring config.

## Verification

- [x] JSON validity: `jq '.env' claude/settings.json` returns `{"DISABLE_AUTOUPDATER": "1"}`
- [x] pre-commit hooks pass (`Check JSON` + others)
- [x] CI green (bootstrap macos/ubuntu, shellcheck, python-doctest, Socket Security)
- [x] After merge & deploy: launch a fresh `claude` session and confirm the "Update available!" line is gone
- [x] `echo "$DISABLE_AUTOUPDATER"` inside the new session prints `1`
- [x] `brew upgrade claude-code` still works for the manual cadence

## Out of scope

- Removing `autoUpdatesChannel` (kept intentionally)
- Shell-rc env management (settings.json is the single source)
- Automated weekly `brew upgrade` (cron / launchd) — separate PR if needed
