### PR TITLE
Add UserPromptSubmit hook to inject current datetime into context

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -287,7 +287,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "date '+%Y-%m-%dT%H:%M:%S%z' | sed 's/..$/:&/' | jq -R '{hookSpecificOutput:{hookEventName:\"UserPromptSubmit\",additionalContext:(\"Current datetime: \"+.)}}' || true"
+            "command": "date '+%Y-%m-%dT%H:%M:%S%z' | sed 's/..$/:&/' | jq -Rc '{hookSpecificOutput:{hookEventName:\"UserPromptSubmit\",additionalContext:(\"Current datetime: \"+.)}}' || true"
           }
         ]
       }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -282,6 +282,16 @@
     ]
   },
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "date '+%Y-%m-%dT%H:%M:%S%z' | sed 's/..$/:&/' | jq -R '{hookSpecificOutput:{hookEventName:\"UserPromptSubmit\",additionalContext:(\"Current datetime: \"+.)}}' || true"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Purpose

The Claude Code harness provides the current date (`Today's date is 2026-05-23`) in context, but not the time of day or timezone. This adds a UserPromptSubmit hook so Claude knows the current time on every turn.

## Approach

UserPromptSubmit is one of the few hook events whose output is injected into Claude's context on exit 0 (official docs: https://code.claude.com/docs/en/hooks ). Injection can be done via (1) plain stdout or (2) `hookSpecificOutput.additionalContext` JSON; the former also shows up in the transcript every turn. To keep the chat clean and inject only into context, this uses the latter.

Design decisions:

- Format is ISO 8601 (e.g. `2026-05-23T13:41:50+09:00`).
- The offset colon is produced by piping `date '+...%z'` (BSD date, the macOS default, emits `+0900`) through `sed 's/..$/:&/'` to get `+09:00`. This avoids the GNU-only `%:z` extension, so it yields the same result under both BSD and GNU date with no tool detection needed.
- `jq -Rc` reads the timestamp as a raw string and emits compact single-line JSON.
- Trailing `|| true`: UserPromptSubmit blocks prompt submission on exit code 2. Since the hook fires on every prompt, it always exits 0 so a failure never blocks submission (consistent with the always-exit-0 stance in AGENTS.md "Personal Tool Defaults"). If the pipeline ever yields empty output, jq emits nothing and no context is injected — harmless.

## Scope

A single `UserPromptSubmit` entry added to `hooks` in `claude/settings.json`. Existing hooks (PreToolUse / PermissionRequest / Notification / Stop) are unchanged.

## Verification

Verified (with evidence):

- Pipe-test on the actual machine emits `{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"Current datetime: 2026-05-23T13:47:34+09:00"}}` (single line via `jq -Rc`), confirming the colon-form offset `+09:00`.
- `jq -e '.hooks.UserPromptSubmit[].hooks[] | select(.type=="command") | .command'` exits 0 and returns the command string (nesting correct).
- `jq empty claude/settings.json` exits 0 (whole file is valid JSON).
- pre-commit `Check JSON` Passed on commit; all PR CI checks (bootstrap macos/ubuntu, python-doctest, shellcheck, Socket Security) pass.

Not verified (out of reach this session):

- [x] The hook actually fires on the next prompt and injects `Current datetime: ...` into context. UserPromptSubmit fires out of band (on the next prompt), so it cannot be proven within this session. Activation may also require opening `/hooks` once or restarting Claude Code: the settings watcher reportedly only watches files present at session start (observed / internal guidance, not stated in the official hooks docs).
