### PR TITLE
Add neov-ime.nvim for Neovide inline IME preedit

### DIFF
--- a/xdg-config/vim/vimrc
+++ b/xdg-config/vim/vimrc
@@ -293,6 +293,8 @@ if has('nvim')
     Plug 'kassio/neoterm'
     Plug 'folke/snacks.nvim'
     Plug 'coder/claudecode.nvim'
+    " Neovide IME inline preedit; self-detects Neovide, no-op in terminal nvim
+    Plug 'sevenc-nanashi/neov-ime.nvim'
 endif
 
 " This automatically executes `filetype plugin indent on` and `syntax enable`.


### PR DESCRIPTION
## Purpose

Enable inline IME preedit (the in-composition text shown at the cursor) when editing in Neovide. Neovide exposes the preedit display only as a Lua hook (`neovide.preedit_handler()` / `commit_handler()`, added in neovide#3110, fixed in neovide#3221) that does nothing by default, so a handler implementation is required. This adopts the turnkey plugin recommended by Neovide's FAQ instead of hand-rolling one.

## Scope

Adds a single `Plug` line for `sevenc-nanashi/neov-ime.nvim` under the existing `if has('nvim')` block.

Intentionally out of scope: the `g:neovide_input_ime` mode-toggle (forcing IME off in normal mode). It is a separate ergonomic choice whose autocmd-driven IME state switching is an added side effect, so it is left out to keep this change minimal.

No setup() call and no `exists('g:neovide')` guard are added. The plugin self-detects Neovide: in plain terminal nvim it only registers a `dictwatcher` on `g:neovide` and never `require`s its module, so highlight groups, autocmds, and handler registration do not run there. That watcher also absorbs the late-set timing of `g:neovide` (neovide#919), which is why a static `exists('g:neovide')` guard would be unreliable and is omitted. `config.toml` is untouched because preedit lives entirely on the nvim side, and `g:neovide_input_ime` defaults to true so preedit events already flow.

## Sources

- Neovide IME API and FAQ recommending neov-ime.nvim: https://neovide.dev/api.html , https://neovide.dev/faq.html
- Plugin requirements (neovide >= 0.16.0, Neovim >= 0.12.0-dev-1724): https://github.com/sevenc-nanashi/neov-ime.nvim

## Verification

Confirmed from a shell:

- Local environment meets the plugin requirements: `neovide --version` -> 0.16.2 (>= 0.16.0), `nvim --version` -> v0.12.2 (>= 0.12.0-dev-1724). nvim 0.12.2 passes the plugin's version check without warning (patch 2 > 0 short-circuits), so `g:neovime_no_version_warning` is unnecessary.
- No-op-in-terminal-nvim behavior is grounded in the plugin source (`plugin/neov-ime.lua` requires its module only when `g:neovide` is/becomes true).

Requires the live Neovide GUI + IME, cannot be checked from a shell:

- [x] After `:PlugInstall` and a Neovide restart, `:lua print(vim.g.neovide)` is `true` and `:lua print(neovide.preedit_handler)` is a function (handler registered).
- [x] In insert mode, Japanese IME composition text renders inline at the cursor (Pmenu-style highlight) and the confirmed string is inserted on commit.
- [x] Terminal nvim regression: starts with no error/warning, `:lua print(vim.g.neovide)` is `nil`, and `:augroup` does not list `ImePreeditMoveExtMark` (module not loaded, zero side effect).
