### PR TITLE
Deny GitHub MCP Server tools and remove rules mention

### DIFF
--- a/AIRULES.md
+++ b/AIRULES.md
@@ -58,7 +58,7 @@
 
 - Web 検索より MCP サーバー等の外部情報ツールを優先する
 - 通常の Web サイトよりもプレーンテキスト・Markdown ファイルの取得を優先する
-- GitHub の操作はコーディングタスクの場合 `gh` コマンドを使う。gh が使えない環境や gh で実現できない操作の場合のみ `raw.githubusercontent.com` や GitHub MCP サーバー（`mcp__*_GitHub_MCP_Server__*` ツール群）等を使ってよい
+- GitHub の操作はコーディングタスクの場合 `gh` コマンドを使う。gh が使えない環境や gh で実現できない操作の場合のみ `raw.githubusercontent.com` 等を使ってよい
 
 ---
 

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "DISABLE_AUTOUPDATER": "1"
+  },
   "permissions": {
     "allow": [
       "Read(~/.local/share/sre-knowledge-base/**)",
@@ -220,6 +223,7 @@
       "WebFetch(domain:*.internal)",
       "WebFetch(domain:169.254.169.254)",
       "mcp__claude_ai_GitHub_MCP",
+      "mcp__claude_ai_GitHub_MCP_Server__*",
       "Read(**/.env)",
       "Read(**/.env.local)",
       "Read(**/.env.*.local)",
@@ -406,9 +410,6 @@
         "~/.ssh/known_hosts"
       ]
     }
-  },
-  "env": {
-    "DISABLE_AUTOUPDATER": "1"
   },
   "autoUpdatesChannel": "stable",
   "theme": "auto",

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "env": {
-    "DISABLE_AUTOUPDATER": "1"
-  },
   "permissions": {
     "allow": [
       "Read(~/.local/share/sre-knowledge-base/**)",
@@ -410,6 +407,9 @@
         "~/.ssh/known_hosts"
       ]
     }
+  },
+  "env": {
+    "DISABLE_AUTOUPDATER": "1"
   },
   "autoUpdatesChannel": "stable",
   "theme": "auto",


### PR DESCRIPTION
Deny `mcp__claude_ai_GitHub_MCP_Server__*` and remove the fallback mention from AIRULES.md.

The existing deny entry `"mcp__claude_ai_GitHub_MCP"` does not match actual tool names because the server is registered as `claude_ai_GitHub_MCP_Server`. Using the wildcard syntax `mcp__server__*` introduced in Claude Code 2.0.70 covers all 42 tools from that server. The `"mcp__claude_ai_GitHub_MCP"` entry (without `_Server`) is kept for a potential separately-named server.

The AIRULES.md rule for GitHub operations previously allowed falling back to the GitHub MCP Server when `gh` was unavailable. Since the server is now denied, that fallback is removed and `raw.githubusercontent.com` remains the only stated alternative.

## Verification

- After commit, Claude Code immediately reported "42 deferred tools are no longer available (MCP server disconnected): mcp__claude_ai_GitHub_MCP_Server__* (42)" — deny is in effect.
- `raw.githubusercontent.com` fallback remains intact in AIRULES.md.
