### PR TITLE
Show effort and thinking state in status line

### DIFF
--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -47,13 +47,13 @@ color_for_effort() {
 EFFORT_SEG=""
 if [ -n "$EFFORT" ]; then
   EFFORT_COLOR=$(color_for_effort "$EFFORT")
-  EFFORT_SEG="⚡${EFFORT_COLOR}${EFFORT}${RESET}${SEP}"
+  EFFORT_SEG="⚡ ${EFFORT_COLOR}${EFFORT}${RESET}${SEP}"
 fi
 
 if [ "$THINKING" = "true" ]; then
-  THINKING_SEG="🧠${GREEN}on${RESET}${SEP}"
+  THINKING_SEG="🧠 ${GREEN}on${RESET}${SEP}"
 else
-  THINKING_SEG="🧠${GREY}off${RESET}${SEP}"
+  THINKING_SEG="🧠 ${GREY}off${RESET}${SEP}"
 fi
 
 # Line 1: model, effort, thinking, context, lines changed

--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -32,7 +32,8 @@ color_for_pct() {
   fi
 }
 
-# Higher effort costs more latency/budget, so color by intensity.
+# Higher effort costs more latency/budget, so color by intensity
+# (default green covers low/medium and any future/unknown level).
 color_for_effort() {
   case "$1" in
     xhigh|max) printf '%s' "$RED" ;;
@@ -41,8 +42,8 @@ color_for_effort() {
   esac
 }
 
-# effort.level is absent when the model does not support the parameter;
-# drop the whole segment in that case rather than printing a placeholder.
+# The effort object is absent on models without the parameter, so
+# .effort.level // "" yields ""; drop the segment instead of a placeholder.
 EFFORT_SEG=""
 if [ -n "$EFFORT" ]; then
   EFFORT_COLOR=$(color_for_effort "$EFFORT")

--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -15,6 +15,8 @@ SEP="${GREY} | ${RESET}"
 INPUT=$(cat)
 
 MODEL=$(echo "$INPUT" | jq -r '.model.display_name // "Unknown"')
+EFFORT=$(echo "$INPUT" | jq -r '.effort.level // ""')
+THINKING=$(echo "$INPUT" | jq -r '.thinking.enabled // false')
 CONTEXT_PCT=$(echo "$INPUT" | jq -r '.context_window.used_percentage // 0')
 LINES_ADDED=$(echo "$INPUT" | jq -r '.cost.total_lines_added // 0')
 LINES_REMOVED=$(echo "$INPUT" | jq -r '.cost.total_lines_removed // 0')
@@ -30,6 +32,29 @@ color_for_pct() {
   fi
 }
 
-# Line 1: model, context, lines changed
+# Higher effort costs more latency/budget, so color by intensity.
+color_for_effort() {
+  case "$1" in
+    xhigh|max) printf '%s' "$RED" ;;
+    high) printf '%s' "$YELLOW" ;;
+    *) printf '%s' "$GREEN" ;;
+  esac
+}
+
+# effort.level is absent when the model does not support the parameter;
+# drop the whole segment in that case rather than printing a placeholder.
+EFFORT_SEG=""
+if [ -n "$EFFORT" ]; then
+  EFFORT_COLOR=$(color_for_effort "$EFFORT")
+  EFFORT_SEG="⚡${EFFORT_COLOR}${EFFORT}${RESET}${SEP}"
+fi
+
+if [ "$THINKING" = "true" ]; then
+  THINKING_SEG="🧠${GREEN}on${RESET}${SEP}"
+else
+  THINKING_SEG="🧠${GREY}off${RESET}${SEP}"
+fi
+
+# Line 1: model, effort, thinking, context, lines changed
 CTX_COLOR=$(color_for_pct "$CONTEXT_PCT")
-printf '%b' "🤖 ${MODEL}${SEP}📊 ${CTX_COLOR}${CONTEXT_PCT}%${RESET}${SEP}✏️ +${LINES_ADDED}/-${LINES_REMOVED}${SEP}\n"
+printf '%b' "🤖 ${MODEL}${SEP}${EFFORT_SEG}${THINKING_SEG}📊 ${CTX_COLOR}${CONTEXT_PCT}%${RESET}${SEP}✏️ +${LINES_ADDED}/-${LINES_REMOVED}${SEP}\n"


### PR DESCRIPTION
## Purpose

Surface the active reasoning configuration in the status line. effort level and extended-thinking state are the two response quality/latency levers that Claude Code exposes in the status line JSON, so showing them next to the model and context-usage gives an at-a-glance view of how the current session is tuned — including after a mid-session `/effort` change.

## What changes

The first status line now reads `🤖 model | ⚡effort | 🧠thinking | 📊 context% | ✏️ +/-`, or `🤖 model | 🧠thinking | 📊 context% | ✏️ +/-` on models without effort support.

- `⚡` shows `.effort.level`, colored by intensity to flag higher latency/budget: low/medium green, high yellow, xhigh/max red (consistent with the existing context-% coloring).
- `🧠` shows `.thinking.enabled` as on (green) / off (grey).

## Scope

Only `claude/statusline-command.sh`. The effort segment is dropped entirely when the `effort` object is absent (the whole object is omitted for models that do not support the effort parameter, per the docs) rather than printing a placeholder. The unrelated working-tree change to `claude/settings.json` is intentionally left out of this PR.

Fast mode (`/fast`) is deliberately not shown: the official status line JSON schema exposes no field for it.

## Source

Field names and absence behavior verified against the official docs: https://code.claude.com/docs/en/statusline.md (`effort.level`, `thinking.enabled`, conditional absence of the `effort` object).

## Verification

- [x] `shellcheck claude/statusline-command.sh` passes (exit 0).
- [x] CI green: shellcheck, bootstrap (macos-latest, ubuntu-latest), python-doctest, Socket Security.
- [x] Mock JSON, effort=high / thinking=on / ctx=8% → `⚡high` yellow, `🧠on` green.
- [x] Mock JSON, effort=max / thinking=off / ctx=85% → `⚡max` red, `🧠off` grey, ctx red.
- [x] Mock JSON, effort absent (Haiku) → effort segment omitted, thinking still shown.
- [x] Mock JSON, empty `{}` input → no crash; falls back to `🤖 Unknown | 🧠off | 📊 0%`.

Live in-terminal rendering will be confirmed after `./scripts/deploy.sh` refreshes the symlink and a Claude Code session reloads the status line.
