### PR TITLE
Pin per-skill effort for retrospective and pr-selfcheck

### DIFF
--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -1,6 +1,7 @@
 ---
 description: Perform a self-review of a PR before requesting human review. TRIGGER when user invokes /pr-selfcheck or when the git workflow reaches the self-review step after PR creation. Accepts a PR number as an argument.
 model: sonnet
+effort: medium
 context: fork
 agent: general-purpose
 ---

--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -1,6 +1,7 @@
 ---
 description: Use when the user wants to reflect on AI communication quality and get improvement suggestions for rule files or the project itself. TRIGGER when user invokes /retrospective or asks to review the session.
 model: opus
+effort: xhigh
 ---
 
 # Session Retrospective


### PR DESCRIPTION
## Purpose

Explicitly pin reasoning effort on the two local skills so their cost/depth no longer silently tracks whatever the session effort happens to be.

- retrospective gets `effort: xhigh` — session retrospectives do deep structural reasoning, so this keeps them at xhigh even when the session effort is dialed down.
- pr-selfcheck gets `effort: medium` — it is a mechanical PR-presentation check running on Sonnet (whose default effort is `high`), so this lowers cost while staying on the docs-recommended balance.

## Scope

Only the two repo-managed skills. Plugin skills (codex, pr-review-toolkit, hookify, etc.) are out of scope since they are not defined in this repo. The global `effortLevel: high` in `settings.json` is unrelated and left untouched.

## Sources

- `effort` is a valid skill frontmatter key that overrides the session effort level while the skill is active (but not the `CLAUDE_CODE_EFFORT_LEVEL` env var). https://code.claude.com/docs/en/model-config.md ("Skill and subagent frontmatter")
- Per-model effort levels (same source, "Adjust effort level"): Opus 4.8 and Opus 4.7 support `low`/`medium`/`high`/`xhigh`/`max`; Opus 4.6 and Sonnet 4.6 support `low`/`medium`/`high`/`max`. An unsupported level falls back to the highest supported level at or below it (e.g. `xhigh` runs as `high` on Opus 4.6). Default effort is `high` on Sonnet 4.6; `medium` is documented as the cost/intelligence trade-off level.

## Verification

- [x] `effort: xhigh` works for retrospective (`model: opus`): on the Anthropic API `opus` resolves to Opus 4.8, which supports `xhigh`; on the rare Opus 4.6 provider it gracefully falls back to `high` rather than erroring (per the fallback rule above).
- [x] `effort: medium` is valid for pr-selfcheck (`model: sonnet` → Sonnet 4.6), which supports `medium`.
- [x] Diff is limited to the two SKILL.md frontmatters; the `claude/settings.json` working-tree change was deliberately not staged (`git status` confirmed staged set = the two SKILL.md files only).
- [x] CI green on the PR branch (Socket Security, bootstrap macos/ubuntu, python-doctest, shellcheck all pass).
