### PR TITLE
Add JetBrains Junie CLI with shared global guidelines

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -9,6 +9,7 @@ tap "keidarcy/tap"
 tap "oven-sh/bun"
 tap "configcat/tap"
 tap "pipe-cd/homebrew-tap"
+tap "jetbrains/junie"
 
 brew "mas"
 
@@ -47,6 +48,7 @@ brew "grep"
 cask "codex"
 cask "claude-code"
 brew "gemini-cli"
+brew "junie"
 
 # required by vim
 brew "python"

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: pr-selfcheck
 description: Perform a self-review of a PR before requesting human review. TRIGGER when user invokes /pr-selfcheck or when the git workflow reaches the self-review step after PR creation. Accepts a PR number as an argument.
 model: sonnet
 effort: medium

--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: retrospective
 description: Use when the user wants to reflect on AI communication quality and get improvement suggestions for rule files or the project itself. TRIGGER when user invokes /retrospective or asks to review the session.
 model: opus
 effort: xhigh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -77,5 +77,4 @@ mkdir -p "$HOME/.codex/rules"
 find "$DOTPATH/codex/rules" -maxdepth 1 -mindepth 1 -type f -name '*.rules' -exec ln -fvns {} "$HOME/.codex/rules/" \;
 
 # Junie CLI (JetBrains)
-mkdir -p "$HOME/.junie"
 link AIRULES.md  "$HOME/.junie/AGENTS.md"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -77,4 +77,5 @@ mkdir -p "$HOME/.codex/rules"
 find "$DOTPATH/codex/rules" -maxdepth 1 -mindepth 1 -type f -name '*.rules' -exec ln -fvns {} "$HOME/.codex/rules/" \;
 
 # Junie CLI (JetBrains)
+mkdir -p "$HOME/.junie"
 link AIRULES.md  "$HOME/.junie/AGENTS.md"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -78,3 +78,5 @@ find "$DOTPATH/codex/rules" -maxdepth 1 -mindepth 1 -type f -name '*.rules' -exe
 
 # Junie CLI (JetBrains)
 link AIRULES.md  "$HOME/.junie/AGENTS.md"
+mkdir -p "$HOME/.junie/skills"
+find "$DOTPATH/claude/skills" -maxdepth 1 -mindepth 1 -type d -exec ln -fvns {} "$HOME/.junie/skills/" \;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -75,3 +75,8 @@ find "$DOTPATH/claude/rules" -maxdepth 1 -mindepth 1 -type f -name '*.md' -exec 
 link AIRULES.md  "$HOME/.codex/AGENTS.md"
 mkdir -p "$HOME/.codex/rules"
 find "$DOTPATH/codex/rules" -maxdepth 1 -mindepth 1 -type f -name '*.rules' -exec ln -fvns {} "$HOME/.codex/rules/" \;
+
+# Junie CLI (JetBrains): share AIRULES.md as global guidelines, and skills with Claude Code
+link AIRULES.md  "$HOME/.junie/AGENTS.md"
+mkdir -p "$HOME/.junie/skills"
+find "$DOTPATH/claude/skills" -maxdepth 1 -mindepth 1 -type d -exec ln -fvns {} "$HOME/.junie/skills/" \;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -78,5 +78,3 @@ find "$DOTPATH/codex/rules" -maxdepth 1 -mindepth 1 -type f -name '*.rules' -exe
 
 # Junie CLI (JetBrains)
 link AIRULES.md  "$HOME/.junie/AGENTS.md"
-mkdir -p "$HOME/.junie/skills"
-find "$DOTPATH/claude/skills" -maxdepth 1 -mindepth 1 -type d -exec ln -fvns {} "$HOME/.junie/skills/" \;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -76,7 +76,7 @@ link AIRULES.md  "$HOME/.codex/AGENTS.md"
 mkdir -p "$HOME/.codex/rules"
 find "$DOTPATH/codex/rules" -maxdepth 1 -mindepth 1 -type f -name '*.rules' -exec ln -fvns {} "$HOME/.codex/rules/" \;
 
-# Junie CLI (JetBrains): share AIRULES.md as global guidelines, and skills with Claude Code
+# Junie CLI (JetBrains)
 link AIRULES.md  "$HOME/.junie/AGENTS.md"
 mkdir -p "$HOME/.junie/skills"
 find "$DOTPATH/claude/skills" -maxdepth 1 -mindepth 1 -type d -exec ln -fvns {} "$HOME/.junie/skills/" \;

--- a/xdg-config/git/ignore
+++ b/xdg-config/git/ignore
@@ -22,3 +22,7 @@ CLAUDE.local.md
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 .claude/worktrees/
+
+# Junie session/user data (project-level AGENTS.md / skills etc. stay trackable)
+.junie/memory/
+.junie/plans/

--- a/xdg-config/git/ignore
+++ b/xdg-config/git/ignore
@@ -23,6 +23,5 @@ CLAUDE.local.md
 .claude/scheduled_tasks.lock
 .claude/worktrees/
 
-# Junie session/user data (project-level AGENTS.md / skills etc. stay trackable)
-.junie/memory/
-.junie/plans/
+# Junie
+.junie/


### PR DESCRIPTION
## Purpose

Start using JetBrains Junie CLI (and the JetBrains IDE plugin) alongside Claude Code and Codex CLI. Junie's global guidelines are pointed at the same `AIRULES.md` already shared with Claude Code and Codex, and Junie's skills directory is symlinked to the same `claude/skills/` tree, so all three agents read one source of truth.

## What this PR does

- Installs Junie via Brewfile (`tap "jetbrains/junie"` + `brew "junie"`) so it is provisioned along with other AI tools.
- Extends `scripts/deploy.sh` with a Junie section that symlinks `AIRULES.md` to `~/.junie/AGENTS.md` and the `claude/skills/` subdirectories into `~/.junie/skills/`, mirroring the existing Codex CLI section.

## Why this approach

Junie reads global guidelines from `~/.junie/AGENTS.md` and skills from `~/.junie/skills/<name>/SKILL.md` ([Guidelines and memory](https://junie.jetbrains.com/docs/guidelines-and-memory.html), [Agent skills](https://junie.jetbrains.com/docs/agent-skills.html)). Both follow the open Agent Skills format already used for Codex (`~/.codex/AGENTS.md`) and Claude Code (`~/.claude/CLAUDE.md`), so a symlink share is the lowest-friction path to keep one source of truth.

## Out of scope (intentionally not migrated)

These Claude Code features have no clean Junie equivalent. Re-implementing them would require non-trivial workarounds, so they are deferred:

- `claude/hooks/` (PreToolUse / PermissionRequest scripts such as auto-approve-git-commit, approve_gh_graphql_readonly): Junie only supports session-lifecycle hooks, not per-tool hooks ([Junie CLI configuration files](https://junie.jetbrains.com/docs/junie-cli-configuration.html)). Auto-approval on Junie side will rely on `~/.junie/allowlist.json` ("Always allow" during approval prompts) instead.
- `claude/agents/` (custom subagents): Frontmatter schema differs (`tools` / `disallowedTools` / `reasoningLevel` / `skills` / `allowPromptArgument`) ([Custom subagents](https://junie.jetbrains.com/docs/junie-cli-subagents.html)). Not portable as-is.
- `claude/settings.json`: Junie uses `~/.junie/config.json` + `~/.junie/settings.json` with a different schema.
- Statusline / keybindings: No documented Junie equivalent.

`AIRULES.md` still contains Claude-Code-specific lines (`/retrospective` automation, `EnterWorktree` references, hooks references). The shared Claude skills also carry frontmatter fields outside the documented Junie spec (`model` / `effort` / `context` / `agent`). These are tolerated the same way Codex CLI already tolerates the Claude-specific lines today; if Junie surfaces problems, a follow-up can make `AIRULES.md` and the skills agent-agnostic.

## Verification

- [x] `./scripts/deploy.sh` creates `~/.junie/AGENTS.md` and `~/.junie/skills/*` as symlinks. Confirmed locally:

  ```
  /Users/ikuwow/.junie/AGENTS.md -> /Users/ikuwow/dotfiles/AIRULES.md
  /Users/ikuwow/.junie/skills/retrospective -> /Users/ikuwow/dotfiles/claude/skills/retrospective
  /Users/ikuwow/.junie/skills/pr-selfcheck  -> /Users/ikuwow/dotfiles/claude/skills/pr-selfcheck
  ```
- [x] `scripts/deploy.sh` passes shellcheck.
- [ ] `brew bundle` installs `junie` (run on host; verify with `brew list junie`).
- [ ] `junie --version` prints a version.
- [ ] `junie` started inside the dotfiles repo loads `~/.junie/AGENTS.md` as global guidelines (visible after first-run authentication with the JetBrains account).
- [ ] `junie` recognises the symlinked skills (`retrospective`, `pr-selfcheck`). If the Claude-Code-extension frontmatter fields cause failures, revert just the skills symlink block.
- [ ] JetBrains IDE picks up the Junie CLI automatically (per [Junie CLI inside the JetBrains IDE](https://blog.jetbrains.com/junie/2026/04/junie-cli-inside-your-jb-ide/)).
