### PR TITLE
Drop bash3 warning and silence stale fzf --bash error

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,11 +1,6 @@
 # shellcheck disable=SC2148
 # vim: filetype=sh :
 
-if [ "${BASH_VERSINFO[0]}" -le 3 ]; then
-  echo "WARNING: Your bash version is ${BASH_VERSINFO[0]}!"
-  echo "Please use bash 4.0~"
-fi
-
 # shellcheck disable=SC1091
 [[ -f /etc/bashrc ]] && . /etc/bashrc
 
@@ -16,7 +11,7 @@ if [ -n "${BREW_PREFIX:-}" ]; then
 elif [ -f /usr/share/bash-completion/bash_completion ]; then
   . /usr/share/bash-completion/bash_completion
 fi
-[[ $(command -v fzf) ]] && eval "$(fzf --bash)"
+[[ $(command -v fzf) ]] && eval "$(fzf --bash 2>/dev/null)"
 [[ $(command -v akamai) ]] && eval "$(akamai --bash)"
 
 ## Language Specific configs


### PR DESCRIPTION
## Summary

Two minimal `.bashrc` cleanups bundled because they touch the same file:

- Drop the `BASH_VERSINFO[0] <= 3` warning block. Sourced unconditionally; produced repeated noise per ssh handshake on macOS hosts where the stock `/bin/bash` 3.x is fine for routine use.
- Wrap `fzf --bash` with `2>/dev/null`. The `--bash` flag was added in fzf 0.48.0; the apt-shipped fzf 0.44.1 on Ubuntu 24.04 used by `bootstrap/claude-code-web.sh` prints `unknown option: --bash` on every shell start. Suppressing stderr makes `eval` a harmless no-op on old fzf while keeping shell integration on modern fzf.

## Verification

- [x] Local bash starts without error and `fzf` shell integration still works (modern fzf).
- [x] On a Claude Code web environment (fzf 0.44.1): no `unknown option: --bash` on shell start.
- [x] On a host with `/bin/bash` 3.x: no `WARNING: Your bash version is 3!` lines.

Closes #11
Closes #110
