### PR TITLE
Enable Power Nap on battery and AC

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -35,6 +35,7 @@ defaults -currentHost write com.apple.Spotlight MenuItemHidden -int 1
 echo "Configuring with sudo..."
 sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on
 sudo pmset -b lessbright 0  # Disable "Slightly dim the display on battery"
+sudo pmset -a powernap 1  # Enable Power Nap on battery and AC
 
 defaults -currentHost write com.apple.screensaver idleTime -int 0
 


### PR DESCRIPTION
## Summary

Add `sudo pmset -a powernap 1` next to the existing `pmset -b lessbright 0` line so configure.sh provisions Power Nap on every fresh setup. `-a` covers both battery and AC; the call is idempotent.

`pmset` reference: `man pmset` (`powernap` flag).

## Verification

- [x] `pmset -g | grep -i powernap` on the author's host returns `powernap             1`.

Closes #7
