### PR TITLE
Auto-remove worktree in git-delete-squashed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ pre-commit run --all-files
 
 - Always create a branch before making changes (direct commits to main are prohibited)
 - Do NOT create git worktrees — branch only, no worktree
-- Clean up merged local branches with `bin/git-delete-squashed` (PRs are squash-merged, which `git branch -d` does not recognize).
+- Clean up merged local branches with `bin/git-delete-squashed` (PRs are squash-merged, which `git branch -d` rejects as "not fully merged").
 
 ## Language
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ pre-commit run --all-files
 
 - Always create a branch before making changes (direct commits to main are prohibited)
 - Do NOT create git worktrees — branch only, no worktree
-- Clean up merged local branches with `bin/git-delete-squashed` (PRs are squash-merged, which `git branch -d` rejects as "not fully merged").
+- Clean up merged local branches (and their worktrees, if any) with `bin/git-delete-squashed` (PRs are squash-merged, which `git branch -d` rejects as "not fully merged").
 
 ## Language
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ pre-commit run --all-files
 
 - Always create a branch before making changes (direct commits to main are prohibited)
 - Do NOT create git worktrees — branch only, no worktree
-- Clean up merged local branches with `bin/git-delete-squashed`, not `git branch -d`. PRs are squash-merged, so `git branch -d` refuses them as "not fully merged"; `git-delete-squashed` detects squash-merged branches by tree comparison and force-deletes them while leaving unmerged branches intact.
+- Clean up merged local branches with `bin/git-delete-squashed` (PRs are squash-merged, which `git branch -d` does not recognize).
 
 ## Language
 

--- a/bin/git-delete-squashed
+++ b/bin/git-delete-squashed
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-# ref: https://github.com/not-an-aardvark/git-delete-squashed#sh
+# Delete local branches whose content is already in the default branch
+# (including squash-merged ones). If a deletable branch is checked out in
+# a worktree, remove that worktree first.
+#
+# Origin of the squash-merge detection trick:
+# https://github.com/not-an-aardvark/git-delete-squashed#sh
 
 set -eu
 
-# This script checks out the default branch, which would silently carry
-# uncommitted work off the current branch. Refuse to run unless clean so
-# it is safe to invoke automatically (e.g. from a cleanup workflow).
 if [ -n "$(git status --porcelain)" ]; then
   echo "git-delete-squashed: uncommitted changes present; commit or stash first." >&2
   exit 1
@@ -18,10 +20,39 @@ if [ ! "$(git rev-parse --verify "$default_branch" 2>/dev/null)" ];then
 fi
 
 git checkout -q "$default_branch"
+
+# Build branch -> worktree path map once.
+worktree_map=$(git worktree list --porcelain | awk '
+  /^worktree /  { path = substr($0, 10) }
+  /^branch /    {
+    ref = substr($0, 8)
+    sub(/^refs\/heads\//, "", ref)
+    print ref "\t" path
+  }
+')
+
+lookup_worktree() {
+  local branch="$1"
+  printf '%s\n' "$worktree_map" | awk -F'\t' -v b="$branch" '$1 == b { print $2; exit }'
+}
+
 git for-each-ref refs/heads/ "--format=%(refname:short)" | \
   while read -r branch; do
     mergeBase=$(git merge-base "$default_branch" "$branch")
-    if [[ $(git cherry "$default_branch" "$(git commit-tree "$(git rev-parse "$branch^{tree}")" -p "$mergeBase" -m _)") == "-"* ]]; then
-      git branch -D "$branch"
+    if [[ $(git cherry "$default_branch" "$(git commit-tree "$(git rev-parse "$branch^{tree}")" -p "$mergeBase" -m _)") != "-"* ]]; then
+      continue
+    fi
+
+    wt_path=$(lookup_worktree "$branch")
+    if [ -n "$wt_path" ]; then
+      if ! git worktree remove "$wt_path"; then
+        echo "git-delete-squashed: skip '$branch' (worktree at $wt_path not removable; uncommitted changes?)" >&2
+        continue
+      fi
+    fi
+
+    if ! git branch -D "$branch"; then
+      echo "git-delete-squashed: skip '$branch' (branch deletion failed)" >&2
+      continue
     fi
   done

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -313,7 +313,7 @@ After the PR is merged (or the task is fully done):
 
 1. Move back to the repository root:
    `cd <repository root>`
-2. Delete the merged local branch (and its worktree, if any):
+2. Delete the merged local branch and its worktree (if any):
    `git delete-squashed`
    - Use the space form (`git delete-squashed`); it is already covered by
      the `Bash(git *)` allow rule, so no extra permission is needed.

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -313,15 +313,7 @@ After the PR is merged (or the task is fully done):
 
 1. Move back to the repository root:
    `cd <repository root>`
-2. Remove the worktree (worktree-based workflows only):
-   `git worktree remove .worktrees/<branch>`
-   - Skip if the project prohibits worktrees and the branch was created
-     via `git checkout -b` only.
-3. Delete the merged local branch:
+2. Delete the merged local branch (and its worktree, if any):
    `git delete-squashed`
-   - Removes local branches whose content is already in the default
-     branch, including squash-merged ones that `git branch -d` refuses
-     ("not fully merged"). Unmerged branches are left untouched, and the
-     script aborts on a dirty working tree.
    - Use the space form (`git delete-squashed`); it is already covered by
      the `Bash(git *)` allow rule, so no extra permission is needed.


### PR DESCRIPTION
## Purpose

`git-delete-squashed` previously failed with `branch is checked out at <path>` when a squash-merged branch still had a worktree, so the local cleanup step (Step 7 of [git-workflow.md](claude/rules/git-workflow.md)) required a manual `git worktree remove .worktrees/<branch>` before each run. Have the script discover and remove the worktree itself so the cleanup is a single command.

## Scope

- `bin/git-delete-squashed`: build a branch → worktree path map up front, and for each branch the existing `git cherry` check identifies as squash-merged, attempt `git worktree remove` first when one exists. `--force` is intentionally not used — `git worktree remove` already refuses dirty / untracked worktrees and refuses to remove the main worktree, so the change inherits git's own safety semantics. A dirty worktree is reported and skipped per-branch; the loop continues with the rest. The squash-merge detection logic itself is unchanged.
- `claude/rules/git-workflow.md` and `AGENTS.md`: previously described the script's internal behavior (which branches it deletes, what it does on dirty trees, that worktree removal is a separate step). Removed those descriptions so the docs do not need to be re-synced on every behavior change.

Out of scope: changing the squash-merge detection itself, supporting `--force`, or auto-pruning worktrees that are no longer associated with any local branch.

## Sources and references

- `git-worktree(1)` — `git worktree remove` without `--force` refuses dirty / untracked worktrees and refuses to remove the main worktree. <https://git-scm.com/docs/git-worktree>
- Origin of the squash-merge detection trick (preserved in the script comment): <https://github.com/not-an-aardvark/git-delete-squashed#sh>

## Verification

- [x] `shellcheck bin/git-delete-squashed` — passes (no output).
- [x] Manual test in a throwaway repo with three squash-merged branches:
  - `feat-clean` (clean worktree) → worktree removed, branch deleted.
  - `feat-dirty` (worktree with an untracked file) → `fatal: ... contains modified or untracked files, use --force to delete it` from git, followed by `git-delete-squashed: skip 'feat-dirty' (worktree at ... not removable; uncommitted changes?)`. Loop continued; `feat-dirty` and its worktree remained intact.
  - `feat-nowt` (no worktree) → branch deleted directly, no worktree interaction.
  - Post-state: only `main` and `feat-dirty` remained as branches; only the main worktree and `.worktrees/feat-dirty` remained.
