### PR TITLE
Add colima auto-start wrapper to clear stale vz state

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -158,7 +158,7 @@ brew "virt-manager"
 brew "docker"
 brew "docker-compose"
 brew "docker-buildx"
-brew "colima", restart_service: true
+brew "colima" # auto-start via launchagents/com.ikuwow.colima.plist (see #98)
 brew "lima-additional-guestagents" # https://github.com/abiosoft/colima/issues/1333
 brew "kubie"
 brew "k9s"

--- a/bin/colima-clean-start
+++ b/bin/colima-clean-start
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Wrapper around `colima start -f` that clears stale state from a non-clean
+# shutdown of the vz vmType driver before starting.
+#
+# Symptom this guards against:
+#   level=fatal msg="errors inspecting instance: [vz driver is running but host agent is not]"
+#   level=fatal msg="failed to run attach disk \"colima\", in use by instance \"colima\""
+#
+# Caused by the vz driver leaving disk attach state behind across macOS reboot.
+#
+# Upstream: https://github.com/abiosoft/colima/issues/985
+
+set -eu
+
+colima stop --force >/dev/null 2>&1 || true
+exec colima start -f "$@"

--- a/launchagents/com.ikuwow.colima.plist
+++ b/launchagents/com.ikuwow.colima.plist
@@ -20,6 +20,8 @@
 		<key>SuccessfulExit</key>
 		<true/>
 	</dict>
+	<key>ThrottleInterval</key>
+	<integer>300</integer>
 	<key>StandardErrorPath</key>
 	<string>/opt/homebrew/var/log/colima.log</string>
 	<key>StandardOutPath</key>

--- a/launchagents/com.ikuwow.colima.plist
+++ b/launchagents/com.ikuwow.colima.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.ikuwow.colima</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/ikuwow/bin/colima-clean-start</string>
+	</array>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<dict>
+		<key>SuccessfulExit</key>
+		<true/>
+	</dict>
+	<key>StandardErrorPath</key>
+	<string>/opt/homebrew/var/log/colima.log</string>
+	<key>StandardOutPath</key>
+	<string>/opt/homebrew/var/log/colima.log</string>
+	<key>WorkingDirectory</key>
+	<string>/Users/ikuwow</string>
+</dict>
+</plist>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -73,6 +73,11 @@ find "$DOTPATH/claude/agents" -maxdepth 1 -mindepth 1 -type f -name '*.md' -exec
 mkdir -p "$HOME/.claude/rules"
 find "$DOTPATH/claude/rules" -maxdepth 1 -mindepth 1 -type f -name '*.md' -exec ln -fvns {} "$HOME/.claude/rules/" \;
 
+# LaunchAgents (macOS only, conditional)
+if [[ -d "$HOME/Library/LaunchAgents" ]]; then
+  find "$DOTPATH/launchagents" -maxdepth 1 -mindepth 1 -type f -name '*.plist' -exec ln -fvns {} "$HOME/Library/LaunchAgents/" \;
+fi
+
 # Codex CLI
 link AIRULES.md  "$HOME/.codex/AGENTS.md"
 mkdir -p "$HOME/.codex/rules"


### PR DESCRIPTION
Closes #98.

## Why

`brew services start colima` runs `colima start -f` directly, which fails after every macOS reboot because the vz vmType driver leaves stale disk-attach state when the system shuts down uncleanly. Manual `colima stop --force && colima start` recovers, which is the daily toil this PR removes.

Picks Solution 2 from the issue body (wrapper + LaunchAgent). Switching to qemu (Solution 1) trades reboot-stability for a perf drop on Apple Silicon; the wrapper keeps vz and only pays the cost when stale state is actually present.

## What

- `bin/colima-clean-start` wraps `colima start -f` with `colima stop --force` as a pre-step. Idempotent and silent when there is nothing to clean.
- `launchagents/com.ikuwow.colima.plist` is a personal LaunchAgent that calls the wrapper at login. Mirrors brew's plist (KeepAlive.SuccessfulExit, RunAtLoad, log paths) plus a `ThrottleInterval` of 300 s so a persistent start failure does not respawn-loop.
- `scripts/deploy.sh` symlinks every `launchagents/*.plist` into `~/Library/LaunchAgents/` (macOS-only, conditional).
- `Brewfile`: removed `restart_service: true` so `brew bundle` no longer races to start its own service.

## Manual one-time activation

After this PR is merged and `./scripts/deploy.sh` runs, the brew-installed plist `~/Library/LaunchAgents/homebrew.mxcl.colima.plist` will still exist and brew services will still consider colima as a service. To switch to the new wrapper-based LaunchAgent:

- [ ] `brew services stop colima`
- [ ] `rm ~/Library/LaunchAgents/homebrew.mxcl.colima.plist`
- [ ] `launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.ikuwow.colima.plist`
- [ ] Reboot once, confirm `colima status` reports the VM as running

The plist hardcodes `/Users/ikuwow/bin/colima-clean-start` as `ProgramArguments[0]` because LaunchAgent property lists cannot expand `$HOME`. This is intentional and personal-scope.

## Verification

- [x] `shellcheck bin/colima-clean-start scripts/deploy.sh` clean.
- [x] `plutil -lint launchagents/com.ikuwow.colima.plist` reports OK.
- [x] Wrapper trace-read: `colima stop --force >/dev/null 2>&1 || true` swallows the "not running" error, `exec colima start -f "$@"` preserves the start exit code and forwards args; semantics match the manual workaround the issue captures.
- [x] LaunchAgent `ThrottleInterval=300` is in the plist so a persistent start failure is throttled (added after review; otherwise the default 10 s window would hammer the log).
- [ ] End-to-end reboot test: defer until activation steps above are run; the brew-managed plist still owns the running service today.

## Upstream

- https://github.com/abiosoft/colima/issues/985
- https://github.com/abiosoft/colima/issues/1170
- https://github.com/abiosoft/colima/issues/1490
