### PR TITLE
Consolidate pr-guidelines.md Checklist and Review Criteria

### DIFF
--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -77,7 +77,7 @@ Note: `.worktrees/` is covered by the global gitignore.
 2. Write the PR body to the generated path using the Write tool:
    `Write(<path from mktemp>)`
    - Follow the repository's PR template if one exists.
-   - Follow the PR Body Checklist and Review Criteria.
+   - Follow the PR Body Checklist (it now covers both writing and self-review in one section).
 3. Create the PR as a draft:
    `gh pr create --draft --body-file <path from mktemp>`
    - Never use `--body` for PR creation. The `#`-prefixed lines in the body

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -77,7 +77,7 @@ Note: `.worktrees/` is covered by the global gitignore.
 2. Write the PR body to the generated path using the Write tool:
    `Write(<path from mktemp>)`
    - Follow the repository's PR template if one exists.
-   - Follow the PR Body Checklist (it now covers both writing and self-review in one section).
+   - Follow the PR Body Checklist.
 3. Create the PR as a draft:
    `gh pr create --draft --body-file <path from mktemp>`
    - Never use `--body` for PR creation. The `#`-prefixed lines in the body

--- a/claude/rules/pr-guidelines.md
+++ b/claude/rules/pr-guidelines.md
@@ -1,7 +1,7 @@
 # PR Guidelines
 
 Quality criteria for pull requests. Follow these when writing a PR body
-and when reviewing your own PR.
+and when self-reviewing your own PR.
 
 ## Writing Style
 
@@ -64,161 +64,88 @@ content that doesn't fit on one line — including issue references
   at the end of the body (e.g., in a "Follow-up" / "Notes" section).
   Do not surface them in the opening sections (purpose, scope,
   summary), where they compete with the approve/reject decision.
-  Reviewer attention is limited; the most-actionable information for
-  this PR should reach the reader first.
 - Inside GitHub PR / issue bodies and PR / issue comments only — that
   is, Markdown posted through the GitHub web UI — do not hard-wrap
   paragraphs or list items. Write each paragraph as a single line and
   let the browser wrap it; use blank lines for paragraph breaks. GitHub
   Flavored Markdown renders soft line breaks inside a paragraph as
   visible breaks (or runs lines together awkwardly) only in these
-  contexts, so a body wrapped at ~70 chars looks broken on the web.
-  Plain Markdown files (READMEs, ADRs, this guidelines file itself,
-  and any other in-repo documentation) follow standard Markdown
-  rendering — single line breaks inside a paragraph are ignored — so
-  they may be hard-wrapped for file-side readability.
-- DO / DON'T example for a paragraph in a PR / issue body:
-
-  DO (single line, the browser wraps it):
-
-  ````
-  Fix the broken X path so Y stops emitting spurious diffs.
-  ````
-
-  DON'T (paragraph hard-wrapped at column width):
-
-  ````
-  Fix the broken X path so Y stops emitting
-  spurious diffs.
-  ````
+  contexts. Plain Markdown files (READMEs, ADRs, this guidelines file
+  itself, and any other in-repo documentation) follow standard Markdown
+  rendering and may be hard-wrapped for file-side readability.
 
 ## PR Body Checklist
 
-When writing a PR body, cover every applicable item:
+Used both when authoring a PR body and when self-reviewing it (via
+`/pr-selfcheck`). Cover every applicable item — each rule is stated
+once and applies to both perspectives.
 
-1. Purpose and motivation
-   - State what changed and why (bug, feature, tech debt, compliance, etc.).
-   - A reviewer should understand the intent from the body alone.
+1. Purpose, scope, intent
+   - State what changed and why (bug, feature, tech debt, compliance,
+     etc.). The body alone should convey the intent and let a reviewer
+     understand the purpose, what changed, and the impact.
+   - Describe the boundary of the change and call out anything
+     intentionally left out of scope.
+   - Keep the PR self-contained. Verification items, acceptance
+     criteria, and follow-up actions that depend on changes outside
+     this PR's diff (other repos, downstream releases, E2E flows)
+     belong in the parent issue, not in the PR body.
 
-2. Scope
-   - Clearly describe the boundary of the change.
-   - Call out anything intentionally left out of scope.
-   - A PR should be a self-contained unit. Verification items, acceptance
-     criteria, and follow-up actions that depend on changes outside this
-     PR's diff (other repos, downstream releases, E2E flows) belong in
-     the parent issue, not in the PR body.
+2. Sources and references
+   - Provide official documentation URLs or other authoritative
+     sources that justify configuration values, tool choices, or
+     version selections. Especially important for dotfiles /
+     infrastructure changes where "why this value" matters.
+   - All URLs and anchor links must resolve to the expected content.
 
-3. Sources and references
-   - Provide official documentation URLs or other authoritative sources
-     that justify configuration values, tool choices, or version selections.
-   - Especially important for dotfiles / infrastructure changes where
-     "why this value" matters.
-
-4. Issue linking
+3. Issue linking
    - Do NOT use auto-close keywords (`Closes`, `Fixes`, `Resolves`).
 
-5. Verification
+4. Verification
    - Attempt every verification within reach before drafting this
      section: shell commands, API calls, file inspection, mocked
      failure modes, simulated missing-config tests. Punting reachable
-     items to "Pending" or "User to verify" (see below) is itself the
-     violation — overstating what is "untestable" is the common
-     failure mode.
-   - List only items actually verified, with evidence (command output,
-     exit code, log excerpt).
+     items to "Pending" or "User to verify" is itself the violation —
+     overstating what is "untestable" is the common failure mode.
+   - List only items actually verified, with evidence (command
+     output, exit code, log excerpt). Never record what the diff or
+     GitHub UI already shows: line counts, `wc -l` of a file you
+     edited, the list of changed files, percentage removed,
+     paraphrase of own edits, or CI / lint / type-check results
+     (those live in the Checks panel and bot comments).
    - Items that genuinely require interactive UI, user-only
      credentials, target environments unreachable from a shell, or
-     the live session itself must be clearly distinguished from the
-     already-verified ones, with reproduction steps and a one-line
-     reason why the author could not verify them. Follow the
-     repository's PR template if it defines a structure; otherwise
-     use any organization that makes the distinction unambiguous
-     (separate subsection, prefix, etc.) — the section name itself
-     is not prescribed. Scope still applies (§2): items that depend
-     on changes outside this PR's diff belong in the parent issue,
-     not here.
+     the live session itself must be clearly distinguished with
+     reproduction steps and a one-line reason why the author could
+     not verify them.
    - Use `- [ ] …` markdown checkboxes for items the user is
      expected to verify or act on later, so they can be ticked off
-     after completion. This applies regardless of section name or
-     structure.
-   - Why over what applies to Verification too. Do not record items
-     that the diff or GitHub UI already shows: line counts,
-     percentage of lines removed, `wc -l` of a file you edited, the
-     list of changed files, or a paraphrase of your own edits. List
-     only what an external resource confirms — command output, API
-     responses, log excerpts, UI behavior, etc.
+     after completion.
+   - Every changed code path is covered by CI, manual test steps in
+     the PR body, or another verification mechanism. All verification
+     items are scoped to this PR's diff alone; cross-component or E2E
+     items belong in the parent issue.
 
-6. Never include in the initial draft
-   - The following are visible elsewhere and must not be restated:
-     - Enumerations of added rules, linters, settings, constants, or
-       values (visible in the diff)
-     - CI job pass/fail, lint results, type-check results (visible
-       in the Checks panel and bot comments)
+5. Conciseness (Essence-first)
+   - The principles above (Why over what, DRY, Inverted pyramid,
+     Progressive disclosure, Diff scope discipline) apply directly
+     here — they are not restated as separate review questions.
+     A sentence that paraphrases the diff, duplicates a linked
+     source, or buries the lead is a violation regardless of which
+     principle names it.
+   - Never include in the body:
+     - Enumerations of added rules, linters, settings, constants,
+       or values (visible in the diff)
+     - CI job pass/fail, lint results, type-check results
      - Self-paraphrase of own edits ("edited file X", "bumped value
        from A to B", "added N items", "raised timeout to M")
      - File lists, line counts, percentage of lines removed
      - Per-item rendering of a pre-flight checklist when every item
        is "N/A" — collapse to one line
-   - Write what a reviewer needs to grasp the holistic intent of the
-     PR (what the change is trying to achieve across the whole diff),
-     not a narration of the diff itself.
+   - Bullets are few and meaningful, each conveying a distinct point.
 
-## Review Criteria
-
-Used by `/pr-selfcheck` to evaluate a PR after creation.
-
-1. Reviewer-facing information
-   - Can a reviewer understand the purpose, what changed, and the impact
-     from the PR body alone?
-   - Is the scope of the change clear?
-
-2. Sources and references
-   - Are official documentation URLs or other authoritative sources provided
-     to justify configuration values, tool choices, or version selections?
-
-3. Intent and rationale
-   - Does the PR explain not just what changed but why?
-   - Is the motivation stated?
-
-4. Link validity
-   - Do all URLs in the PR body resolve to the expected content?
-   - Do anchor links point to the correct section?
-
-5. Title / body / diff consistency
-   - Does the PR title accurately reflect the change?
-   - Is there any contradiction between the body description and the
-     actual diff?
-
-6. Diff coverage
-   - Does the PR body account for all files and changes in the diff?
-   - Are there unexplained changes?
-
-7. Conciseness (Essence-first)
-   - Is the body a high-level summary rather than a line-by-line
-     restatement of the diff?
-   - Does any sentence paraphrase facts the diff already shows
-     (file lists, "added X to Y", per-file summaries)? If so,
-     remove it. (Why over what)
-   - Is content duplicated from a linked issue, doc, or prior PR?
-     Replace with a one-line summary plus link. (Single source of
-     truth)
-   - Does the reader hit the most important information in the first
-     few lines? (Inverted pyramid)
-   - Is implementation detail, history, or alternatives narrative
-     mixed into the main body? Move it to a "Notes" / "Background"
-     section at the end. (Progressive disclosure)
-   - Are bullet points few and meaningful, each conveying a distinct
-     point?
-
-8. Verification completeness
-   - Did the author attempt the verifications they could reach
-     (shell, API, mocked failures), or punt them to "Pending" /
-     "User to verify"? Items reachable from a shell or API belong
-     in the verified list.
-   - Is every changed code path covered by CI, manual test steps in the
-     PR body, or another verification mechanism?
-   - Are there paths that only run in a specific target environment
-     (e.g., Claude Code web, external services) without a stated plan
-     to verify them?
-   - Are all verification items scoped to this PR's diff alone?
-     Cross-component or E2E items belong in the parent issue.
+6. Title / body / diff consistency
+   - The title accurately reflects the change.
+   - The body does not contradict the diff.
+   - The body accounts for all files and changes in the diff; there
+     are no unexplained hunks.

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -24,7 +24,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 
 ## Review Criteria
 
-Evaluate the PR against the Review Criteria defined in `pr-guidelines.md`.
+Evaluate the PR against the PR Body Checklist defined in `pr-guidelines.md`.
 
 ## Output Format
 


### PR DESCRIPTION
## Purpose

Part of #211 (shrink the always-on AI rule context). `claude/rules/pr-guidelines.md` was 224 lines because the same rules were stated twice — once as a writer-side "PR Body Checklist" and again as a reviewer-side "Review Criteria" — plus the four guiding principles were spelled out in full inside both the Principles subsection and Review Criteria item 7. This PR collapses those duplications into one audience-agnostic checklist with the principles stated only in the canonical subsection.

## Scope

- `claude/rules/pr-guidelines.md` — merge Checklist + Review Criteria into one section, drop the DO/DON'T hard-wrap example block, collapse the in-line restatement of principles.
- `claude/skills/pr-selfcheck/SKILL.md` — update the one-line reference from "Review Criteria" to the new "PR Body Checklist" section name. Scoped in because the rename invalidates the old reference.
- `claude/rules/git-workflow.md` — same class of rename fix: Step 4 sub-bullet referenced "Review Criteria" which no longer exists. Caught by the code review pass on this PR.

Not in scope: moving pr-guidelines.md out of always-on context, AIRULES.md edits, the rest of git-workflow.md (separate items in #211).

## Rule preservation cross-check

Every previously stated rule has a surviving home:

| Previously stated as | Surviving location |
|---|---|
| Checklist 1 (Purpose / motivation) + Review 1 (Reviewer-facing info) + Review 3 (Intent and rationale) | Merged into checklist item 1 (Purpose, scope, intent) |
| Checklist 2 (Scope) | Folded into checklist item 1 |
| Checklist 3 (Sources and references) + Review 2 + Review 4 (Link validity) | Merged into checklist item 2 |
| Checklist 4 (Issue linking) | Retained as standalone checklist item 3 |
| Checklist 5 (Verification) + Review 8 (Verification completeness) | Merged into checklist item 4 (with the "diff / GitHub UI shows this — don't restate" rule consolidated from the old Verification's last sub-bullet) |
| Checklist 6 (Never include in initial draft) + Review 7 (Conciseness, principle restatements) | Merged into checklist item 5; principle restatements collapse to a reference back to the Principles subsection (single source of truth) |
| Review 5 (Title / body / diff consistency) + Review 6 (Diff coverage) | Merged into checklist item 6 |
| DO/DON'T hard-wrap example block | Dropped — the preceding rule sentence ("Write each paragraph as a single line and let the browser wrap it") already states it; the example was visual reinforcement only |
| Five Principles (Why over what, DRY, Inverted pyramid, Progressive disclosure, Diff scope discipline) | Unchanged in the Principles subsection — only the duplicate restatement inside the old Review Criteria #7 is removed |

## Verification

- [x] SKILL.md rename resolves: `/pr-selfcheck` ran twice on this draft (Phase 1 and Phase 3) and both runs completed successfully with the new "PR Body Checklist" section name, proving the rename did not break the skill.
- [ ] Open a fresh Claude Code session after merge and confirm the rule-context footprint reflects the smaller pr-guidelines.md.

## Notes

The DO/DON'T example block was the largest single chunk removed. The remaining length comes from the Principles and Style rules subsections, which are intentionally verbose because they are the canonical rules referenced from the checklist.

A `/pr-selfcheck` run on this draft flagged a hard-wrap violation in this body, but inspection of the raw body (`gh pr view 213 --json body`) confirmed every paragraph is on a single source line; the agent appears to have interpreted browser line-wrap as source line-wrap. Not addressed.
