### PR TITLE
Add rule-authoring conventions to AIRULES.md

### DIFF
--- a/AIRULES.md
+++ b/AIRULES.md
@@ -56,9 +56,11 @@
 - 冗長な記述は省くのを基本とする
 - 特定の AI agent に依存した書き方をしない
 - scope（global / project）を把握し、変更時に明示する
-- Rule file 間の cross-file path 参照は基本入れない（auto-load 同士なら情報追加ゼロ、rename で壊れる、相対パスが symlink 経由だと解決しない）。skill / workflow → rule の framework 名参照（"X defined in `file.md`" 等）は skill が評価対象を名付けるために load-bearing なので残す
+- Rule file 間の cross-file path 参照は基本入れない（auto-load 同士なら情報追加ゼロ、rename で壊れる、相対パスが symlink 経由だと解決しない）
+    - 例外: skill / workflow → rule の framework 名参照（"X defined in `file.md`" 等）は skill が評価対象を名付けるために load-bearing なので残す
 - Loading mechanism についての meta-statement（"already in context"、"auto-loaded as global rule" 等）はどこにも入れない。mechanism 変更で drift し、rule としては noise
-- 番号付き list は Markdown ordered list 構文（`1. 1. 1.`）で書きレンダラーに連番させる。番号を hardcode した見出し（`## 1. Foo` 等）は要素削除時に gap が出ないか確認、出るなら placeholder section で繋ぐか renumber + cross-reference 更新
+- 番号付き list は Markdown ordered list 構文（`1. 1. 1.`）で書きレンダラーに連番させる（要素削除で gap が出ない）
+    - 番号を hardcode した見出し（`## 1. Foo` 等）の場合は要素削除時に gap が出ないか確認、出るなら placeholder section で繋ぐか renumber + cross-reference 更新
 
 ## セッション終了時
 

--- a/AIRULES.md
+++ b/AIRULES.md
@@ -56,6 +56,9 @@
 - 冗長な記述は省くのを基本とする
 - 特定の AI agent に依存した書き方をしない
 - scope（global / project）を把握し、変更時に明示する
+- Rule file 間の cross-file path 参照は基本入れない（auto-load 同士なら情報追加ゼロ、rename で壊れる、相対パスが symlink 経由だと解決しない）。skill / workflow → rule の framework 名参照（"X defined in `file.md`" 等）は skill が評価対象を名付けるために load-bearing なので残す
+- Loading mechanism についての meta-statement（"already in context"、"auto-loaded as global rule" 等）はどこにも入れない。mechanism 変更で drift し、rule としては noise
+- 番号付き list は Markdown ordered list 構文（`1. 1. 1.`）で書きレンダラーに連番させる。番号を hardcode した見出し（`## 1. Foo` 等）は要素削除時に gap が出ないか確認、出るなら placeholder section で繋ぐか renumber + cross-reference 更新
 
 ## セッション終了時
 

--- a/AIRULES.md
+++ b/AIRULES.md
@@ -49,6 +49,8 @@
 - Markdown の強調記法（太字 `**` `__`、イタリック `*` `_`、取り消し線 `~~`）は使用しない。コードブロック・インラインコード内に同記号が現れる場合（コード片・正規表現・ファイル名等）は対象外
 - 事実を述べるとき、ユーザーの誤解・「以前そう思っていた前提」・存在しない基準を打ち消す形（「X ではなく Y」「単一の〜ではなく」等）で書かない。確定した Y を肯定形で直接書く。ただし設計上の代替案を意図的に対比する場合は除く
 - 箇条書きの項目はなるべく小さく、1項目1文を基本とし、文末の句点「。」は付けない（複数文になるなら子箇条書きに分ける）
+- 番号付き list は Markdown ordered list 構文（`1. 1. 1.`）で書きレンダラーに連番させる（要素削除で gap が出ない）
+    - 番号を hardcode した見出し（`## 1. Foo` 等）の場合は要素削除時に gap が出ないか確認、出るなら placeholder section で繋ぐか renumber + cross-reference 更新
 
 ## AI 向けルール・規約ドキュメントの編集
 
@@ -59,8 +61,6 @@
 - Rule file 間の cross-file path 参照は基本入れない（auto-load 同士なら情報追加ゼロ、rename で壊れる、相対パスが symlink 経由だと解決しない）
     - 例外: skill / workflow → rule の framework 名参照（"X defined in `file.md`" 等）は skill が評価対象を名付けるために load-bearing なので残す
 - Loading mechanism についての meta-statement（"already in context"、"auto-loaded as global rule" 等）はどこにも入れない。mechanism 変更で drift し、rule としては noise
-- 番号付き list は Markdown ordered list 構文（`1. 1. 1.`）で書きレンダラーに連番させる（要素削除で gap が出ない）
-    - 番号を hardcode した見出し（`## 1. Foo` 等）の場合は要素削除時に gap が出ないか確認、出るなら placeholder section で繋ぐか renumber + cross-reference 更新
 
 ## セッション終了時
 


### PR DESCRIPTION
## Purpose

Three meta-rules surfaced from PR #214 (extract git-essentials) that govern how to edit Markdown documents (two specific to rule / spec files, one general to any Markdown output). They belong in AIRULES.md, not in session memory: per the existing AIRULES.md guidance ("メモリは AI が次回以降の会話で参照する事実の記録に限定し、行動変容や成果の蓄積には使わない"), behavior-shaping principles live in source-controlled rule files.

The cross-reference rule is the load-bearing one. The other two are adjacent lessons from the same PR.

## Scope

- Modified: `AIRULES.md`
  - "出力フォーマット" section gains one bullet (with a child bullet): ordered-list `1. 1. 1.` rendering, and the caveat for hardcoded numbered headings. This is a general Markdown editing rule that applies to any persisted output, not just AI rule files.
  - "AI 向けルール・規約ドキュメントの編集" section gains two bullets: the cross-file path-reference rule (with a load-bearing exception for skill / workflow → rule references) and the loading-mechanism meta-statement prohibition. These are rule-file-specific.

No other section touched.

## Context for the cross-reference rule

The rule is scoped to the specific case of this dotfiles repo: every file under `claude/rules/*.md` is auto-loaded into the same Claude Code session (native scan of `~/.claude/rules/*.md`), and `AIRULES.md` itself is symlinked into `~/.claude/CLAUDE.md`. In that situation, a path reference like "see `claude/rules/X.md`" embedded in another rule file:

- adds no information for the AI, which already has the target file in context;
- gathers maintenance debt: every rename or move requires updating each reference;
- the relative path does not resolve from the symlinked path the AI sees (`~/.claude/rules/...`).

Broader community advice points the other way for rule systems where files are NOT all loaded into the same context — for those, references with explicit toolchain-resolved import syntax (e.g. `@path/to/file`) are the recommended way to modularize:

- [Best practices for Claude Code (Anthropic)](https://code.claude.com/docs/en/best-practices) describes the `@path/to/import` syntax for CLAUDE.md and warns that "Bloated CLAUDE.md files cause Claude to ignore your actual instructions! ... For each line, ask: 'Would removing this cause Claude to make mistakes?' If not, cut it." That brevity bias supports cutting noise; it doesn't speak directly to the cross-file ref case, but the framing aligns.
- [AGENTS.md Specification: A Research-Backed Guide (ASDLC.io)](https://asdlc.io/practices/agents-md-spec/) recommends progressive disclosure — "if a constraint can be expressed elsewhere, it must not live here" — with references pointing to authority files, but that pattern assumes the agent will follow the reference on demand.

So the rule as written here is a specialization, not a contradiction: when the target is already loaded into the same context, the reference becomes pure noise; when it isn't, an explicit toolchain-resolved import is what to use.

The exception clause ("skill / workflow → rule の framework 名参照は load-bearing なので残す") was discovered the hard way mid-PR #214: removing the SKILL.md reference to `pr-guidelines.md` left the skill unable to express what framework it evaluates against. Captured here so the next session does not repeat the over-removal.

## Verification

- [x] AIRULES.md is symlinked to `~/.claude/CLAUDE.md` (and `~/.codex/AGENTS.md`) via `scripts/deploy.sh`, so the new bullets reach all future Claude Code / Codex sessions automatically without a redeploy needed.
- [ ] After merge, open a fresh Claude Code session and confirm the AIRULES.md content in the system reminder includes the three new bullets in their new homes (one under 出力フォーマット, two under AI 向けルール・規約ドキュメントの編集). Reason this cannot be verified pre-merge: the rule auto-load fires only at session start, so the current session's AIRULES content reflects pre-merge state.

## Notes

A corresponding entry in the user's session memory (`/Users/ikuwow/.claude/projects/-Users-ikuwow-dotfiles/memory/feedback_rule_files_direct_content.md`, plus its pointer in `MEMORY.md`) will be deleted after merge. That cleanup is outside the dotfiles repo, so it is not part of this PR's diff.
