### PR TITLE
Keep PR as draft until the user marks it ready

### DIFF
--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -72,8 +72,8 @@ The implementation work for this branch happens here.
 ## 5. CI Wait & Review
 
 Five phases: pass all mechanical checks, run the code review,
-consolidate fixes, finalize the PR while it stays in draft, then watch
-PR activity until merge.
+consolidate fixes, finalize the PR, then watch PR activity until
+merge.
 
 ### Phase 1: PR self-review + CI (parallel)
 
@@ -112,10 +112,10 @@ The code review is single-pass — do not re-run after fixes.
 `/pr-selfcheck` runs again in Phase 3 to catch inconsistencies
 introduced by review fix changes.
 
-### Phase 4: Finalize PR (stays draft)
+### Phase 4: Finalize PR
 
-Bring the PR into a state where the user can confirm it and mark it
-ready for review themselves. This covers three things:
+Bring the PR into a state where the user can give it a final
+confirmation. This covers three things:
 
 1. Reflect actual verification in the PR body. Update the body to
    describe what was confirmed, with evidence (HTTP status, Location
@@ -127,11 +127,9 @@ ready for review themselves. This covers three things:
 2. Confirm acceptance criteria are met. Cross-check the PR body and
    any linked issue against the actual change. If something is unmet,
    either address it or call it out as out-of-scope / follow-up.
-3. Report completion to the user, keeping the PR in draft. Marking the
-   PR ready for review is the user's gate: the user confirms the
-   finished PR and runs `gh pr ready` themselves. Never run
-   `gh pr ready <number>` autonomously — only when the user explicitly
-   instructs it.
+3. Report completion to the user. Marking the PR ready for review is
+   the user's decision — do not run `gh pr ready` unless explicitly
+   instructed.
 
 Update incrementally as conditions are confirmed (e.g., after Phase 1
 CI passes, after apply / deploy succeeds, after post-deploy
@@ -145,10 +143,9 @@ for the user to remind you. Use the section 6 procedure
 ### Phase 5: Watch PR activity until merge
 
 After Phase 4 completes, arm a persistent `Monitor` to watch the PR
-until it is merged or closed. The PR is still a draft at this point;
-the user marks it ready out-of-band after confirming, and reviewers
-(human, Devin, Copilot) often act soon after that, while CI may still
-be running. The Monitor runs a background poll loop whose stdout
+until it is merged or closed. Reviewers (human, Devin, Copilot) often
+act soon after the user marks the PR ready, and CI may still be
+running. The Monitor runs a background poll loop whose stdout
 lines become notifications, so only an actionable change wakes you —
 quiet periods stay silent (unlike a timer-based `/loop`, which wakes
 on every tick regardless of change).

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -72,8 +72,8 @@ The implementation work for this branch happens here.
 ## 5. CI Wait & Review
 
 Five phases: pass all mechanical checks, run the code review,
-consolidate fixes, finalize the PR, then watch PR activity until
-merge.
+consolidate fixes, finalize the PR for review readiness, then watch
+PR activity until merge.
 
 ### Phase 1: PR self-review + CI (parallel)
 
@@ -112,10 +112,10 @@ The code review is single-pass — do not re-run after fixes.
 `/pr-selfcheck` runs again in Phase 3 to catch inconsistencies
 introduced by review fix changes.
 
-### Phase 4: Finalize PR
+### Phase 4: Finalize PR for review readiness
 
-Bring the PR into a state where the user can give it a final
-confirmation. This covers three things:
+Bring the PR into a state where a human reviewer can act on it. This
+covers three things:
 
 1. Reflect actual verification in the PR body. Update the body to
    describe what was confirmed, with evidence (HTTP status, Location
@@ -156,6 +156,8 @@ on every tick regardless of change).
    - `STATE: MERGED` / `STATE: CLOSED` — top-level `state` changed.
    - `REVIEW: CHANGES_REQUESTED` / `REVIEW: APPROVED` —
      `reviewDecision` changed.
+   - `READY_FOR_REVIEW` — `isDraft` changed from true to false (the
+     user marked the PR ready).
    - `NEW_COMMENT: <author> <path>:<line>` — a review-thread comment
      (GraphQL `reviewThreads` query) whose ID was not seen before, in
      a thread where `isResolved == false` and `isOutdated == false`.
@@ -186,7 +188,7 @@ on every tick regardless of change).
    run history each carry information the others lack):
 
    - PR top-level state:
-     `gh pr view <number> --json state,reviewDecision,latestReviews,statusCheckRollup,comments,updatedAt,mergedAt,headRefName`
+     `gh pr view <number> --json state,isDraft,reviewDecision,latestReviews,statusCheckRollup,comments,updatedAt,mergedAt,headRefName`
    - Review threads with `isResolved` / `isOutdated` (REST
      `/pulls/<num>/comments` does not expose resolution status, so
      use GraphQL):
@@ -220,6 +222,8 @@ on every tick regardless of change).
      applicable — skip them.
    - `REVIEW: APPROVED` (no further action requested): report to the
      user in the next turn, do not act.
+   - `READY_FOR_REVIEW`: the user took the PR out of draft. No action
+     needed — register that review activity is now expected.
    - `CI_FAILURE`: get the `databaseId` from `gh run list` at re-fetch
      (`statusCheckRollup` check names don't always map 1:1 to run
      names), inspect with `gh run view --log-failed <databaseId>`, fix,

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -28,7 +28,7 @@ Follow each step in order. Skip steps that don't apply.
   (Step 6 is a utility section; reference it only if the plan involves
   editing an existing PR/issue body.) Plans must still surface
   scope-specific deviations explicitly — e.g., "skip Step 7 because
-  the branch is kept" or "stop after Step 4, this PR stays as draft".
+  the branch is kept" or "stop after Step 4, skip CI wait & review".
 
 ## 1. Start Work
 
@@ -72,7 +72,7 @@ The implementation work for this branch happens here.
 ## 5. CI Wait & Review
 
 Five phases: pass all mechanical checks, run the code review,
-consolidate fixes, finalize the PR for review readiness, then watch
+consolidate fixes, finalize the PR while it stays in draft, then watch
 PR activity until merge.
 
 ### Phase 1: PR self-review + CI (parallel)
@@ -112,10 +112,10 @@ The code review is single-pass — do not re-run after fixes.
 `/pr-selfcheck` runs again in Phase 3 to catch inconsistencies
 introduced by review fix changes.
 
-### Phase 4: Finalize PR for review readiness
+### Phase 4: Finalize PR (stays draft)
 
-Bring the PR into a state where a human reviewer can act on it. This
-covers three things:
+Bring the PR into a state where the user can confirm it and mark it
+ready for review themselves. This covers three things:
 
 1. Reflect actual verification in the PR body. Update the body to
    describe what was confirmed, with evidence (HTTP status, Location
@@ -127,8 +127,11 @@ covers three things:
 2. Confirm acceptance criteria are met. Cross-check the PR body and
    any linked issue against the actual change. If something is unmet,
    either address it or call it out as out-of-scope / follow-up.
-3. Mark the PR ready for review. Run `gh pr ready <number>` to take it
-   out of draft. Skip if the user asked to keep it as draft.
+3. Report completion to the user, keeping the PR in draft. Marking the
+   PR ready for review is the user's gate: the user confirms the
+   finished PR and runs `gh pr ready` themselves. Never run
+   `gh pr ready <number>` autonomously — only when the user explicitly
+   instructs it.
 
 Update incrementally as conditions are confirmed (e.g., after Phase 1
 CI passes, after apply / deploy succeeds, after post-deploy
@@ -141,9 +144,10 @@ for the user to remind you. Use the section 6 procedure
 
 ### Phase 5: Watch PR activity until merge
 
-After Phase 4 marks the PR ready for review, arm a persistent
-`Monitor` to watch the PR until it is merged or closed. Reviewers
-(human, Devin, Copilot) often act soon after ready, and CI may still
+After Phase 4 completes, arm a persistent `Monitor` to watch the PR
+until it is merged or closed. The PR is still a draft at this point;
+the user marks it ready out-of-band after confirming, and reviewers
+(human, Devin, Copilot) often act soon after that, while CI may still
 be running. The Monitor runs a background poll loop whose stdout
 lines become notifications, so only an actionable change wakes you —
 quiet periods stay silent (unlike a timer-based `/loop`, which wakes


### PR DESCRIPTION
## Why

Phase 4 of the git workflow had the agent run `gh pr ready` autonomously once mechanical checks and the code review passed. In practice the ready-for-review flip is a human gate: the user wants to confirm the finished PR before reviewers are pulled in. This PR moves that gate to the user — the workflow now stops right before `gh pr ready`, keeps the PR in draft, and reports completion instead.

## Design notes

- Phase 4 still updates verification evidence and cross-checks acceptance criteria autonomously; only the ready flip leaves the agent's responsibility
- Phase 5 (Monitor watch) still arms right after Phase 4 while the PR is a draft, so CI failures and the post-ready review activity are caught without re-prompting the agent; a READY_FOR_REVIEW event lets the agent register the user's manual flip
- Wording is deliberately compact: draft creation is instructed once (Step 4) and the user gate is stated once (Phase 4 item 3); other sections avoid restating the draft state

## Verification

- Confirmed via `git grep -n 'pr ready' claude/rules/` that the only remaining `gh pr ready` occurrences are inside the new user-gate instruction; no phase instructs the agent to flip ready anymore
- Exercised the new Phase 5 event in this session: armed the Monitor with `isDraft` tracking against this PR while still in draft
- [ ] Next workflow run stops at draft and reports completion without running `gh pr ready` (only confirmable by exercising a future workflow run, so left for the user)
