### PR TITLE
Add SubagentStart sentinel-read hook to cross-repo-reader agent

### DIFF
--- a/claude/agents/cross-repo-reader.md
+++ b/claude/agents/cross-repo-reader.md
@@ -3,6 +3,11 @@ name: cross-repo-reader
 description: Use when the parent needs to read or search code in another GitHub repository that is already cloned locally via ghq. The agent only reads existing clones; if the repo is not in ghq, it returns "not available locally" and the parent decides next steps. Examples — "how does upstream X implement Y", "find usages of Z across foo/bar", "summarize the architecture of foo/bar".
 tools: Bash, Read, Grep, Glob
 model: sonnet
+hooks:
+  SubagentStart:
+    - hooks:
+        - type: command
+          command: "echo '{\"hookSpecificOutput\": {\"hookEventName\": \"SubagentStart\", \"additionalContext\": \"First action: Read a file directly at the target repository root (e.g. README.md) so a single permission prompt grants read access to the whole repository. Even when the task instructions list specific files, always perform this sentinel read first.\"}}'"
 ---
 
 You are a cross-repository file reader. Your job is to locate a repository already cloned on the local filesystem, optionally sync it, read what the parent asked for, and return a concise factual answer with citations. You do not clone, design, recommend, or modify.
@@ -26,7 +31,7 @@ You are a cross-repository file reader. Your job is to locate a repository alrea
    `git -C <path> pull --ff-only`
    - Only pull when the current branch is the default branch (verify with `git -C <path> symbolic-ref refs/remotes/origin/HEAD --short` and `git -C <path> rev-parse --abbrev-ref HEAD`) and there are no unpushed or uncommitted changes (`git -C <path> status --porcelain`).
    - If `--ff-only` fails, do not force. Proceed with the existing state and note this in the output.
-3. Read any file located directly at the repo root (not in a subdirectory; e.g., `README.md`, `LICENSE`, `.gitignore`) before any other reads, so a single permission prompt covers the whole repo. Stop if the parent denies.
+3. Read any file located directly at the repo root (not in a subdirectory; e.g., `README.md`, `LICENSE`, `.gitignore`) before any other reads, so a single permission prompt covers the whole repo. Perform this sentinel read even when the task instructions already list specific files to read. Stop if the parent denies.
 4. Read files using the Read tool with the absolute ghq path. For content searches, prefer `git -C <path> grep` via Bash — the built-in Grep/Glob tools may be scoped to the working tree and are not guaranteed to reach a path outside it. Use `ls` or `find` via Bash for file enumeration when Glob does not work. The global rule against `find` in AIRULES applies to in-tree exploration, not to cross-repo paths the built-in tools cannot reach.
 
 # Output format

--- a/claude/agents/cross-repo-reader.md
+++ b/claude/agents/cross-repo-reader.md
@@ -7,7 +7,7 @@ hooks:
   SubagentStart:
     - hooks:
         - type: command
-          command: "echo '{\"hookSpecificOutput\": {\"hookEventName\": \"SubagentStart\", \"additionalContext\": \"First action: Read a file directly at the target repository root (e.g. README.md) so a single permission prompt grants read access to the whole repository. Even when the task instructions list specific files, always perform this sentinel read first.\"}}'"
+          command: "echo '{\"hookSpecificOutput\": {\"hookEventName\": \"SubagentStart\", \"additionalContext\": \"Before reading any other file, Read one file located directly at the target repository root (e.g. README.md) so a single permission prompt grants read access to the whole repository. Do this sentinel read even when the task instructions list specific files to read.\"}}'"
 ---
 
 You are a cross-repository file reader. Your job is to locate a repository already cloned on the local filesystem, optionally sync it, read what the parent asked for, and return a concise factual answer with citations. You do not clone, design, recommend, or modify.

--- a/claude/rules/pr-guidelines.md
+++ b/claude/rules/pr-guidelines.md
@@ -143,6 +143,13 @@ once and applies to both perspectives.
      - Per-item rendering of a pre-flight checklist when every item
        is "N/A" — collapse to one line
    - Bullets are few and meaningful, each conveying a distinct point.
+   - Length budget: the main description section (実装内容 or
+     equivalent) stays within roughly 10 lines — one background
+     paragraph plus change bullets. When the whole body excluding
+     template-mandated sections exceeds ~30 lines, treat it as a
+     Progressive disclosure violation: compress mechanism deep-dives,
+     history, and repeated explanations into a link or delete them.
+     `/pr-selfcheck` reports budget overruns as Should Fix.
 
 6. Title / body / diff consistency
    - The title accurately reflects the change.


### PR DESCRIPTION
## Why

The cross-repo-reader agent reads repositories outside the working tree, so its first Read triggers a permission prompt. The Lookup procedure already tells it to read a repo-root file first so a single prompt covers the whole repository, but in practice the agent sometimes skips straight to the files listed in the task instructions, causing repeated prompts. This change reinforces the rule at subagent start; the hook was drafted manually first and lands here in English per the repository language rule.

## What

A SubagentStart hook injects the sentinel-read instruction as additionalContext, and Lookup procedure step 3 now states the rule applies even when the task instructions already list specific files.

## Verification

- Confirmed the hook's `echo` emits valid JSON accepted by `jq` (parsed successfully, `hookEventName` and `additionalContext` fields intact)
- [ ] Spawn a cross-repo-reader task and confirm the injected context appears and only one read permission prompt is shown (requires a live session)

## Notes

The `claude/rules/pr-guidelines.md` hunk in the diff is commit 22c27cf, which is on local main ahead of origin/main; it drops out of the diff once main is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
