### PR TITLE
Emit NEW_REVIEW events for COMMENTED-state PR reviews

### DIFF
--- a/bin/pr-monitor
+++ b/bin/pr-monitor
@@ -36,7 +36,8 @@ prev_ci_sha=""
 declare -A seen_runs=()
 seen_comments="$(mktemp)"
 seen_top_comments="$(mktemp)"
-trap 'rm -f "$seen_comments" "$seen_top_comments"' EXIT
+seen_reviews="$(mktemp)"
+trap 'rm -f "$seen_comments" "$seen_top_comments" "$seen_reviews"' EXIT
 
 # First-poll seeding: do not emit events for state that already held at
 # arm time. Only transitions during this monitor's lifetime should wake
@@ -53,6 +54,17 @@ threads_query='query($owner:String!,$repo:String!,$num:Int!){
           isOutdated
           comments(first:100){ nodes{ id author{login} path line } }
         }
+      }
+    }
+  }
+}'
+
+# shellcheck disable=SC2016 # GraphQL query: $vars are query variables
+reviews_query='query($owner:String!,$repo:String!,$num:Int!){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$num){
+      reviews(first:100){
+        nodes{ id state body author{login} }
       }
     }
   }
@@ -150,6 +162,20 @@ while true; do
 
   fresh_top="$(echo "$pr_json" | jq -r --arg me "$me" '.comments[]? | select(.author.login != $me) | "\(.id)\t\(.author.login)"' 2>/dev/null || true)"
   emit_new "$fresh_top" "$seen_top_comments" "NEW_TOP_COMMENT"
+
+  # Reviews API surfaces `state=COMMENTED` reviews (e.g. Devin Review, or a
+  # human submitting "Comment") that neither change `reviewDecision` nor
+  # appear in reviewThreads / issue comments. Empty-body reviews are
+  # filtered out: empty APPROVED / CHANGES_REQUESTED are already covered
+  # by the `REVIEW:` decision event, and an empty COMMENTED has nothing
+  # to read.
+  reviews_json="$(gh api graphql -f owner="$owner" -f repo="$repo" -F num="$pr" -f query="$reviews_query" 2>/dev/null || true)"
+  fresh_reviews="$(echo "$reviews_json" | jq -r --arg me "$me" '
+    .data.repository.pullRequest.reviews.nodes[]
+    | select(.author.login != $me and .state != "PENDING" and (.body // "") != "")
+    | "\(.id)\t\(.author.login)\t\(.state)"' \
+    2>/dev/null || true)"
+  emit_new "$fresh_reviews" "$seen_reviews" "NEW_REVIEW"
 
   case "$state" in
     MERGED|CLOSED) exit 0 ;;

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -163,6 +163,12 @@ on every tick regardless of change).
      false` and `isOutdated == false`.
    - `NEW_TOP_COMMENT: <author>` — a top-level PR comment whose ID
      was not seen before. Not gated by resolution state.
+   - `NEW_REVIEW: <author> <state>` — a PR review (summary body) whose
+     ID was not seen before. `state` is `COMMENTED` / `APPROVED` /
+     `CHANGES_REQUESTED` / `DISMISSED`. Catches reviews that do not
+     change `reviewDecision` (e.g. Devin Review posted as `COMMENTED`,
+     or a human submitting "Comment"). Empty-body reviews are filtered
+     out.
    - `CI_FAILURE: <check name>` — a new `FAILURE` from `gh run list`
      on the PR's head SHA.
 
@@ -184,6 +190,9 @@ on every tick regardless of change).
    - Workflow run history on the PR branch (catches CI cycles
      `statusCheckRollup` doesn't show — e.g. older runs, re-run jobs):
      `gh run list --branch <headRefName> --json databaseId,name,status,conclusion,createdAt,headSha,workflowName --limit 20`
+   - PR reviews (the event line carries only author + state; re-fetch
+     for body):
+     `gh api repos/<owner>/<repo>/pulls/<number>/reviews`
 
 1. On each event notification, re-fetch full detail with the three
    polling commands in step 1 (the event line is only a signal), then
@@ -200,12 +209,13 @@ on every tick regardless of change).
 1. React by content, not event type. `NEW_COMMENT` is pre-filtered by
    the monitor to unresolved, non-outdated threads; `NEW_TOP_COMMENT`
    is not, so classify it by content:
-   - Clear fix request (`CHANGES_REQUESTED`, a `NEW_COMMENT`, or a
-     `NEW_TOP_COMMENT` asking for a change — from a human or an
-     automated reviewer like Devin or Copilot): modify code and push,
-     subject to the step-3 pre-push checks and the step-5 cap. For a
-     `NEW_COMMENT`, if the re-fetched thread is now `isResolved` or
-     `isOutdated`, it was handled in the interim — skip it.
+   - Clear fix request (`CHANGES_REQUESTED`, a `NEW_COMMENT`, a
+     `NEW_TOP_COMMENT`, or a `NEW_REVIEW` asking for a change — from a
+     human or an automated reviewer like Devin or Copilot): modify code
+     and push, subject to the step-3 pre-push checks and the step-5 cap.
+     For a `NEW_COMMENT`, if the re-fetched thread is now `isResolved`
+     or `isOutdated`, it was handled in the interim — skip it. For a
+     `NEW_REVIEW`, re-fetch the review body to classify intent.
    - Question, nit, or ambiguous intent: reply via `gh pr comment`,
      do not push.
    - `READY_FOR_REVIEW`: the user took the PR out of draft; no action,


### PR DESCRIPTION
Closes #223

## Background

`pr-monitor` did not detect PR reviews submitted with `state=COMMENTED` (e.g. Devin Review, or a human submitting "Comment"). Such reviews do not change `reviewDecision`, do not surface in `reviewThreads` (those only carry inline comments), and do not appear in issue `comments[]` (which is the issue-comment API, not the reviews API). All three existing review-related code paths missed them.

## Changes

- `bin/pr-monitor`: add a new polling path that queries `pullRequest.reviews` via GraphQL and emits unseen review IDs as `NEW_REVIEW: <author> <state>` through the existing `emit_new` helper
- Filter out self-author reviews, `PENDING` state, and empty-body reviews. Empty-body `APPROVED` / `CHANGES_REQUESTED` are already covered by the existing `REVIEW:` decision event, and an empty-body `COMMENTED` carries nothing to read
- `claude/rules/git-workflow.md` Phase 5: sync docs with the implementation (event list, polling commands, fix-request classification)

A review with a non-empty body and an effective decision emits both `REVIEW: APPROVED` (or `CHANGES_REQUESTED`) and `NEW_REVIEW: <author> <state>` — by design, so neither the decision nor the body is missed.

## Verification

- [x] `shellcheck bin/pr-monitor` — no warnings
- [x] `bash -n bin/pr-monitor` — syntax OK
- [x] Ran the new `reviews_query` against PR #222 via `gh api graphql`; the response shape matches the jq filter (the PR has zero reviews so `nodes` is `[]`, which still confirms the query path is valid)
- [ ] End-to-end dry-run on this PR. Steps:
  1. Run `pr-monitor 224 10` in the foreground and wait until the first poll completes (no events seeded)
  2. From a separate account (or any account where `gh api user --jq .login` does not match `me`), run `gh pr review 224 --comment --body "monitor smoke test"`
  3. Within the next poll interval (≤10s), the monitor should emit exactly one line: `NEW_REVIEW: <reviewer-login> COMMENTED`
  4. Submit a second review with `--approve --body "..."` and confirm both `REVIEW: APPROVED` and `NEW_REVIEW: <reviewer-login> APPROVED` are emitted (one per review id, one per decision change)

Note on docs: the polling-commands section uses the REST endpoint (`gh api repos/<owner>/<repo>/pulls/<n>/reviews`) for re-fetching the review body on a reactor turn, even though the monitor itself uses GraphQL for polling. REST is convenient for one-shot detail fetches; the GraphQL form (`reviews(first:100){ nodes{ body author{login} state } }`) is equivalent if preferred.
