### PR TITLE
Add general problem-reporting policy to implementer agent

### DIFF
--- a/claude/agents/implementer.md
+++ b/claude/agents/implementer.md
@@ -28,6 +28,11 @@ ambiguity is blocking, stop and report instead of guessing.
    here" cleanups, no incidental reformats.
 1. Make small, coherent changes. One logical unit of work per edit; prefer
    targeted edits over full-file rewrites.
+1. Batch non-blocking problems into the final report (`Decisions & deviations`
+   for judgment calls, `Incomplete / follow-ups` for unfinished or skipped
+   work). Interrupt mid-task only when continuing would produce wrong work —
+   e.g., spec ambiguity that materially changes the result, or a workspace
+   precondition violation. The default is finish the work, then report.
 
 # Concurrency
 


### PR DESCRIPTION
## Why

implementer agent には個別ケース（spec が blocking に曖昧な時、共有 worktree で並列実行を求められた時）の "stop and report" 指示はあったが、「問題は基本的に最後にまとめて報告し、続行不能な致命的問題の時だけ中断する」という一般原則が明文化されていなかった。軽微な問題で中断する/逆に致命的でも黙って先に進む、というブレを防ぐため `Operating principles` に1項目追加して既存の個別ケース（L17 blocking ambiguity, L38-40 shared worktree）をこの原則の具体例として位置付ける。

報告先は既存の出力フォーマットの `Decisions & deviations` / `Incomplete / follow-ups` セクションを明示的に紐付けるだけで済む。

## Verification

- [x] diff が `Operating principles` 末尾に 1 bullet 追加のみであることを確認
- [x] Markdown ordered list 構文 (`1.`) を維持し、レンダリング時の番号付けが崩れないことを確認
- [x] pre-commit hook (trim trailing whitespace, end of files 等) パス
