### PR TITLE
Default git-worktree-create base to origin default branch

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -9,7 +9,7 @@ Custom executable scripts deployed to `~/bin/` via symlinks.
 | `aws-mfa` | Automate AWS session token acquisition via MFA |
 | `install-aimsg-hook.sh` | Symlink `~/.config/git/hooks/prepare-commit-msg` into the current repo's `.git/hooks/` to enable the AI commit-message drafter |
 | `git-cleanup-branches` | Delete unused local branches (merged, squash-merged, upstream gone) and prune stale worktree entries |
-| `git-worktree-create` | Create a git worktree with a sanitized directory name under `.worktrees/` |
+| `git-worktree-create` | Create a git worktree under `.worktrees/`. Defaults to branching from `origin/<default>`; pass a second argument to override the base |
 | `pipectlx` | PipeCD CLI wrapper that auto-injects API key and server address from config |
 | `ssm` | Start an AWS SSM session by instance ID or Name tag |
 | `vssh` | SSH into a Vagrant machine using sshrc with auto-generated ssh-config |

--- a/bin/git-worktree-create
+++ b/bin/git-worktree-create
@@ -1,12 +1,17 @@
 #!/bin/bash
 
 # Create a git worktree with a sanitized directory name under .worktrees/
-# Usage: git-worktree-create <branch-name>
+# Usage: git-worktree-create <branch-name> [base]
+#
+# If <base> is omitted, the worktree branches from origin's default branch
+# (e.g. origin/main). The remote tip is fetched first so the new branch
+# reflects the latest upstream state regardless of which branch you're
+# currently on. If <base> is given, it is used verbatim (no fetch).
 
 set -eu
 
-if [ $# -ne 1 ]; then
-  echo "Usage: git-worktree-create <branch-name>" >&2
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: git-worktree-create <branch-name> [base]" >&2
   exit 1
 fi
 
@@ -16,11 +21,25 @@ if [ "$(pwd)" != "$(git rev-parse --show-toplevel)" ]; then
 fi
 
 branch="$1"
+
+if [ $# -eq 2 ]; then
+  base="$2"
+else
+  if ! head_ref="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null)"; then
+    echo "Error: origin/HEAD is not set; cannot resolve default branch" >&2
+    echo "Hint: run 'git remote set-head origin -a' first" >&2
+    exit 1
+  fi
+  default_branch="${head_ref#refs/remotes/origin/}"
+  git fetch origin "$default_branch"
+  base="origin/${default_branch}"
+fi
+
 sanitized="$(echo "$branch" | tr '/' '-')"
 date_str="$(date +%Y%m%d)"
 dir=".worktrees/${date_str}-${sanitized}"
 
-git worktree add -b "$branch" "$dir"
+git worktree add -b "$branch" "$dir" "$base"
 echo ""
 echo "Run this to start working in the worktree:"
 echo "  cd $dir"

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -34,8 +34,10 @@ Follow each step in order. Skip steps that don't apply.
 
 1. Pull the latest default branch:
    `git pull`
-1. Create a worktree and branch:
+1. Create a worktree and branch (defaults to branching from origin's default branch):
    `git-worktree-create <branch-name>`
+   - To branch from somewhere other than origin's default:
+     `git-worktree-create <branch-name> <base>`
 1. Follow the command shown in the script output to move into the worktree
 1. If the project rules explicitly prohibit worktrees, create a branch only:
    `git checkout -b <branch-name>`


### PR DESCRIPTION
## Why

`git-worktree-create` previously branched from `HEAD`, so running it while sitting on a feature branch produced a worktree based on that branch instead of `main`. The mistake was easy to miss and the recovery was always the same: throw away the worktree and recreate it. Forcing the default to come from origin's default branch eliminates that class of mistake.

## What changed

- Default base (1-arg form) is now `origin/<default>`, resolved via `git symbolic-ref refs/remotes/origin/HEAD`. The script fetches that ref before `git worktree add` so the new branch reflects the latest remote tip regardless of the local checkout.
- Optional 2nd argument lets the caller pick any base (`origin/foo`, local branch, sha, tag) for the deliberate "branch from somewhere else" case. The fetch is skipped in that path — the caller named the ref, trust it.
- `origin/HEAD` unset is a hard error with a hint pointing at `git remote set-head origin -a`. Network failure during fetch also fails hard (no fallback), matching the AGENTS.md "let bash propagate errors under `set -eu`" stance.

## Verification

- [x] `bin/git-worktree-create test/from-main` from a feature branch fetched `origin/main` and created `.worktrees/20260623-test-from-main` at `01d1894` (origin/main HEAD).
- [x] `bin/git-worktree-create test/from-explicit HEAD~1` skipped fetch and pointed at `a08a542` (the requested ref).
- [x] `bin/git-worktree-create test/bad-base nonexistent-ref` exited non-zero with `fatal: invalid reference`.
- [x] No-arg and 3-arg invocations print the usage line and exit 1.
- [x] `shellcheck bin/git-worktree-create` clean.
- [x] `pre-commit run --all-files` passes.
- [x] `origin/HEAD` unset path — not reproduced locally (would require detaching the symbolic ref). Covered by code review.
