### PR TITLE
Fix tmux version-check typo, resolve shellcheck warnings

### DIFF
--- a/.functions
+++ b/.functions
@@ -115,7 +115,7 @@ if [ ! "$(command -v aps)" ]; then
 
   aps() {
     if [ ! "$(command -v fzf)" ]; then
-      echo "Error: ${FUNCNAME} requires fzf executable."
+      echo "Error: ${FUNCNAME[0]} requires fzf executable."
       return 1
     fi
     query="$1"
@@ -192,7 +192,7 @@ fi
 if [ ! "$(command -v gps)" ]; then
   gps() {
     if [ ! "$(command -v fzf)" ]; then
-      echo "Error: ${FUNCNAME} requires fzf executable."
+      echo "Error: ${FUNCNAME[0]} requires fzf executable."
       return 1
     fi
     query="$1"
@@ -221,7 +221,7 @@ EOF
     fi
 
     DUMMY_CONFIG_NAME="none"
-    if [ ! "$(gcloud config configurations list --format='value(name)' | grep "^${DUMMY_CONFIG_NAME}$")" ]; then
+    if ! gcloud config configurations list --format='value(name)' | grep -q "^${DUMMY_CONFIG_NAME}$"; then
       gcloud config configurations create "$DUMMY_CONFIG_NAME"
     fi
 
@@ -258,7 +258,8 @@ EOF
     fi
 
     gcloud config configurations activate "$config"
-    export GC_ACTIVE_CONFIG="$(cat "${CLOUDSDK_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/gcloud}/active_config")"
+    GC_ACTIVE_CONFIG="$(cat "${CLOUDSDK_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/gcloud}/active_config")"
+    export GC_ACTIVE_CONFIG
     echo "Google Cloud config set: $config"
   }
 fi

--- a/xdg-config/tmux/tmux.conf
+++ b/xdg-config/tmux/tmux.conf
@@ -24,7 +24,7 @@ if-shell '[ "$(echo "$TMUX_VERSION >= 2.9" | bc)" == 1 ]' " \
   set-window-option -g window-status-current-style bright;\
 "
 
-if-shell '[ "$(echo "$TMUX_VERSION < 2.9" | bc)"J == 1 ]' " \
+if-shell '[ "$(echo "$TMUX_VERSION < 2.9" | bc)" == 1 ]' " \
   set-window-option -g window-status-fg white; \
   set-window-option -g window-status-bg default; \
   set-window-option -g window-status-attr dim; \


### PR DESCRIPTION
## Purpose\n\nWeekly routine: fix a typo in tmux config and resolve shellcheck warnings in shell functions.\n\n## Changes\n\n### Stray `J` in tmux version check (xdg-config/tmux/tmux.conf)\n\nThe pre-2.9 compatibility block had `)"J == 1` instead of `)" == 1`. The stray `J` made the condition always false, so the old-style `window-status-fg`/`window-status-attr` options were never applied on tmux < 2.9.\n\n### shellcheck fixes in .functions\n\n- `${FUNCNAME}` replaced with `${FUNCNAME[0]}` in `aps()` and `gps()` (SC2128: expanding an array without an index only gives the first element)\n- `gps()` config existence check rewritten from `[ ! \"$(... | grep ...)\" ]` to `! ... | grep -q ...` (SC2143: use grep exit code directly)\n- `export GC_ACTIVE_CONFIG=\"$(cat ...)\"` split into separate declaration and export (SC2155: declare and assign separately to avoid masking return values)\n\n## Verification\n\n- shellcheck confirms SC2128, SC2143, SC2155 are resolved; no new warnings introduced\n- All changes are behavior-preserving on the success path\n- The tmux fix only affects tmux versions older than 2.9 (released 2019); the >= 2.9 block was unaffected by the typo\n\n## Past feedback\n\nPRs #138, #174, #218 (all merged, no comments). No rejected PRs or negative feedback to incorporate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTe3YHt8JK9DodsZ4CygDw)_