### PR TITLE
Add textlint MCP server at user scope

### DIFF
--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "preset-jtf-style": true,
+    "preset-ja-technical-writing": true,
+    "preset-ai-writing": true
+  }
+}

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -106,6 +106,7 @@
       "mcp__jetbrains",
       "mcp__Context7",
       "mcp__claude_ai_Context7",
+      "mcp__textlint",
       "mcp__notion__notion-search",
       "mcp__mcp-obsidian__obsidian_list_files_in_vault",
       "mcp__mcp-obsidian__obsidian_list_files_in_dir",

--- a/scripts/claude-code-setup.sh
+++ b/scripts/claude-code-setup.sh
@@ -33,6 +33,10 @@ mcp_add Context7 '{"command":"npx","args":["-y","@upstash/context7-mcp"]}'
 # they're not secret and Claude Code's diagnostics warn about missing env vars.
 # shellcheck disable=SC2016
 mcp_add mcp-obsidian '{"command":"uvx","args":["mcp-obsidian"],"env":{"OBSIDIAN_API_KEY":"${OBSIDIAN_API_KEY}","OBSIDIAN_HOST":"127.0.0.1","OBSIDIAN_PORT":"27123"}}'
+# textlint MCP: Japanese proofreading. `npx -p` pulls textlint and presets into a
+# shared cache (~/.npm/_npx/<hash>) so sibling resolution finds the rules.
+# No global install or local node_modules needed.
+mcp_add textlint "{\"command\":\"npx\",\"args\":[\"-y\",\"-p\",\"textlint\",\"-p\",\"textlint-rule-preset-jtf-style\",\"-p\",\"textlint-rule-preset-ja-technical-writing\",\"-p\",\"textlint-rule-preset-ai-writing\",\"textlint\",\"--mcp\",\"--config\",\"$HOME/.textlintrc.json\"]}"
 
 # --- Plugins ---
 # Ensure marketplaces exist (required on fresh environments like Claude Code web).

--- a/scripts/claude-code-setup.sh
+++ b/scripts/claude-code-setup.sh
@@ -33,9 +33,7 @@ mcp_add Context7 '{"command":"npx","args":["-y","@upstash/context7-mcp"]}'
 # they're not secret and Claude Code's diagnostics warn about missing env vars.
 # shellcheck disable=SC2016
 mcp_add mcp-obsidian '{"command":"uvx","args":["mcp-obsidian"],"env":{"OBSIDIAN_API_KEY":"${OBSIDIAN_API_KEY}","OBSIDIAN_HOST":"127.0.0.1","OBSIDIAN_PORT":"27123"}}'
-# textlint MCP: Japanese proofreading. `npx -p` pulls textlint and presets into a
-# shared cache (~/.npm/_npx/<hash>) so sibling resolution finds the rules.
-# No global install or local node_modules needed.
+# textlint resolves presets via Node sibling lookup, so each preset needs its own -p.
 mcp_add textlint "{\"command\":\"npx\",\"args\":[\"-y\",\"-p\",\"textlint\",\"-p\",\"textlint-rule-preset-jtf-style\",\"-p\",\"textlint-rule-preset-ja-technical-writing\",\"-p\",\"textlint-rule-preset-ai-writing\",\"textlint\",\"--mcp\",\"--config\",\"$HOME/.textlintrc.json\"]}"
 
 # --- Plugins ---

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -35,6 +35,7 @@ link .gemrc                   "$HOME/.gemrc"
 link .default-gems            "$HOME/.default-gems"
 link .default-npm-packages    "$HOME/.default-npm-packages"
 link .default-python-packages "$HOME/.default-python-packages"
+link .textlintrc.json         "$HOME/.textlintrc.json"
 
 # XDG config: all subdirs in xdg-config/ auto-discovered
 mkdir -p "$XDG_CONFIG_HOME"


### PR DESCRIPTION
## Why

Wanted textlint available to Claude Code as a Japanese proofreading MCP server across every project, without each repo having to set up textlint locally.

## Approach

User-scope MCP entry that runs `npx -p` with textlint and the three presets (JTF style, ja-technical-writing, ai-writing) in one command. That keeps the dotfiles repo free of `node_modules` and avoids `npm install -g` while still letting the global `~/.textlintrc.json` drive configuration. npx caches the resolved package set in `~/.npm/_npx/<hash>` so only the first launch pays the download cost.

Node version is intentionally not pinned in the MCP command; `.tool-versions` already pins `nodejs 22.16.0` via mise, so a bare `npx` is enough and stays portable across hosts (ARM/Intel/Linux).

All four tools the textlint MCP server exposes are read-only (the `getLintFixed*` tools return corrected content without writing files), so `claude/settings.json` allows `mcp__textlint` server-wide alongside the existing `mcp__Context7` / `mcp__deepwiki` entries.

## Verification

- [x] `shellcheck scripts/claude-code-setup.sh scripts/deploy.sh` — clean
- [x] `./scripts/deploy.sh` — created `~/.textlintrc.json` symlink into the repo file (`ls -la ~/.textlintrc.json` confirms target)
- [x] `./scripts/claude-code-setup.sh` — `claude mcp add-json` succeeded idempotently
- [x] `claude mcp list` shows `textlint: ... - ✔ Connected`
- [x] Smoke test produced 3 findings from ja-technical-writing and ai-writing presets, confirming all three presets resolve inside the npx-managed cache:

```sh
echo 'この機能を使用することができます。' | npx -y -p textlint -p textlint-rule-preset-jtf-style -p textlint-rule-preset-ja-technical-writing -p textlint-rule-preset-ai-writing textlint --config ~/.textlintrc.json --stdin --stdin-filename test.md
```

## Notes / follow-up

- A guideline in `AIRULES.md` to route Japanese markdown lint requests to this MCP server is deliberately out of scope here; will be added once the server has shaken out in real use.
- mise migration (PR #111) is independent; this PR assumes the current node setup on PATH.
