### PR TITLE
Add interim rule for PR review thread response

### DIFF
--- a/claude/rules/pr-review-response.md
+++ b/claude/rules/pr-review-response.md
@@ -1,0 +1,75 @@
+# PR Review Response
+
+How to reply to and resolve PR review thread comments.
+Scope: review-thread comments only. Top-level PR comments
+(`gh pr comment`) are out of scope.
+
+This is the interim rule-only form of ikuwow/dotfiles#126. A future
+script (`bin/gh-pr-thread-{reply,resolve}`) will absorb the bot check
+and replace these instructions.
+
+## Targeting policy
+
+Reply to and resolve only bot comments. Never reply to or resolve a
+human comment by mutation. For human comments, summarize the content
+to the user and wait for an explicit instruction.
+
+A thread's author is the author of the thread's first comment.
+
+Bot author: GraphQL `author.__typename == "Bot"`. Known logins
+include `github-actions`, `dependabot`, `copilot-pull-request-reviewer`,
+`renovate`, `devin-ai-integration` (note: GraphQL `author.login` has no
+`[bot]` suffix even when the UI shows one). `__typename` is the
+authoritative signal; the login list is a sanity check.
+
+Anything not classified as bot is treated as human.
+
+## Step 1: List review threads (read-only)
+
+Extend the `reviewThreads` query in `git-workflow.md` with
+`author{login __typename}` on each comment node. Example:
+
+```bash
+gh api graphql -f query='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$num){reviewThreads(first:100){nodes{id isResolved isOutdated comments(first:100){nodes{id author{login __typename} body path line}}}}}}}' -f owner=<owner> -f repo=<repo> -F num=<number>
+```
+
+Filter to actionable threads: `isResolved == false` and
+`isOutdated == false`. Classify each by the first comment's
+`author.__typename`.
+
+## Step 2: Reply to a bot thread
+
+Only after confirming the first comment is a bot. Mutation is
+manually approved every time (`approve_gh_graphql_readonly.py` only
+auto-approves read-only queries) — re-verify the author at the
+approval prompt.
+
+```bash
+gh api graphql -f query='mutation($threadId:ID!,$body:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId,body:$body}){comment{id url}}}' -f threadId=<thread id> -f body=<reply body>
+```
+
+## Step 3: Resolve a bot thread
+
+After the reply lands, resolve the same thread:
+
+```bash
+gh api graphql -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id isResolved}}}' -f threadId=<thread id>
+```
+
+## Human threads
+
+Do not call `addPullRequestReviewThreadReply` or `resolveReviewThread`
+for a human-authored thread. Surface the comment content to the user
+with thread id, path, line, and body excerpt, then stop.
+
+If the user explicitly asks to reply to a specific human thread,
+present the draft reply text, wait for approval, then issue the
+mutation in step 2. Resolution of a human thread stays with the user.
+
+## Forbidden shortcuts
+
+- Skipping the bot check before any mutation
+- Using `gh pr comment` to work around the human-thread restriction
+  (top-level comments are a different surface, not a substitute reply)
+- Using `--field` / `-F` / `--raw-field` for the `query` argument
+  (see `gh-graphql.md`)

--- a/claude/rules/pr-review-response.md
+++ b/claude/rules/pr-review-response.md
@@ -73,3 +73,10 @@ mutation in step 2. Resolution of a human thread stays with the user.
   (top-level comments are a different surface, not a substitute reply)
 - Using `--field` / `-F` / `--raw-field` for the `query` argument
   (see `gh-graphql.md`)
+
+## References
+
+- `addPullRequestReviewThreadReply`: https://docs.github.com/en/graphql/reference/mutations#addpullrequestreviewthreadreply
+- `resolveReviewThread`: https://docs.github.com/en/graphql/reference/mutations#resolvereviewthread
+- `PullRequestReviewThread` (fields used: `id`, `isResolved`, `isOutdated`, `comments`): https://docs.github.com/en/graphql/reference/objects#pullrequestreviewthread
+- `Bot` vs `User` (`__typename` source): https://docs.github.com/en/graphql/reference/interfaces#actor

--- a/claude/rules/pr-review-response.md
+++ b/claude/rules/pr-review-response.md
@@ -10,39 +10,44 @@ and replace these instructions.
 
 ## Targeting policy
 
-Reply to and resolve only bot comments. Never reply to or resolve a
-human comment by mutation. For human comments, summarize the content
-to the user and wait for an explicit instruction.
+Reply to and resolve only bot threads. Never reply to or resolve a
+thread that contains any human comment. For threads with human
+involvement, summarize the content to the user and wait for an
+explicit instruction.
 
-A thread's author is the author of the thread's first comment.
+A thread qualifies as a bot thread only when every comment in it has
+`author.__typename == "Bot"`. A single human comment anywhere in the
+thread flips it to the human path — including the common case where a
+bot opens a thread and a human follows up.
 
-Bot author: GraphQL `author.__typename == "Bot"`. Known logins
-include `github-actions`, `dependabot`, `copilot-pull-request-reviewer`,
-`renovate`, `devin-ai-integration` (note: GraphQL `author.login` has no
-`[bot]` suffix even when the UI shows one). `__typename` is the
-authoritative signal; the login list is a sanity check.
+Known bot logins for cross-reference: `github-actions`, `dependabot`,
+`copilot-pull-request-reviewer`, `renovate`. GraphQL `author.login`
+has no `[bot]` suffix even when the UI shows one. `__typename` is the
+authoritative signal; the login list only confirms identity at a
+glance. Some automated reviewers (e.g. `devin-ai-integration`) post
+under regular user accounts and return `__typename == "User"` — those
+go on the human path under this rule and require explicit user
+authorization to reply or resolve.
 
-Anything not classified as bot is treated as human.
+Anything not classified as a bot thread is treated as human.
 
 ## Step 1: List review threads (read-only)
 
-Extend the `reviewThreads` query in `git-workflow.md` with
-`author{login __typename}` on each comment node. Example:
-
 ```bash
-gh api graphql -f query='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$num){reviewThreads(first:100){nodes{id isResolved isOutdated comments(first:100){nodes{id author{login __typename} body path line}}}}}}}' -f owner=<owner> -f repo=<repo> -F num=<number>
+gh api graphql -f query='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$num){reviewThreads(first:100){nodes{id isResolved isOutdated comments(first:100){nodes{id author{login __typename} body createdAt path line}}}}}}}' -f owner=<owner> -f repo=<repo> -F num=<number>
 ```
 
 Filter to actionable threads: `isResolved == false` and
-`isOutdated == false`. Classify each by the first comment's
-`author.__typename`.
+`isOutdated == false`. Classify each by walking every comment in the
+thread, per the rule in the previous section.
 
 ## Step 2: Reply to a bot thread
 
-Only after confirming the first comment is a bot. Mutation is
-manually approved every time (`approve_gh_graphql_readonly.py` only
-auto-approves read-only queries) — re-verify the author at the
-approval prompt.
+Only after confirming every comment in the thread is a bot. Mutation
+is manually approved every time (`approve_gh_graphql_readonly.py` only
+auto-approves read-only queries) — re-verify the thread at the
+approval prompt. Use `-f query='...'` with single quotes; do not use
+`--field`, `-F`, or `--raw-field` for the `query` argument.
 
 ```bash
 gh api graphql -f query='mutation($threadId:ID!,$body:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId,body:$body}){comment{id url}}}' -f threadId=<thread id> -f body=<reply body>
@@ -69,10 +74,10 @@ mutation in step 2. Resolution of a human thread stays with the user.
 ## Forbidden shortcuts
 
 - Skipping the bot check before any mutation
+- Treating a thread as a bot thread based only on its opening comment
+  when a later human comment is present
 - Using `gh pr comment` to work around the human-thread restriction
   (top-level comments are a different surface, not a substitute reply)
-- Using `--field` / `-F` / `--raw-field` for the `query` argument
-  (see `gh-graphql.md`)
 
 ## References
 

--- a/claude/rules/pr-review-response.md
+++ b/claude/rules/pr-review-response.md
@@ -4,7 +4,7 @@ How to reply to and resolve PR review thread comments.
 Scope: review-thread comments only. Top-level PR comments
 (`gh pr comment`) are out of scope.
 
-This is the interim rule-only form of ikuwow/dotfiles#126. A future
+This is the interim rule-only form of #126. A future
 script (`bin/gh-pr-thread-{reply,resolve}`) will absorb the bot check
 and replace these instructions.
 
@@ -43,11 +43,9 @@ thread, per the rule in the previous section.
 
 ## Step 2: Reply to a bot thread
 
-Only after confirming every comment in the thread is a bot. Mutation
-is manually approved every time (`approve_gh_graphql_readonly.py` only
-auto-approves read-only queries) — re-verify the thread at the
-approval prompt. Use `-f query='...'` with single quotes; do not use
-`--field`, `-F`, or `--raw-field` for the `query` argument.
+Only after confirming every comment in the thread is a bot. Mutations
+require manual approval every time — re-verify the thread at the
+approval prompt.
 
 ```bash
 gh api graphql -f query='mutation($threadId:ID!,$body:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId,body:$body}){comment{id url}}}' -f threadId=<thread id> -f body=<reply body>


### PR DESCRIPTION
## Purpose

Interim rule-only step toward #126. The issue plans dedicated `bin/`
scripts with bot detection baked in, but that work is large and would
block any near-term automation. This PR delivers the same operational
policy through a user-global rule so Claude Code can start handling
bot review threads now, while the script-based implementation is
still pending.

## Scope

Adds one file: `claude/rules/pr-review-response.md`.
No changes to `AIRULES.md`, `git-workflow.md`, `settings.json`, or `bin/`.

The rule covers review-thread reply and resolve only. Top-level PR
comments (`gh pr comment`) are intentionally out of scope.

## Guardrails

- Bot thread requires every comment in the thread to have
  `author.__typename == "Bot"`; a known-login list serves as a sanity
  check. A bot-opened thread followed by any human comment falls
  through to the human path
- Mutations (`addPullRequestReviewThreadReply`,
  `resolveReviewThread`) remain gated by the existing read-only
  GraphQL auto-approve hook, so every reply or resolve still surfaces
  an approval prompt
- Human threads (including automated reviewers that post as users,
  e.g. `devin-ai-integration`) are summary-only; replies require
  explicit user authorization and never auto-resolve

## Verification

- [x] GraphQL example query executed against #124 and returned
  `author.__typename` correctly (`Bot` for
  `copilot-pull-request-reviewer`, `User` for `ikuwow`)
- [x] `pre-commit run --files claude/rules/pr-review-response.md`
  passes
- [ ] Reviewer to confirm wording around the human-thread restriction
  is unambiguous

## Follow-up

- Script-based implementation per #126
  (`bin/gh-pr-review-threads`, `gh-pr-thread-reply`,
  `gh-pr-thread-resolve` with internal bot check, plus the
  corresponding `settings.json` allow entries). When that lands, this
  rule file will be replaced with a short pointer to the scripts.
