### PR TITLE
Embed concrete redundancy and hard-wrap signals in pr-selfcheck

### DIFF
--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -26,6 +26,41 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 
 Evaluate the PR against the PR Body Checklist defined in `pr-guidelines.md`.
 
+In addition to the high-level checklist, apply the following concrete
+signals so detection does not rely on subagent interpretation alone.
+
+### Redundancy / essence-first signals
+
+Flag each as Should Fix; if multiple signals fire across the body,
+escalate to Must Fix.
+
+- Sentences or bullets that paraphrase what the diff already shows ("edited file X", "bumped value from A to B", "added N items", per-file summaries)
+- CI / lint / type-check / `go build` / `go test` / `go vet` / `pre-commit` results recorded in the Verification section (the Checks panel and bot comments are the authoritative source)
+- The same fact (environment variable name, file name, design decision, summary of a linked source) repeated in multiple places in the body
+- Bullets in the same list that restate the same decision or fact in different wording, with no distinct information per item
+- Content copied verbatim from a design doc, spec, linked issue, or primary source where a one-line summary plus link would suffice
+- Length budget as a heuristic prompt: when the implementation-summary section exceeds ~10 lines, or the whole body (excluding template-mandated sections) exceeds ~30 lines, re-examine the body against the redundancy signals above
+
+### Hard-wrap detection (GitHub-posted markdown)
+
+For PR bodies, PR comments, issue bodies, and issue comments, GitHub
+Flavored Markdown renders soft line breaks inside a paragraph as
+visible breaks. Blank lines between paragraphs serve as paragraph
+separators and are allowed. Flag each violation as Should Fix;
+multiple violations across the body escalate to Must Fix.
+
+Violations:
+
+- Two or more consecutive non-empty lines with no blank line between them (paragraph-internal soft break)
+- Continuation lines of a list item (a line beginning with whitespace indentation following a line that starts with `- `, `* `, or `1. `)
+
+Excluded from detection to avoid false positives:
+
+- Inside fenced code blocks
+- Table rows (lines whose first and last non-whitespace characters are `|`)
+- HTML comments (`<!-- ... -->`)
+- Blockquotes (lines starting with `> `)
+
 ## Output Format
 
 ```

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -39,7 +39,11 @@ escalate to Must Fix.
 - The same fact (environment variable name, file name, design decision, summary of a linked source) repeated in multiple places in the body
 - Bullets in the same list that restate the same decision or fact in different wording, with no distinct information per item
 - Content copied verbatim from a design doc, spec, linked issue, or primary source where a one-line summary plus link would suffice
-- Length budget as a heuristic prompt: when the implementation-summary section exceeds ~10 lines, or the whole body (excluding template-mandated sections) exceeds ~30 lines, re-examine the body against the redundancy signals above
+
+When the implementation-summary section exceeds ~10 lines, or the
+whole body (excluding template-mandated sections) exceeds ~30 lines,
+re-examine the body against the signals above before deciding their
+severity.
 
 ### Hard-wrap detection (GitHub-posted markdown)
 
@@ -49,15 +53,19 @@ visible breaks. Blank lines between paragraphs serve as paragraph
 separators and are allowed. Flag each violation as Should Fix;
 multiple violations across the body escalate to Must Fix.
 
+A "block marker" below means a line starting with any of: `#`, `-`,
+`*`, `+`, a digit followed by `.` (e.g. `1.`), `>`, `|`, four spaces
+of indent, or a fenced code marker (``` or ~~~).
+
 Violations:
 
-- Two or more consecutive non-empty lines with no blank line between them (paragraph-internal soft break)
-- Continuation lines of a list item (a line beginning with whitespace indentation following a line that starts with `- `, `* `, or `1. `)
+- Two or more consecutive non-empty lines with no blank line between them, where neither line begins with a block marker (this catches paragraph-internal soft breaks while leaving tight lists, headings, and other block constructs alone)
+- An indented continuation line directly following a list-item line (`- `, `* `, `+ `, or `N. `) with no blank line between them; a blank-line gap before the indent denotes a valid continuation paragraph and is not a violation
 
 Excluded from detection to avoid false positives:
 
-- Inside fenced code blocks
-- Table rows (lines whose first and last non-whitespace characters are `|`)
+- Inside fenced code blocks (track open / close of paired ``` or ~~~ fences)
+- GFM tables in either form: rows whose first and last non-whitespace characters are `|`, or pipeless rows recognized by the `---|---` divider line directly below the header row
 - HTML comments (`<!-- ... -->`)
 - Blockquotes (lines starting with `> `)
 


### PR DESCRIPTION
## Purpose

The `pr-selfcheck` Review Criteria was a single one-line reference to `pr-guidelines.md`, which left detection entirely to subagent interpretation and let multiple categories of violation slip through. This change embeds operation-level signals directly in `SKILL.md` so detection becomes reproducible.

## Background

- #227: length-budget breaches and redundant content (CI result restatement, diff paraphrasing, repeated facts) were not flagged; two pr-selfcheck runs on a 48-line body missed them and the user had to trim by hand
- #237: paragraph-internal hard-wrap in GitHub-posted markdown was missed even though `pr-guidelines.md` documents the rule; the rule was never wired into a mechanical check

## Scope

`claude/skills/pr-selfcheck/SKILL.md` gains two subsections under Review Criteria:

- Redundancy / essence-first signals — five flags (diff paraphrasing, CI/lint result restatement, fact duplication, indistinct bullets, primary-source copying) plus a separate length-budget paragraph that triggers re-examination against those signals
- Hard-wrap detection — paragraph-internal soft breaks and list-item indented continuations, with a block-marker exclusion (`#`, `-`, `*`, `+`, `N.`, `>`, `|`, indented code, fenced code) keeping tight lists and headings unflagged, plus exclusions for fenced code blocks, GFM tables (pipe-bounded and pipeless), HTML comments, and blockquotes

`pr-guidelines.md` is intentionally not touched: the rule statements already live there and duplicating them would invite drift.

## Verification

- [x] `pre-commit run --files claude/skills/pr-selfcheck/SKILL.md` passes (recorded locally because this repo's CI does not run pre-commit)
- [x] `/pr-selfcheck 238` run twice; the second pass caught a Scope-section count-off in this body as Should Fix, exercising the redundancy signals against real content
- [x] Spot-check: `/pr-selfcheck 237` (hard-wrap-heavy body) escalated to Must Fix on every wrapped paragraph and list-item continuation and flagged the pre-commit-in-Verification line as Should Fix; `/pr-selfcheck 235` (clean body, contains a fenced code block) returned PASS with no false positives from the new signals

## Follow-up

A `pr` skill that bundles creation + self-check + guidelines (removing the auto-load on `pr-guidelines.md` and rerouting `git-workflow.md` Step 4) is a separate, larger restructure tracked in its own issue. A mechanical lint hook in front of `gh pr create --body-file` is also deferred.

Refs: #227, #237
