### PR TITLE
Add IME Enter Fixer userscript and manage Userscripts.app via dotfiles

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -201,6 +201,7 @@ cask "zotero"
 # Work related
 
 mas "Dark Reader for Safari", id: 1438243180
+mas "Userscripts", id: 1463298887
 mas "The Unarchiver", id: 425424353
 mas "Numbers", id: 409203825
 mas "Keynote", id: 409183694

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ dotfiles/
 ├── bin/                  # Custom executable scripts → ~/bin/
 ├── xdg-config/           # XDG config files → ~/.config/
 ├── claude/               # Claude Code settings → ~/.claude/
+├── userscripts/          # Safari userscripts (Userscripts.app reads this path directly)
 ├── .bash_profile         # Login shell config → ~/
 ├── .bashrc               # Interactive shell config → ~/
 └── ... (other dotfiles)
@@ -130,6 +131,16 @@ export ANTHROPIC_MODEL=opusplan
 - Linux: Symlink deployment only
 
 On Linux, the bootstrap process deploys symlinks and exits. Homebrew is not used on Linux in this project; shell configuration (`.bash_profile`, `.bashrc`) detects whether Homebrew is installed and skips all Homebrew-dependent setup when it is absent.
+
+### Safari Userscripts
+
+`userscripts/` holds Safari user scripts that are loaded by the [Userscripts](https://github.com/quoid/userscripts) Safari extension (installed via `mas` from the Brewfile). The extension stores its save location as a macOS security-scoped bookmark, so point it directly at the real `userscripts/` path under this repo. See [`userscripts/README.md`](userscripts/README.md) for the list of scripts and how to add new ones.
+
+Post-`brew bundle` setup (one time per Mac):
+
+1. Enable the Userscripts extension in Safari → Settings → Extensions.
+1. Open Userscripts from the Safari toolbar → Settings (gear icon) → Save Location → choose this repo's `userscripts/` directory.
+1. Reload Safari tabs; the scripts in `userscripts/` are picked up automatically.
 
 ### Claude Code Web
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ dotfiles/
 ├── bin/                  # Custom executable scripts → ~/bin/
 ├── xdg-config/           # XDG config files → ~/.config/
 ├── claude/               # Claude Code settings → ~/.claude/
-├── userscripts/          # Safari userscripts (Userscripts.app reads this path directly)
+├── userscripts/          # Safari userscripts loaded by the Userscripts extension
 ├── .bash_profile         # Login shell config → ~/
 ├── .bashrc               # Interactive shell config → ~/
 └── ... (other dotfiles)
@@ -138,9 +138,9 @@ On Linux, the bootstrap process deploys symlinks and exits. Homebrew is not used
 
 Post-`brew bundle` setup (one time per Mac):
 
-1. Enable the Userscripts extension in Safari → Settings → Extensions.
-1. Open Userscripts from the Safari toolbar → Settings (gear icon) → Save Location → choose this repo's `userscripts/` directory.
-1. Reload Safari tabs; the scripts in `userscripts/` are picked up automatically.
+1. Enable the Userscripts extension in Safari → Settings → Extensions
+1. Open the Userscripts popover from the Safari toolbar → Settings (gear icon) → Save Location → choose this repo's `userscripts/` directory
+1. Reload any open Safari tabs to pick up the scripts
 
 ### Claude Code Web
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ On Linux, the bootstrap process deploys symlinks and exits. Homebrew is not used
 Post-`brew bundle` setup (one time per Mac):
 
 1. Enable the Userscripts extension in Safari → Settings → Extensions
-1. Open the Userscripts popover from the Safari toolbar → Settings (gear icon) → Save Location → choose this repo's `userscripts/` directory
-1. Reload any open Safari tabs to pick up the scripts
+1. Open the Userscripts popover from the Safari toolbar and click the gear icon to open the Settings modal
+1. Click the cogs icon next to "Save Location" — this launches the Userscripts host app
+1. In the host app, pick this repo's `userscripts/` directory as the Save Location
+1. Back in the popover, every `.user.js` in that directory (including `ime-enter-fixer.user.js`) appears in the script list and is active automatically; reload any open Safari tabs to pick them up
 
 ### Claude Code Web
 

--- a/README.md
+++ b/README.md
@@ -134,15 +134,7 @@ On Linux, the bootstrap process deploys symlinks and exits. Homebrew is not used
 
 ### Safari Userscripts
 
-`userscripts/` holds Safari user scripts that are loaded by the [Userscripts](https://github.com/quoid/userscripts) Safari extension (installed via `mas` from the Brewfile). The extension stores its save location as a macOS security-scoped bookmark, so point it directly at the real `userscripts/` path under this repo. See [`userscripts/README.md`](userscripts/README.md) for the list of scripts and how to add new ones.
-
-Post-`brew bundle` setup (one time per Mac):
-
-1. Enable the Userscripts extension in Safari → Settings → Extensions
-1. Open the Userscripts popover from the Safari toolbar and click the gear icon to open the Settings modal
-1. Click the cogs icon next to "Save Location" — this launches the Userscripts host app
-1. In the host app, pick this repo's `userscripts/` directory as the Save Location
-1. Back in the popover, every `.user.js` in that directory (including `ime-enter-fixer.user.js`) appears in the script list and is active automatically; reload any open Safari tabs to pick them up
+`userscripts/` holds Safari user scripts loaded by the [Userscripts](https://github.com/quoid/userscripts) extension (installed via `mas` from the Brewfile). The per-Mac setup procedure, current script catalog, and how to add new scripts live in [`userscripts/README.md`](userscripts/README.md).
 
 ### Claude Code Web
 

--- a/userscripts/README.md
+++ b/userscripts/README.md
@@ -2,9 +2,15 @@
 
 Safari user scripts loaded by the [Userscripts](https://github.com/quoid/userscripts) extension. This directory is set as the extension's Save Location so the scripts are version-controlled with the rest of the dotfiles.
 
-## Setup
+The Userscripts extension keeps its Save Location as a macOS security-scoped bookmark, so point it at the real path of this directory under the repo rather than a `$HOME` symlink — the bookmark resolves more reliably against the real path, and it must be set once per Mac via the app's UI (no way to bootstrap it from the dotfiles deploy).
 
-See the "Safari Userscripts" section in the top-level [README.md](../README.md) for the full installation and Save Location procedure, including why the extension is pointed at the real repo path.
+## Setup (one time per Mac, after `brew bundle`)
+
+1. Enable the Userscripts extension in Safari → Settings → Extensions
+1. Open the Userscripts popover from the Safari toolbar and click the gear icon to open the Settings modal
+1. Click the cogs icon next to "Save Location" — this launches the Userscripts host app
+1. In the host app, pick this repo's `userscripts/` directory as the Save Location
+1. Back in the popover, every `.user.js` in this directory appears in the script list and is active automatically; reload any open Safari tabs to pick them up
 
 ## Scripts
 

--- a/userscripts/README.md
+++ b/userscripts/README.md
@@ -1,19 +1,18 @@
 # userscripts
 
-Safari user scripts loaded by the [Userscripts](https://github.com/quoid/userscripts) extension.
-
-This directory is intended to be set as the extension's Save Location so the scripts are version-controlled with the rest of the dotfiles. The path is registered in the Userscripts app as a macOS security-scoped bookmark, so point the app directly at the real path of this directory under the repo (the bookmark resolves more reliably against a real path).
+Safari user scripts loaded by the [Userscripts](https://github.com/quoid/userscripts) extension. This directory is set as the extension's Save Location so the scripts are version-controlled with the rest of the dotfiles.
 
 ## Setup
 
-See the "Safari Userscripts" section in the top-level [README.md](../README.md) for the full installation and Save Location procedure.
+See the "Safari Userscripts" section in the top-level [README.md](../README.md) for the full installation and Save Location procedure, including why the extension is pointed at the real repo path.
 
 ## Scripts
 
-- `ime-enter-fixer.user.js` — Stops the IME confirmation Enter from triggering a site's submit handler in Safari. Applies to all sites (`@include *://*/*`).
+- `ime-enter-fixer.user.js` — stops the IME confirmation Enter from triggering a site's submit handler in Safari, applied to all sites (`@include *://*/*`)
 
 ## Adding a new script
 
-1. Create a file ending in `.user.js` in this directory.
-1. Include a `// ==UserScript==` metadata block with at least `@name`, `@include` (or `@match`), and `@run-at`.
-1. The Userscripts app picks it up automatically once the Save Location is set.
+1. Create a file ending in `.user.js` in this directory
+1. Include a `// ==UserScript==` metadata block with at least `@name` and one of `@include` / `@match`
+1. Add `@run-at document-start` when the script needs to hook events before the page's own listeners attach (defaults to `document-end` if omitted)
+1. The Userscripts extension picks it up automatically once the Save Location is set

--- a/userscripts/README.md
+++ b/userscripts/README.md
@@ -1,0 +1,19 @@
+# userscripts
+
+Safari user scripts loaded by the [Userscripts](https://github.com/quoid/userscripts) extension.
+
+This directory is intended to be set as the extension's Save Location so the scripts are version-controlled with the rest of the dotfiles. The path is registered in the Userscripts app as a macOS security-scoped bookmark, so point the app directly at the real path of this directory under the repo (the bookmark resolves more reliably against a real path).
+
+## Setup
+
+See the "Safari Userscripts" section in the top-level [README.md](../README.md) for the full installation and Save Location procedure.
+
+## Scripts
+
+- `ime-enter-fixer.user.js` — Stops the IME confirmation Enter from triggering a site's submit handler in Safari. Applies to all sites (`@include *://*/*`).
+
+## Adding a new script
+
+1. Create a file ending in `.user.js` in this directory.
+1. Include a `// ==UserScript==` metadata block with at least `@name`, `@include` (or `@match`), and `@run-at`.
+1. The Userscripts app picks it up automatically once the Save Location is set.

--- a/userscripts/ime-enter-fixer.user.js
+++ b/userscripts/ime-enter-fixer.user.js
@@ -1,0 +1,11 @@
+// ==UserScript==
+// @name         IME Enter Fixer
+// @description  Prevent Safari from sending the IME confirmation Enter as a submit keystroke
+// @run-at       document-start
+// @include      *://*/*
+// ==/UserScript==
+document.addEventListener('keydown', function(event) {
+    if ((event.key === 'Enter' && event.isComposing) || event.keyCode === 229) {
+        event.stopPropagation();
+    }
+}, {capture: true});

--- a/userscripts/ime-enter-fixer.user.js
+++ b/userscripts/ime-enter-fixer.user.js
@@ -4,6 +4,9 @@
 // @run-at       document-start
 // @include      *://*/*
 // ==/UserScript==
+// Safari clears `isComposing` before keydown for the IME confirmation Enter,
+// so cover both signals: the modern `isComposing` flag and the legacy
+// `keyCode === 229` that some WebKit input paths still emit.
 document.addEventListener('keydown', function(event) {
     if ((event.key === 'Enter' && event.isComposing) || event.keyCode === 229) {
         event.stopPropagation();


### PR DESCRIPTION
## Purpose

See ikuwow/dotfiles#240.

Safari sends the IME confirmation Enter as a real submit keystroke because `event.isComposing` is already `false` by the time `keydown` fires — see the article references in the linked issue. This trips chat UIs (Claude web app, etc.) that bind Enter to submit.

The fix is a single user script that stops the propagation of that keystroke in the capture phase, applied to all sites via the [Userscripts](https://github.com/quoid/userscripts) Safari extension. Both the extension and the script directory are now managed by this repo so the fix syncs across Macs.

## Scope

Out of scope: any `scripts/deploy.sh` change. Userscripts.app keeps its save location as a macOS security-scoped bookmark, so the extension is pointed at the repo's `userscripts/` path directly via the app's UI; a symlink under `$HOME` would not help here.

## Sources

- Userscripts extension: https://github.com/quoid/userscripts
- Safari IME background: https://tech.classi.jp/entry/2024/04/23/183000, https://webfrontend.ninja/js-input-ime-enter/

## Verification

End-to-end verified on the author's Mac, following the "Safari Userscripts" procedure in `README.md`:

- [x] `brew bundle --file=Brewfile` installs Userscripts.app from the App Store
- [x] Userscripts extension enabled in Safari → Settings → Extensions
- [x] Save Location set to this repo's `userscripts/` directory via the Userscripts popover → gear → cogs icon → host app; `IME Enter Fixer` appears in the script list
- [x] In Claude web app, IME confirmation Enter no longer submits the message; a second Enter with no active conversion sends as expected
