### PR TITLE
Switch default model to Opus and use Fable as advisor

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -313,7 +313,8 @@
       "Bash(copilot update *)"
     ]
   },
-  "model": "fable",
+  "model": "opus",
+  "advisorModel": "fable",
   "hooks": {
     "UserPromptSubmit": [
       {


### PR DESCRIPTION
## Why

Claude Fable 5 became available and is currently set as the session default (`"model": "fable"`), which burns Fable-rate usage on every session. Fable should be reserved for hard decisions only, with Opus doing the day-to-day work.

Claude Code's built-in advisor feature fits this exactly: the main model escalates to the advisor model at key decision points (choosing an approach, stuck on errors, before declaring done), so Fable is consulted only when it adds value. See the [advisor docs](https://code.claude.com/docs/en/advisor).

- Default model: `opus`
- Advisor model: `fable` (requires Claude Code v2.1.170+; local CLI is v2.1.197)

Runaway-spend protection is handled outside this repo: claude.ai Settings > Usage offers a configurable monthly spending cap on usage credits, with alerts as the cap is approached ([support article](https://support.claude.com/en/articles/12429409-manage-usage-credits-for-paid-claude-plans)). No Claude Code setting exists for per-model spend caps.

## Verification

- `jq empty claude/settings.json` passes (exit 0)
- `claude --version` → 2.1.197, above the v2.1.170 minimum for Fable as advisor
- [x] Set a monthly spending limit (e.g. $10) in claude.ai Settings > Usage
- [ ] After merge + new session: statusline/`/model` shows Opus as the main model and `/advisor` shows Fable

## Notes

Merge is intentionally deferred until the Fable billing transition on July 8, 2026 (included access ends July 7, per the [redeployment announcement](https://www.anthropic.com/news/redeploying-fable-5)); keep as draft until then.
