### PR TITLE
Fix stale docs, CI globstar, dead config, and missing set -eu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
         run: shellcheck --version
       - name: shellcheck
         run: |
+          shopt -s globstar
           shellcheck -- **/*.sh
           find bin/ -type f ! -name '*.md' -exec shellcheck {} +
           find xdg-config/git/hooks/ -type f -exec shellcheck {} +

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ pre-commit run --all-files
 ## Script Requirements
 
 - Bootstrap scripts use `/bin/bash` (not `/usr/bin/env bash`) for compatibility
-- All scripts must pass shellcheck validation (see `.shellcheckrc` for disabled rules)
+- All scripts must pass shellcheck validation (disabled rules are set via `SHELLCHECK_OPTS` in `.bash_profile` and `.github/workflows/ci.yml`)
 - Use `set -eu` for error handling in critical scripts
 
 ## Personal Tool Defaults

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Editing any dotfile means editing the source file in this repository.
 
 | Repository source | Deployed to |
 | --- | --- |
-| `.aliases`, `.bash_profile`, `.bashrc`, `.vimrc`, etc. (19 dotfiles) | `~/` |
+| `.aliases`, `.bash_profile`, `.bashrc`, `.functions`, `.inputrc`, etc. (12 dotfiles) | `~/` |
 | `xdg-config/*` (all subdirectories) | `~/.config/` |
 | `.ssh/config` | `~/.ssh/config` |
 | `.kube/kubie.yaml` | `~/.kube/kubie.yaml` |
@@ -83,7 +83,7 @@ dotfiles/
 ├── bootstrap.sh          # Entry point (run via curl on a new Mac)
 ├── bootstrap/
 │   ├── main.sh           # OS detection, prerequisites, orchestrates full setup
-│   └── remote.sh         # Minimal bootstrap for remote environments
+│   └── claude-code-web.sh # Minimal bootstrap for Claude Code web environments
 ├── scripts/
 │   ├── deploy.sh         # Creates all symlinks (runs on Linux too)
 │   ├── configure.sh      # macOS system preferences via defaults command
@@ -117,7 +117,7 @@ export ANTHROPIC_MODEL=opusplan
 
 ### Bootstrap Flow
 
-1. `bootstrap.sh` — Clones the repo (or updates it). If `DOTFILES_MINIMAL=1`, runs `bootstrap/claude-code-web.sh` (symlinks only) and exits. Otherwise calls `bootstrap/main.sh`
+1. `bootstrap.sh` — Clones the repo (or updates it). If `CLAUDE_CODE_REMOTE=true`, runs `bootstrap/claude-code-web.sh` (symlinks only) and exits. Otherwise calls `bootstrap/main.sh`
 1. `bootstrap/main.sh` — Detects OS/architecture, checks prerequisites, orchestrates:
    - `scripts/deploy.sh` — Creates symlinks (runs on Linux and macOS)
    - `scripts/configure.sh` — macOS system defaults (macOS only)

--- a/bin/README.md
+++ b/bin/README.md
@@ -11,5 +11,6 @@ Custom executable scripts deployed to `~/bin/` via symlinks.
 | `git-cleanup-branches` | Delete unused local branches (merged, squash-merged, upstream gone) and prune stale worktree entries |
 | `git-worktree-create` | Create a git worktree under `.worktrees/`. Defaults to branching from `origin/<default>`; pass a second argument to override the base |
 | `pipectlx` | PipeCD CLI wrapper that auto-injects API key and server address from config |
+| `pr-monitor` | Poll a GitHub PR for actionable changes (state, reviews, comments, CI) and emit one-line events to stdout |
 | `ssm` | Start an AWS SSM session by instance ID or Name tag |
 | `vssh` | SSH into a Vagrant machine using sshrc with auto-generated ssh-config |

--- a/bin/pipectlx
+++ b/bin/pipectlx
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eu
+
 #
 # pipectl wrapper script
 #

--- a/xdg-config/git/config
+++ b/xdg-config/git/config
@@ -8,9 +8,6 @@
     ui = true
 [grep]
     lineNumber = true
-[filter "media"]
-    clean = git-media-clean %f
-    smudge = git-media-smudge %f
 [alias]
     s = status
     b = branch


### PR DESCRIPTION
## Summary\n\nWeekly routine improvements: fix documentation that drifted from the actual code, a CI gap that skips repo-root shell scripts, a dead git config section, and a missing `set -eu`.\n\n## Changes\n\n- CI (`ci.yml`): add `shopt -s globstar` before `shellcheck -- **/*.sh` so `bootstrap.sh` (and any future root-level `.sh` files) are actually linted. GitHub Actions uses `bash` which does not enable `globstar` by default, so `**/*.sh` was only matching one directory level deep.\n- Git config: remove the `[filter \"media\"]` section — `git-media` was superseded by `git-lfs`, which is already configured in the same file.\n- README.md: fix three stale references — dotfile count was \"19\" (actual: 12 per `deploy.sh`), `bootstrap/remote.sh` (actual: `bootstrap/claude-code-web.sh`), `DOTFILES_MINIMAL=1` (actual: `CLAUDE_CODE_REMOTE=true` per `bootstrap.sh:27`).\n- AGENTS.md: `.shellcheckrc` does not exist in this repo; disabled rules live in `SHELLCHECK_OPTS` in `.bash_profile` and `ci.yml`.\n- `bin/README.md`: add missing `pr-monitor` entry to the scripts table.\n- `bin/pipectlx`: add `set -eu` for consistency with every other script in `bin/`.\n\n## Verification\n\n- Confirmed `bootstrap/remote.sh` does not exist and `bootstrap/claude-code-web.sh` does\n- Counted 12 direct `link` calls in `deploy.sh` (lines 25-38)\n- Confirmed `bootstrap.sh:27` checks `CLAUDE_CODE_REMOTE`, not `DOTFILES_MINIMAL`\n- Confirmed no `.shellcheckrc` file exists anywhere in the repo\n- Confirmed `pr-monitor` exists in `bin/` but was absent from `bin/README.md`\n- Confirmed all other `bin/` scripts use `set -eu`; `pipectlx` was the only exception\n- `[filter \"lfs\"]` section remains intact after removing `[filter \"media\"]`\n\n## Past routine feedback\n\nAll 3 previous closed routine PRs (#217, #218, #234) were merged. No rejections to avoid repeating.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpkbRXUnFTo9AVc82poJMR)_