### PR TITLE
Import untracked Claude rules and report stale symlinks on deploy

### DIFF
--- a/claude/rules/external-tool-claims.md
+++ b/claude/rules/external-tool-claims.md
@@ -1,0 +1,37 @@
+# External Tool Behavior Claims
+
+When making recommendations or assertions that depend on the behavior
+of an external tool (OS, runtime, cloud service, CLI, library), verify
+that behavior against primary sources before stating it.
+
+## When this applies
+
+- Stating how a tool resolves config paths, environment variables, or
+  precedence between them
+- Stating that a tool persists or regenerates state across operations
+  (delete + recreate, restart, version upgrade)
+- Stating idempotency, safety, or side-effect properties
+- Recommending a workflow that depends on a tool doing something
+  reliably under specific conditions
+
+## Verification sources, in priority order
+
+1. Official documentation (project docs site, man page, `--help` output)
+2. Source code of the tool itself (`gh search code`, `gh api`,
+   `deepwiki`, `context7`)
+3. Issues / discussions with reproducible reports
+
+If none of these can be verified, mark the claim as `要検証 / unverified`
+and either ask the user to verify with a clear "I have not confirmed
+this" caveat, or investigate yourself before asking the user to spend
+their time testing it on their host.
+
+## Don't
+
+- Write "〜のはず" / "〜される" without a primary source check
+- Ask the user to test something on their host before reading the tool's
+  source for the relevant code path
+- Treat training-data recall as verification — re-confirm via a primary
+  source even when you "know" the answer
+- Layer multiple unverified workarounds on top of a tool whose behavior
+  was never read; root-cause first by reading the source

--- a/claude/rules/tech-doc-scoping.md
+++ b/claude/rules/tech-doc-scoping.md
@@ -1,0 +1,41 @@
+# Technical Reference Doc Scoping
+
+## Applies to
+
+Reference documentation for operating or managing a directory, module,
+or service. Specifically:
+
+- README.md
+- Operational / runbook docs
+- Per-host or per-module operations notes
+
+## Does not apply to
+
+Documents where rationale and discussion are part of the value:
+
+- PR description / commit message
+- Issue / discussion / chat
+- ADR / design doc
+
+## Rule
+
+Before writing the body, articulate the file's management scope in one
+sentence. Scope = the range of information needed to operate what this
+file directly manages (the playbook, code, config in this directory).
+
+Information outside that scope does not belong in the body. Common
+out-of-scope material:
+
+- Internal behavior or resolution algorithms of dependencies (external
+  tools, OS, services)
+- Configuration or operations of other directories or systems
+- Design rationale (why A and not B) -- that goes in the PR description
+  or ADR
+- Detailed examples of individual workloads using this thing
+
+When out-of-scope material must be touched, summarize in one line plus
+a link to the primary source. Do not paste the mechanism explanation
+into the body.
+
+This applies from the very first draft. Do not write verbose first and
+trim only after a reviewer or user asks.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -66,12 +66,16 @@ link claude/settings.json          "$HOME/.claude/settings.json"
 link claude/statusline-command.sh  "$HOME/.claude/statusline-command.sh"
 link AIRULES.md           "$HOME/.claude/CLAUDE.md"
 mkdir -p "$HOME/.claude/skills"
+find "$HOME/.claude/skills/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/skills" -maxdepth 1 -mindepth 1 -type d -exec ln -fvns {} "$HOME/.claude/skills/" \;
 mkdir -p "$HOME/.claude/hooks"
+find "$HOME/.claude/hooks/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/hooks" -maxdepth 1 -mindepth 1 -type f ! -name 'test_*' -exec ln -fvns {} "$HOME/.claude/hooks/" \;
 mkdir -p "$HOME/.claude/agents"
+find "$HOME/.claude/agents/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/agents" -maxdepth 1 -mindepth 1 -type f -name '*.md' -exec ln -fvns {} "$HOME/.claude/agents/" \;
 mkdir -p "$HOME/.claude/rules"
+find "$HOME/.claude/rules/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/rules" -maxdepth 1 -mindepth 1 -type f -name '*.md' -exec ln -fvns {} "$HOME/.claude/rules/" \;
 
 # Codex CLI
@@ -82,4 +86,5 @@ find "$DOTPATH/codex/rules" -maxdepth 1 -mindepth 1 -type f -name '*.rules' -exe
 # Junie CLI (JetBrains)
 link AIRULES.md  "$HOME/.junie/AGENTS.md"
 mkdir -p "$HOME/.junie/skills"
+find "$HOME/.junie/skills/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/skills" -maxdepth 1 -mindepth 1 -type d -exec ln -fvns {} "$HOME/.junie/skills/" \;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -66,16 +66,16 @@ link claude/settings.json          "$HOME/.claude/settings.json"
 link claude/statusline-command.sh  "$HOME/.claude/statusline-command.sh"
 link AIRULES.md           "$HOME/.claude/CLAUDE.md"
 mkdir -p "$HOME/.claude/skills"
-find "$HOME/.claude/skills/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
+find "$HOME/.claude/skills/" -maxdepth 1 -type l ! -exec test -e {} \; -print
 find "$DOTPATH/claude/skills" -maxdepth 1 -mindepth 1 -type d -exec ln -fvns {} "$HOME/.claude/skills/" \;
 mkdir -p "$HOME/.claude/hooks"
-find "$HOME/.claude/hooks/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
+find "$HOME/.claude/hooks/" -maxdepth 1 -type l ! -exec test -e {} \; -print
 find "$DOTPATH/claude/hooks" -maxdepth 1 -mindepth 1 -type f ! -name 'test_*' -exec ln -fvns {} "$HOME/.claude/hooks/" \;
 mkdir -p "$HOME/.claude/agents"
-find "$HOME/.claude/agents/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
+find "$HOME/.claude/agents/" -maxdepth 1 -type l ! -exec test -e {} \; -print
 find "$DOTPATH/claude/agents" -maxdepth 1 -mindepth 1 -type f -name '*.md' -exec ln -fvns {} "$HOME/.claude/agents/" \;
 mkdir -p "$HOME/.claude/rules"
-find "$HOME/.claude/rules/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
+find "$HOME/.claude/rules/" -maxdepth 1 -type l ! -exec test -e {} \; -print
 find "$DOTPATH/claude/rules" -maxdepth 1 -mindepth 1 -type f -name '*.md' -exec ln -fvns {} "$HOME/.claude/rules/" \;
 
 # Codex CLI
@@ -86,5 +86,5 @@ find "$DOTPATH/codex/rules" -maxdepth 1 -mindepth 1 -type f -name '*.rules' -exe
 # Junie CLI (JetBrains)
 link AIRULES.md  "$HOME/.junie/AGENTS.md"
 mkdir -p "$HOME/.junie/skills"
-find "$HOME/.junie/skills/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
+find "$HOME/.junie/skills/" -maxdepth 1 -type l ! -exec test -e {} \; -print
 find "$DOTPATH/claude/skills" -maxdepth 1 -mindepth 1 -type d -exec ln -fvns {} "$HOME/.junie/skills/" \;

--- a/scripts/verify_deploy.sh
+++ b/scripts/verify_deploy.sh
@@ -27,6 +27,32 @@ check_dir() {
   fi
 }
 
+check_no_dangling_symlinks() {
+  local dir="$1"
+  local dangling
+  dangling=$(find "$dir" -maxdepth 1 -type l ! -exec test -e {} \; -print)
+  if [ -z "$dangling" ]; then
+    echo "OK: $dir has no dangling symlinks"
+  else
+    echo "FAIL: $dir has dangling symlinks:"
+    echo "$dangling"
+    errors=$((errors + 1))
+  fi
+}
+
+check_no_untracked_real_files() {
+  local dir="$1"
+  local real_files
+  real_files=$(find "$dir" -maxdepth 1 -type f -print)
+  if [ -z "$real_files" ]; then
+    echo "OK: $dir has no untracked real files"
+  else
+    echo "FAIL: $dir has real files not managed by deploy.sh (should be symlinks):"
+    echo "$real_files"
+    errors=$((errors + 1))
+  fi
+}
+
 echo "=== Shell config ==="
 check_symlink "$HOME/.bash_profile"
 check_symlink "$HOME/.bashrc"
@@ -73,6 +99,11 @@ check_symlink "$HOME/.claude/hooks/approve_git_gh_commands.py"
 check_symlink "$HOME/.claude/hooks/hook_utils.py"
 check_symlink "$HOME/.claude/agents/investigator.md"
 check_symlink "$HOME/.claude/rules/git-workflow.md"
+check_no_dangling_symlinks "$HOME/.claude/skills"
+check_no_dangling_symlinks "$HOME/.claude/hooks"
+check_no_dangling_symlinks "$HOME/.claude/agents"
+check_no_dangling_symlinks "$HOME/.claude/rules"
+check_no_untracked_real_files "$HOME/.claude/rules"
 
 echo ""
 if [ "$errors" -gt 0 ]; then


### PR DESCRIPTION
## Purpose

Part 1 of a multi-PR pass to compact the AI rule system (see follow-up PRs for skillification of git-workflow, AIRULES compression, and retrospective redesign). This PR fixes a deploy-drift gap found during that audit: two rule files existed only as live untracked files under `~/.claude/rules/`, and `deploy.sh` never surfaced stale symlinks, so renamed/removed rule files left dangling symlinks behind on the host.

## Key changes

- Import `external-tool-claims.md` and `tech-doc-scoping.md` into `claude/rules/` so they're tracked and deployed like every other rule file
- `deploy.sh` now reports (does not delete) dangling symlinks under `claude/{rules,skills,agents,hooks}` and Junie skills before relinking — removing a symlink pointer never touches its target, but the check can't tell "orphaned by a repo-side rename" from "target temporarily unreachable", so cleanup is left to a human via `verify_deploy.sh`
- `verify_deploy.sh` asserts no dangling symlinks and no untracked real files remain in `~/.claude/rules/`

## Verification

- [x] `shellcheck scripts/deploy.sh scripts/verify_deploy.sh` → no output (clean)
- [x] Ran `./scripts/deploy.sh` locally → reported 2 dangling rule symlinks (`gh-graphql.md`, `pr-review-response.md`) and 3 dangling hook symlinks without deleting them, then relinked the two newly-tracked rule files
- [x] Ran `bash scripts/verify_deploy.sh` → all checks pass, including the new dangling-symlink and untracked-real-file assertions
