### PR TITLE
Redesign retrospective to close the consolidation loop

### DIFF
--- a/claude/routines/weekly-improvement.md
+++ b/claude/routines/weekly-improvement.md
@@ -38,7 +38,7 @@ Look for improvements across the entire dotfiles repository:
 - Rule budget: always-loaded rule files stay within budget (`AIRULES.md` <= 140 lines, each `claude/rules/*.md` <= 100 lines). Propose consolidation or tier demotion when exceeded
 
 Modify with care:
-- `AIRULES.md`: only when implementing a countermeasure recorded in a retrospective issue; link the issue in the PR body
+- `AIRULES.md`: only when implementing a countermeasure recorded in a retrospective issue, or bringing it back within the rule budget above; cite the issue or the budget overage in the PR body
 - `CLAUDE.md` / `AGENTS.md` (only fix clear errors)
 
 ## Step 4: Create a PR

--- a/claude/routines/weekly-improvement.md
+++ b/claude/routines/weekly-improvement.md
@@ -3,7 +3,7 @@
 You are improving the ikuwow/dotfiles repository as a weekly maintenance routine.
 This file contains all instructions for the routine.
 
-## Step 1: Check Past Feedback
+## Step 1: Check Past Feedback and Retrospectives
 
 Before making any changes, check past routine PRs for feedback:
 
@@ -12,6 +12,13 @@ Before making any changes, check past routine PRs for feedback:
 1. For any closed (not merged) PRs, read the comments to understand why they were rejected:
    `gh pr view <number> --repo ikuwow/dotfiles --comments`
 1. Learn from this feedback. Avoid making similar changes that were previously rejected
+
+Then pull the retrospective backlog:
+
+1. List open retrospective issues:
+   `gh issue list --repo ikuwow/dotfiles --label retrospective --state open --json number,title,body`
+1. Treat their countermeasures as the primary improvement candidates for this run. Look for patterns across multiple issues (the same rule failing repeatedly, accumulating rule bloat) before implementing any single countermeasure verbatim.
+1. After a countermeasure is implemented (or rejected with reason), close the issue with a comment linking the PR or stating the decision.
 
 ## Step 2: Understand the Repository
 
@@ -28,9 +35,10 @@ Look for improvements across the entire dotfiles repository:
 - Security: exposed secrets, insecure defaults
 - Dead code or unused configurations
 - Documentation: only where genuinely missing or incorrect
+- Rule budget: always-loaded rule files stay within budget (`AIRULES.md` <= 140 lines, each `claude/rules/*.md` <= 100 lines). Propose consolidation or tier demotion when exceeded
 
-Do NOT modify:
-- `AIRULES.md` (global AI rules, maintained manually by the user)
+Modify with care:
+- `AIRULES.md`: only when implementing a countermeasure recorded in a retrospective issue; link the issue in the PR body
 - `CLAUDE.md` / `AGENTS.md` (only fix clear errors)
 
 ## Step 4: Create a PR

--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: retrospective
 description: Use when the user wants to reflect on AI communication quality and get improvement suggestions for rule files or the project itself. TRIGGER when user invokes /retrospective or asks to review the session.
-model: opus
 effort: xhigh
+context: fork
+agent: general-purpose
 ---
 
 # Session Retrospective
@@ -11,6 +12,14 @@ Review the current session and identify problematic AI behaviors with
 structural countermeasures.
 
 Focus on the interaction process, not on the task content itself.
+
+## Step 0: Load Past Retrospectives
+
+Fetch recent retrospective records before analyzing:
+`gh issue list --repo ikuwow/dotfiles --label retrospective --state all --limit 15 --json number,title,body,state`
+Use them to detect cross-session recurrence. A problem matching a
+past retrospective escalates one severity level and is marked
+"recurring", with the past issue number cited.
 
 ## Step 1: List Problem Behaviors
 
@@ -23,17 +32,23 @@ Keep each entry to 1-2 lines. Skip behaviors that had no real impact.
 
 ## Step 2: Propose Structural Countermeasures
 
-For each problem behavior, propose a countermeasure that prevents
-recurrence through external mechanisms:
+For each problem, identify the governing rule first, then pick the
+highest applicable countermeasure in this order:
 
-- Rule addition (to AIRULES.md for global, or project CLAUDE.md for project-specific)
-- Hook (pre-commit, Claude Code PreToolUse/PostToolUse/PermissionRequest hook)
-- Linter or static analysis rule
-- Script or automation
-- Template or checklist
-- Permission setting
-- CI check (GitHub Actions workflow, test assertion, etc.)
-- Project structure change
+1. Fix the existing rule that failed to prevent the behavior.
+   Diagnose why it failed — wording too vague, wrong loading tier
+   (not in context when needed), or no enforcement — and propose
+   editing, splitting, relocating, or mechanizing that rule.
+   Never add a parallel rule next to a failed one.
+2. Delete or merge rules when overlap, contradiction, or sheer
+   volume contributed to the failure.
+3. Mechanize (hook, CI check, pre-commit, script, permission
+   setting, template) when the behavior is mechanically checkable.
+   A mechanized check may replace the prose rule it enforces.
+4. Add a new rule only when no existing rule covers the problem.
+   State the net context cost: lines added, target loading tier
+   (always-loaded rule vs on-demand skill), and what compensating
+   trim keeps the tier within budget.
 
 Format as a numbered list of pairs. Include a severity rating for each:
 
@@ -60,8 +75,11 @@ self-corrects are not penalized.
 
 Adjustment rules:
 
-- Recurrence alone does not change severity. A self-corrected issue
-  stays at low even when the same pattern shows up a few times.
+- Within-session recurrence alone does not change severity; a
+  self-corrected issue stays at low even when the pattern repeats
+  a few times in the session.
+- Cross-session recurrence (the same pattern appears in a past
+  retrospective issue) escalates one level.
 - Excessive recurrence within a session that visibly degrades overall
   response quality can warrant medium, even when each instance is
   self-corrected.
@@ -129,3 +147,15 @@ remarks. Just the list of problem-countermeasure pairs.
 
 If there are no significant problem behaviors in the session, say so in
 one line and stop.
+
+## Step 3: Record the Retrospective
+
+Skip when there were no significant findings. Otherwise create one
+GitHub issue in ikuwow/dotfiles holding the problem/countermeasure
+list verbatim, via `--body-file` (never `--body`), title
+`Retrospective: <date> <one-line session summary>`, label
+`retrospective`. The label is provisioned once at setup; if
+`gh issue create` fails because it is missing, run
+`gh label create retrospective --repo ikuwow/dotfiles --force` and retry.
+The weekly-improvement routine consumes these issues — do not
+implement the countermeasures in this session unless the user asks.

--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -2,8 +2,6 @@
 name: retrospective
 description: Use when the user wants to reflect on AI communication quality and get improvement suggestions for rule files or the project itself. TRIGGER when user invokes /retrospective or asks to review the session.
 effort: xhigh
-context: fork
-agent: general-purpose
 ---
 
 # Session Retrospective
@@ -17,9 +15,10 @@ Focus on the interaction process, not on the task content itself.
 
 Fetch recent retrospective records before analyzing:
 `gh issue list --repo ikuwow/dotfiles --label retrospective --state all --limit 15 --json number,title,body,state`
-Use them to detect cross-session recurrence. A problem matching a
-past retrospective escalates one severity level and is marked
-"recurring", with the past issue number cited.
+Use them to detect cross-session recurrence: mark any problem that
+matches a past retrospective as "recurring" and cite the past issue
+number. The severity impact of recurrence is applied once, in the
+Severity Criteria adjustment rules below — do not also apply it here.
 
 ## Step 1: List Problem Behaviors
 


### PR DESCRIPTION
## Purpose

Part 4 of the AI rule compaction pass (see #250, #251, #252). The retrospective skill was the root cause of the rule bloat this whole pass exists to undo: its countermeasure menu only ever proposed adding rules, with no path to fix/merge/delete an existing one, and it had no cross-session memory — so every session's retro filed fresh additions and the always-loaded tier only grew. This redesigns it to close that loop. Out of scope: the retro still only records countermeasures; it does not implement them (the weekly-improvement routine does).

## Key changes

- Step 2's countermeasure menu is now priority-ordered: fix the rule that failed first (diagnosing why — vague wording, wrong loading tier, or no enforcement), then delete/merge, then mechanize, and only add a new rule as a last resort while stating its net context-budget cost
- New Step 0 loads past retrospective issues so a recurring problem escalates one severity level (via the Severity Criteria rule) and cites the prior issue, instead of being re-filed as if new
- New Step 3 records each retro as a GitHub issue (label `retrospective`), and `weekly-improvement.md` now consumes that backlog as its primary improvement source — cross-session patterns finally get a reader that runs on cron with a clean context
- `weekly-improvement.md` gains a rule-budget audit (`AIRULES.md` <= 140 lines, `claude/rules/*.md` <= 100 each) and its blanket "do not touch AIRULES" ban is relaxed to allow edits that implement a recorded countermeasure or bring a file back within budget

## Design notes for review

Non-obvious trade-offs worth a reviewer's eye:

- The skill runs inline (not `context: fork`). An initial `context: fork` was reverted after code review: per the Claude Code docs, a forked skill runs in isolation with no access to the conversation history, which is exactly the retrospective's only input. The skill must stay inline to see the session it is reviewing
- The `model: opus` pin is dropped, so the retro inherits the session model. `effort: xhigh` is kept as the main quality lever. Re-pin if you want retro quality independent of the session model
- The `140`-line `AIRULES.md` budget matches the end-state of #252 (which compresses it to ~137). On this branch `AIRULES.md` is still 157 (pre-#252); the routine would correctly flag it as over budget until #252 merges. Merge #252 before relying on the audit
- The plan's per-run `gh label create` is dropped from the skill (it isn't allow-listed, so it would prompt at unattended session-end auto-invoke). The label is provisioned once, with an inline fallback in Step 3 if it is ever missing

## Verification

- [x] `gh label create retrospective --repo ikuwow/dotfiles --force` → label now exists (`gh label list` confirms), so `gh issue create --label retrospective` (allow-listed) works without a per-run label step
- [x] Step 0 query `gh issue list --repo ikuwow/dotfiles --label retrospective --state all --json ...` → returns `[]` (well-formed, no issues yet)
- [ ] Run `/retrospective` in a throwaway session and confirm it runs inline (sees the conversation), loads past issues (Step 0), produces the analysis, and files a `retrospective`-labelled issue (Step 3) without a permission prompt
