### PR TITLE
Enforce a line-count budget on always-loaded AI rule files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,9 @@ repos:
         language: script
         pass_filenames: false
         files: ^scripts/(deploy|verify_deploy)\.sh$
+      - id: check-rule-budget
+        name: Enforce line-count budget on always-loaded AI rule files
+        entry: scripts/check_rule_budget.sh
+        language: script
+        pass_filenames: false
+        files: ^(AIRULES\.md|claude/rules/.*\.md)$

--- a/scripts/check_rule_budget.sh
+++ b/scripts/check_rule_budget.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Enforce a line-count budget on always-loaded AI rule files, so the
+# rules that load into every session don't grow unbounded again.
+
+set -eu
+
+AIRULES_MAX=140
+RULES_MAX=100
+
+errors=0
+
+check_budget() {
+  local path="$1"
+  local max="$2"
+  local lines
+  lines=$(wc -l < "$path" | tr -d ' ')
+  if [ "$lines" -le "$max" ]; then
+    echo "OK: $path ($lines / $max lines)"
+  else
+    echo "FAIL: $path is $lines lines, over the $max-line budget"
+    errors=$((errors + 1))
+  fi
+}
+
+check_budget AIRULES.md "$AIRULES_MAX"
+
+for f in claude/rules/*.md; do
+  check_budget "$f" "$RULES_MAX"
+done
+
+if [ "$errors" -gt 0 ]; then
+  echo "FAILED: $errors rule file(s) over budget"
+  exit 1
+else
+  echo "All rule files within budget"
+fi


### PR DESCRIPTION
## Purpose

Part 5 (optional, per the original plan) of the AI rule compaction pass (see #250-#254). The prior PRs cut the always-loaded rule tier from ~850 lines to under 200, but nothing mechanically stops it from creeping back — `weekly-improvement.md`'s rule-budget audit (#254) only catches drift on a weekly cron run. This adds the same budget as a pre-commit gate so an over-budget rule file fails immediately, at commit time.

## Key changes

- `scripts/check_rule_budget.sh`: `AIRULES.md` <= 140 lines, each `claude/rules/*.md` <= 100 lines — the same values `weekly-improvement.md` already audits against. Skills, agents, and routines are excluded (on-demand tier, not budget-constrained)
- Wired into `.pre-commit-config.yaml`, scoped to only run when `AIRULES.md` or `claude/rules/*.md` change (mirrors the existing `verify-deploy` hook's scoping pattern)

## Verification

- [x] `shellcheck scripts/check_rule_budget.sh` → clean
- [x] Ran the script against the current repo → all 5 rule files pass (`AIRULES.md` 137/140, others well under 100/100)
- [x] Verified the failure path in isolation (a copy of `AIRULES.md` padded past 140 lines) → script reports `FAIL` and returns non-zero
- [x] `pre-commit run check-rule-budget --files AIRULES.md claude/rules/git-essentials.md` → passed
