### PR TITLE
Pin retrospective skill to Fable regardless of session model

### DIFF
--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: retrospective
 description: Use when the user wants to reflect on AI communication quality and get improvement suggestions for rule files or the project itself. TRIGGER when user invokes /retrospective or asks to review the session.
+model: fable
 effort: xhigh
 ---
 


### PR DESCRIPTION
## Purpose

Follow-up to #254. That PR dropped the retrospective skill's `model: opus` pin so it would inherit the session model, mirroring `pr-selfcheck`'s pattern. On reflection, that pattern doesn't fit here: `pr-selfcheck` is a mechanical checklist match, while retrospective is a judgment-heavy analysis task — the entire point of its redesign was that it wasn't surfacing real problems. Pinning it to the strongest available model is worth the session-model independence.

## Key changes

- `claude/skills/retrospective/SKILL.md` frontmatter gains `model: fable` (Claude's most capable generally-available model), alongside the existing `effort: xhigh`

## Verification

- [x] Confirmed via `code.claude.com/docs/en/skills.md` that a skill's `model` frontmatter field overrides the model "for the rest of the current turn" — the docs list `model` and `context` as independent frontmatter fields, so this applies whether or not the skill runs forked; this skill runs inline (not forked)
