### PR TITLE
Route retrospective findings by scope in Step 3

### DIFF
--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -148,14 +148,32 @@ remarks. Just the list of problem-countermeasure pairs.
 If there are no significant problem behaviors in the session, say so in
 one line and stop.
 
-## Step 3: Record the Retrospective
+## Step 3: Route Findings by Scope
 
-Skip when there were no significant findings. Otherwise create one
-GitHub issue in ikuwow/dotfiles holding the problem/countermeasure
-list verbatim, via `--body-file` (never `--body`), title
-`Retrospective: <date> <one-line session summary>`, label
-`retrospective`. The label is provisioned once at setup; if
+Route each finding by the scope assigned in Step 2.
+
+### Global-scope findings
+
+Create one GitHub issue in ikuwow/dotfiles holding the global-scope
+problem/countermeasure pairs verbatim, via `--body-file` (never
+`--body`), title `Retrospective: <date> <one-line session summary>`,
+label `retrospective`. The label is provisioned once at setup; if
 `gh issue create` fails because it is missing, run
 `gh label create retrospective --repo ikuwow/dotfiles --force` and retry.
+Skip issue creation when there are no global-scope findings.
+
+ikuwow/dotfiles is a public repository. Sanitize the issue title and
+body: do not include private repository names, their PR/issue numbers,
+code, or quoted rule text. Describe each problem by its behavior
+pattern (e.g., "a work project's Terraform PR review") so the
+countermeasure stays understandable without the private context.
+
 The weekly-improvement routine consumes these issues — do not
-implement the countermeasures in this session unless the user asks.
+implement global countermeasures in this session unless the user asks.
+
+### Project-scope findings
+
+Never file these in ikuwow/dotfiles. Present them in the session and
+ask the user how to handle them (AskUserQuestion), offering per
+finding: apply to the project's rule files now / create an issue in
+the project's own repository / drop.

--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -154,26 +154,28 @@ Route each finding by the scope assigned in Step 2.
 
 ### Global-scope findings
 
-Create one GitHub issue in ikuwow/dotfiles holding the global-scope
-problem/countermeasure pairs verbatim, via `--body-file` (never
-`--body`), title `Retrospective: <date> <one-line session summary>`,
-label `retrospective`. The label is provisioned once at setup; if
-`gh issue create` fails because it is missing, run
+ikuwow/dotfiles is a public repository. Before filing, sanitize the
+global-scope problem/countermeasure pairs: do not include the names
+of private repositories, their PR/issue numbers, their code, or
+quoted text from their rule files. Describe each problem by its
+behavior pattern (e.g., "a work project's Terraform PR review") so
+the countermeasure stays understandable without the private context.
+
+Create one GitHub issue in ikuwow/dotfiles holding the sanitized
+pairs via `--body-file` (never `--body`), title
+`Retrospective: <date> <one-line session summary>` (sanitized as
+above), label `retrospective`. The label is provisioned once at
+setup; if `gh issue create` fails because it is missing, run
 `gh label create retrospective --repo ikuwow/dotfiles --force` and retry.
 Skip issue creation when there are no global-scope findings.
-
-ikuwow/dotfiles is a public repository. Sanitize the issue title and
-body: do not include private repository names, their PR/issue numbers,
-code, or quoted rule text. Describe each problem by its behavior
-pattern (e.g., "a work project's Terraform PR review") so the
-countermeasure stays understandable without the private context.
 
 The weekly-improvement routine consumes these issues — do not
 implement global countermeasures in this session unless the user asks.
 
 ### Project-scope findings
 
-Never file these in ikuwow/dotfiles. Present them in the session and
-ask the user how to handle them (AskUserQuestion), offering per
-finding: apply to the project's rule files now / create an issue in
-the project's own repository / drop.
+Never file these as retrospective issues in ikuwow/dotfiles. Present
+them in the session and ask the user how to handle them
+(AskUserQuestion), offering these choices for each finding: apply to
+the project's rule files now / create an issue in the project's own
+repository / drop.


### PR DESCRIPTION
## What

Rewrite Step 3 of the retrospective skill (`claude/skills/retrospective/SKILL.md`) to route findings by the scope assigned in Step 2:

- Global-scope findings: still filed as one `retrospective`-labeled issue in ikuwow/dotfiles, but only when at least one global-scope finding exists
- Project-scope findings: no longer filed in this repo; presented in-session with three options (apply to the project's rule files now / create an issue in the project's own repository / drop)
- New sanitization requirement for issue title and body: no private repository names, PR/issue numbers, code, or quoted rule text, since this repository is public

## Why

- Project-scope countermeasures filed here are dead backlog: the weekly-improvement routine only improves this repository, so it can never act on them
- This is a public repository, and past retrospective issues carried private work-project details (repo names, PR numbers, quoted rule content) in title and body

## Out of scope

- Sanitizing or deleting existing retrospective issues that already contain private details (separate manual decision)
- Cross-project recurrence detection for project-scope findings (Step 0 only reads this repo's issues; accepted tradeoff)

## How to verify

- [x] `pre-commit run --all-files` — all 8 hooks passed (trailing whitespace, EOF, JSON/YAML checks, large files, broken symlinks, deploy symlink verify, rule line-count budget)
- [x] Cross-checked the routing labels: Step 2's countermeasure format tags each item `(scope: global / project-specific)`, and the new Step 3 headings consume exactly those two scopes
- [ ] Behavioral check on the next `/retrospective` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157Qjbf33yT2aixPk5shjto
