### PR TITLE
Delegate retrospective analysis to a Fable subagent

### DIFF
--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -1,156 +1,74 @@
 ---
 name: retrospective
 description: Use when the user wants to reflect on AI communication quality and get improvement suggestions for rule files or the project itself. TRIGGER when user invokes /retrospective or asks to review the session.
-model: fable
-effort: xhigh
 ---
 
 # Session Retrospective
 
-Review the current session and identify problematic AI behaviors with
-structural countermeasures.
+Delegate the transcript analysis to a Fable subagent (stronger
+reasoning, session-independent perspective), then route the findings
+from the main session.
 
-Focus on the interaction process, not on the task content itself.
+The Fable subagent runs via the Agent tool's `model:` override, which
+works in Claude Code v2.1.202. Do not rely on this SKILL.md's own
+frontmatter `model:` field — at this version it does not switch the
+orchestrator model, so the orchestrator stays on the session default
+and only the delegated subagent gets Fable.
 
-## Step 0: Load Past Retrospectives
-
-Fetch recent retrospective records before analyzing:
-`gh issue list --repo ikuwow/dotfiles --label retrospective --state all --limit 15 --json number,title,body,state`
-Use them to detect cross-session recurrence: mark any problem that
-matches a past retrospective as "recurring" and cite the past issue
-number. The severity impact of recurrence is applied once, in the
-Severity Criteria adjustment rules below — do not also apply it here.
-
-## Step 1: List Problem Behaviors
-
-Scan the session for AI behaviors that caused issues. For each one, write:
-
-- What the AI did (concrete action, not vague description)
-- Why it was a problem (wasted time, wrong output, user had to correct, etc.)
-
-Keep each entry to 1-2 lines. Skip behaviors that had no real impact.
-
-## Step 2: Propose Structural Countermeasures
-
-For each problem, identify the governing rule first, then pick the
-highest applicable countermeasure in this order:
-
-1. Fix the existing rule that failed to prevent the behavior.
-   Diagnose why it failed — wording too vague, wrong loading tier
-   (not in context when needed), or no enforcement — and propose
-   editing, splitting, relocating, or mechanizing that rule.
-   Never add a parallel rule next to a failed one.
-2. Delete or merge rules when overlap, contradiction, or sheer
-   volume contributed to the failure.
-3. Mechanize (hook, CI check, pre-commit, script, permission
-   setting, template) when the behavior is mechanically checkable.
-   A mechanized check may replace the prose rule it enforces.
-4. Add a new rule only when no existing rule covers the problem.
-   State the net context cost: lines added, target loading tier
-   (always-loaded rule vs on-demand skill), and what compensating
-   trim keeps the tier within budget.
-
-Format as a numbered list of pairs. Include a severity rating for each:
+## Step 0: Load past retrospectives
 
 ```
-## 1. <short title>
-
-Problem: <what happened>
-Severity: high / medium / low (with brief justification: time wasted, user intervention needed, etc.)
-Countermeasure: <structural fix> (scope: global / project-specific)
+gh issue list --repo ikuwow/dotfiles --label retrospective --state all --limit 15 --json number,title,body,state
 ```
 
-### Severity Criteria
+Keep the JSON output for Step 1.
 
-Judge severity by how disproportionate the burden on the user was
-relative to the task's inherent complexity. Evaluate the final outcome,
-not intermediate trial-and-error — failed attempts that the AI
-self-corrects are not penalized.
+## Step 1: Delegate analysis to a Fable subagent
 
-| Level | Conditions (any one is sufficient) |
-|---|---|
-| high | Misjudgment that caused a direction change / User had to redo work manually / Errors introduced into deliverables / Confidently wrong assertion that misled the user |
-| medium | User correction or course adjustment needed / Disproportionately many confirmations relative to task complexity / Communication or judgment mistakes that could affect deliverable quality / Silent failure: appeared to succeed but the result was subtly wrong |
-| low | AI resolved the issue autonomously without user intervention — including trial-and-error, rule violations caught by hooks, and short-time self-corrections / Minor inefficiency only |
+Compute the current session's transcript path. The Session ID is
+already substituted below when this SKILL.md loads:
 
-Adjustment rules:
+- Session ID: `${CLAUDE_SESSION_ID}`
+- Munged cwd: run `pwd | sed 's|/|-|g'` (every `/` becomes `-`, so a
+  leading `/` becomes a leading `-`)
+- Full path: `$HOME/.claude/projects/<munged-cwd>/<session-id>.jsonl`
 
-- Within-session recurrence alone does not change severity; a
-  self-corrected issue stays at low even when the pattern repeats
-  a few times in the session.
-- Cross-session recurrence (the same pattern appears in a past
-  retrospective issue) escalates one level.
-- Excessive recurrence within a session that visibly degrades overall
-  response quality can warrant medium, even when each instance is
-  self-corrected.
-- If high interaction volume is justified by inherent task complexity,
-  do not rate it as medium.
-- When a checkpoint (plan-mode review, PR review, hook rejection) catches
-  an issue, judge severity by the impact the mistake would have had if
-  shipped, not by the fact that a checkpoint caught it. Cosmetic or
-  "could be cleaned up post-merge" issues stay low even when user
-  correction was visible; functionally broken or risky proposals warrant
-  medium even when caught early.
+Confirm the file exists with `ls -la <full-path>` before spawning.
+If it does not exist (rare, e.g. the transcript is still buffered),
+fall back to the newest `*.jsonl` in `$HOME/.claude/projects/<munged-cwd>/`.
 
-### Countermeasure Specificity
+Then invoke the Agent tool with:
 
-Each countermeasure must specify:
+- `subagent_type`: `general-purpose`
+- `model`: `fable`
+- `description`: `retrospective analysis`
+- `prompt`: paste the template below, substituting `<TRANSCRIPT_PATH>`
+  with the resolved absolute path and `<PAST_RETROSPECTIVES>` with the
+  JSON output from Step 0 (or the literal string `[]` if empty).
 
-- The exact target file path (e.g., `AIRULES.md`, `CLAUDE.md`,
-  `.claude/rules/foo.md`, `.pre-commit-config.yaml`)
-- The concrete content to add or modify — draft the actual wording, not
-  just "add a rule about X"
+Prompt template:
 
-### Placement Scope
+```
+You are performing a session retrospective on the outside.
 
-Choose the placement based on who benefits:
+Instructions: Read the analysis instructions at
+${CLAUDE_SKILL_DIR}/analysis.md and follow them exactly.
 
-- Team-shared enforcement → project's `CLAUDE.md` or its `rules/` directory
-- Personal habits or preferences → global `AIRULES.md` or `~/.claude/rules/`
-- Memory is for recording facts only. It must not be used as a mechanism
-  for behavior change (see Prohibited Countermeasures below).
+Inputs:
+- Session transcript (jsonl, one JSON object per line): <TRANSCRIPT_PATH>
+- Past retrospectives on this project (for cross-session recurrence detection): <PAST_RETROSPECTIVES>
 
-## Prohibited Countermeasures
+Output: return the analysis findings in the format specified in
+analysis.md. For each finding, include a `Scope:` tag with value
+`global` or `project-specific`. Do not create GitHub issues and do
+not invoke AskUserQuestion — the orchestrator handles routing after
+you return. Do not add preamble or closing remarks.
+```
 
-The following are NOT valid countermeasures. Never propose them:
+## Step 2: Route findings by scope
 
-- "Follow existing rules more carefully" or any variation of rule compliance
-- "Pay more attention to X"
-- "Be more careful about Y"
-- "Remember to Z"
-- Any countermeasure that relies on the model's judgment, attention, or
-  memory improving in the future
-- "Save to memory" / "Record in memory" — memory depends on model
-  judgment for recall and is not a structural enforcement mechanism.
-  Memory is valid for recording facts, but not for driving behavior change.
-- Restating an existing rule as if adding it would help
-
-The premise: the model's behavior cannot be trusted to improve through
-willpower. Only external enforcement mechanisms count.
-
-## Prohibited Root Causes
-
-Do not attribute problems to:
-
-- "Existing rule was not followed" — the rule exists but failed to prevent
-  the behavior, so the rule or enforcement is insufficient
-- "AI didn't understand the instruction" — if the instruction was clear,
-  the question is why the structure allowed misinterpretation
-
-Instead, ask: what structural change would have made the wrong behavior
-impossible or caught it before it caused damage?
-
-## Output Format
-
-Keep the output compact. No preamble, no summary section, no closing
-remarks. Just the list of problem-countermeasure pairs.
-
-If there are no significant problem behaviors in the session, say so in
-one line and stop.
-
-## Step 3: Route Findings by Scope
-
-Route each finding by the scope assigned in Step 2.
+Take the subagent's output verbatim and act on each finding based on
+its Scope tag.
 
 ### Global-scope findings
 

--- a/claude/skills/retrospective/analysis.md
+++ b/claude/skills/retrospective/analysis.md
@@ -1,0 +1,159 @@
+# Retrospective analysis instructions
+
+Analyze the provided session transcript and past retrospective issues,
+then produce a list of problem behaviors with structural countermeasures.
+
+Focus on the interaction process, not on the task content itself.
+
+## Cross-session recurrence
+
+Mark any problem that matches a past retrospective as "recurring" and
+cite the past issue number. The severity impact of recurrence is
+applied once, in the Severity Criteria adjustment rules below — do not
+also apply it here.
+
+## Step 1: List problem behaviors
+
+Scan the session for AI behaviors that caused issues. For each one, write:
+
+- What the AI did (concrete action, not vague description)
+- Why it was a problem (wasted time, wrong output, user had to correct, etc.)
+
+Keep each entry to 1-2 lines. Skip behaviors that had no real impact.
+
+## Step 2: Propose structural countermeasures
+
+For each problem, identify the governing rule first, then pick the
+highest applicable countermeasure in this order:
+
+1. Fix the existing rule that failed to prevent the behavior.
+   Diagnose why it failed — wording too vague, wrong loading tier
+   (not in context when needed), or no enforcement — and propose
+   editing, splitting, relocating, or mechanizing that rule.
+   Never add a parallel rule next to a failed one.
+1. Delete or merge rules when overlap, contradiction, or sheer
+   volume contributed to the failure.
+1. Mechanize (hook, CI check, pre-commit, script, permission
+   setting, template) when the behavior is mechanically checkable.
+   A mechanized check may replace the prose rule it enforces.
+1. Add a new rule only when no existing rule covers the problem.
+   State the net context cost: lines added, target loading tier
+   (always-loaded rule vs on-demand skill), and what compensating
+   trim keeps the tier within budget.
+
+Format as a numbered list of pairs. Include a severity rating and a
+scope tag (global / project-specific) for each:
+
+```
+## 1. <short title>
+
+Problem: <what happened>
+Severity: high / medium / low (with brief justification)
+Scope: global / project-specific
+Countermeasure: <structural fix>
+```
+
+### Severity Criteria
+
+Judge severity by how disproportionate the burden on the user was
+relative to the task's inherent complexity. Evaluate the final outcome,
+not intermediate trial-and-error — failed attempts that the AI
+self-corrects are not penalized.
+
+| Level | Conditions (any one is sufficient) |
+|---|---|
+| high | Misjudgment that caused a direction change / User had to redo work manually / Errors introduced into deliverables / Confidently wrong assertion that misled the user |
+| medium | User correction or course adjustment needed / Disproportionately many confirmations relative to task complexity / Communication or judgment mistakes that could affect deliverable quality / Silent failure: appeared to succeed but the result was subtly wrong |
+| low | AI resolved the issue autonomously without user intervention — including trial-and-error, rule violations caught by hooks, and short-time self-corrections / Minor inefficiency only |
+
+Adjustment rules:
+
+- Within-session recurrence alone does not change severity; a
+  self-corrected issue stays at low even when the pattern repeats
+  a few times in the session.
+- Cross-session recurrence (the same pattern appears in a past
+  retrospective issue) escalates one level.
+- Excessive recurrence within a session that visibly degrades overall
+  response quality can warrant medium, even when each instance is
+  self-corrected.
+- If high interaction volume is justified by inherent task complexity,
+  do not rate it as medium.
+- When a checkpoint (plan-mode review, PR review, hook rejection) catches
+  an issue, judge severity by the impact the mistake would have had if
+  shipped, not by the fact that a checkpoint caught it. Cosmetic or
+  "could be cleaned up post-merge" issues stay low even when user
+  correction was visible; functionally broken or risky proposals warrant
+  medium even when caught early.
+
+### Countermeasure Specificity
+
+Each countermeasure must specify:
+
+- The exact target file path (e.g., `AIRULES.md`, `CLAUDE.md`,
+  `.claude/rules/foo.md`, `.pre-commit-config.yaml`)
+- The concrete content to add or modify — draft the actual wording, not
+  just "add a rule about X"
+
+### Placement Scope (used for the Scope tag)
+
+Choose the placement based on who benefits:
+
+- Team-shared enforcement → project's `CLAUDE.md` or its `rules/` directory (tag: project-specific)
+- Personal habits or preferences → global `AIRULES.md` or `~/.claude/rules/` (tag: global)
+- Memory is for recording facts only. It must not be used as a mechanism
+  for behavior change (see Prohibited Countermeasures below).
+
+## Prohibited Countermeasures
+
+The following are NOT valid countermeasures. Never propose them:
+
+- "Follow existing rules more carefully" or any variation of rule compliance
+- "Pay more attention to X"
+- "Be more careful about Y"
+- "Remember to Z"
+- Any countermeasure that relies on the model's judgment, attention, or
+  memory improving in the future
+- "Save to memory" / "Record in memory" — memory depends on model
+  judgment for recall and is not a structural enforcement mechanism.
+  Memory is valid for recording facts, but not for driving behavior change.
+- Restating an existing rule as if adding it would help
+
+The premise: the model's behavior cannot be trusted to improve through
+willpower. Only external enforcement mechanisms count.
+
+## Prohibited Root Causes
+
+Do not attribute problems to:
+
+- "Existing rule was not followed" — the rule exists but failed to prevent
+  the behavior, so the rule or enforcement is insufficient
+- "AI didn't understand the instruction" — if the instruction was clear,
+  the question is why the structure allowed misinterpretation
+
+Instead, ask: what structural change would have made the wrong behavior
+impossible or caught it before it caused damage?
+
+## Output Format
+
+Keep the output compact. No preamble, no summary section, no closing
+remarks. Just the list of problem-countermeasure pairs, each tagged
+with severity and scope.
+
+If there are no significant problem behaviors in the session, say so in
+one line and stop.
+
+## Reading the transcript
+
+The jsonl is one JSON object per line and can be large (hundreds of
+KB) with verbose noise — full tool outputs, injected CLAUDE.md /
+system-reminder blocks, permission prompts. Do not let the noise bury
+the reasoning.
+
+- For a small file, read it directly
+- For a large file, use Bash (`wc -l`, `jq`, `tail`) to extract the
+  signal: user turns, the assistant's own text and reasoning, tool
+  calls and their key results. Skip or skim bulk tool output and
+  repeated system reminders
+- The transcript may not include the currently-in-progress turn (the
+  one that triggered this retrospective). If so, note it in your
+  output; do not fabricate content for it.


### PR DESCRIPTION
## Why

`/retrospective` was defined with `model: fable` and `effort: xhigh` in its SKILL.md frontmatter, intending to run on Fable for stronger outside-view analysis. In Claude Code v2.1.202 this override does not take effect: the session log shows every turn is served by the session default (`claude-opus-4-7` in my case) even when the retrospective skill is active. The Fable-branded identity string that the harness injects into the system prompt is decoupled from the actual runtime model, which made this easy to miss until the session jsonl was checked.

The Agent tool's `model:` parameter, on the other hand, does route to Fable — so the workaround is to keep the orchestrator on the session model and delegate the analysis to a Fable subagent, matching the pattern already used by `claude/agents/fable-advisor.md`.

## What

Split the retrospective skill into two files:

- `SKILL.md` (orchestrator): runs on the session model. Step 0 loads past retrospectives, Step 1 spawns a Fable subagent via the Agent tool, Step 2 routes findings by scope (GitHub issue for global, AskUserQuestion for project-scope).
- `analysis.md` (delegated body): the previous Steps 1-2 content (problem behaviors, countermeasures, severity criteria, prohibited categories, output format). Loaded and executed by the Fable subagent.

Removed the ineffective `model: fable` and `effort: xhigh` fields from SKILL.md frontmatter. The subagent gets Fable via the Agent tool's explicit `model:` parameter instead.

## Verification

Session-log inspection to confirm the frontmatter override does NOT switch models. Every `type=assistant` entry in this session's jsonl was served by `claude-opus-4-7`, including turns invoked as `/retrospective`:

```
$ jq -r 'select(.type=="assistant") | .message.model' \
    ~/.claude/projects/-Users-ikuwow-dotfiles/387dd018-8921-4af5-9e4c-ac07fb91eae6.jsonl \
  | sort -u
claude-opus-4-7
```

Probe of the Agent tool `model:` parameter with a trivial general-purpose subagent (`model: "fable"`, prompt: `"reply PROBE_OK"`). Its jsonl records:

```
$ jq -r 'select(.type=="assistant") | .message.model' \
    ~/.claude/projects/-Users-ikuwow-dotfiles/387dd018-8921-4af5-9e4c-ac07fb91eae6/subagents/agent-a92a2836298a7de41.jsonl \
  | sort -u
claude-fable-5
```

End-to-end run of the new SKILL.md orchestration path (Step 0 → Step 1 subagent → returned findings): the subagent produced a valid retrospective on this session's own transcript, and its jsonl model was dominantly `claude-fable-5` (with a small amount of `claude-opus-4-7` for auxiliary compaction turns, expected).

## Notes

- Session-context sharing: the Fable subagent does NOT inherit conversation history. It reads the session transcript jsonl directly from `~/.claude/projects/<munged-cwd>/${CLAUDE_SESSION_ID}.jsonl`, the same pattern as the existing `fable-advisor` agent.
- If the Claude Code SKILL.md `model:` frontmatter starts working in a future CLI version, this split can be reverted or the two files can be re-merged with `model: fable` restored.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
