### PR TITLE
Fix pr-reaction.md bot targeting policy to require live API verification

### DIFF
--- a/claude/skills/git-workflow/pr-reaction.md
+++ b/claude/skills/git-workflow/pr-reaction.md
@@ -10,13 +10,17 @@ when the author is a bot. Never touch anything with a human author
 autonomously — summarize to the user and wait for an explicit
 instruction.
 
-- Bot thread = every comment in it has `user.type == "Bot"`. Any single
-  human comment flips the thread to the human path.
-- Bot `NEW_TOP_COMMENT` / `NEW_REVIEW` = event line tag is `[BOT]`.
-- Known bot logins: `github-actions`, `dependabot`,
-  `copilot-pull-request-reviewer`, `renovate`.
-- `user.type == "User"` bots (`devin-ai-integration` etc.) go on the
-  human path.
+- Bot thread = every comment in it has REST `user.type == "Bot"`. Any
+  single `User`-type comment flips the thread to the human path — a
+  bot can open a thread that a human later joins.
+- Bot `NEW_TOP_COMMENT` / `NEW_REVIEW` = event line tag is `[BOT]`
+  (derived from GraphQL `author.__typename` in `bin/pr-monitor`; on
+  conflict with any other signal, the tag wins).
+- Author type is always taken from a live API response
+  (`user.type` / `__typename`), never assumed from a login name. The
+  same GitHub App can show a different login string per API — e.g.
+  GraphQL `author.login` omits the `[bot]` suffix that REST
+  `user.login` includes — so match on type, not on login text.
 
 ## Step 1: List and classify threads (read-only)
 
@@ -96,6 +100,8 @@ session. Switch to reply-only and notify the user.
   when later comments include a human.
 - Posting a top-level `gh pr comment` in place of a review-thread
   reply to bypass the bot-check.
+- Classifying an author from a remembered login string instead of a
+  live `user.type` / `__typename` lookup.
 
 ## References
 


### PR DESCRIPTION
## Summary

- The `pr-reaction.md` Targeting policy named specific logins as bot/human examples. One example no longer matches the current API response for that GitHub App, and an agent trusted the stale example instead of checking live API data, misclassifying a bot-authored comment as human-authored.
- Replace the login examples with signal-only rules: REST `user.type` for review-thread comments, the event-line `[BOT]`/`[USER]` tag (derived from GraphQL `__typename` in `bin/pr-monitor`) for top-level comments and reviews, plus an explicit note that the same GitHub App's login string differs between REST and GraphQL — so classification must key off type, not login text.
- No behavior change to `bin/pr-monitor` itself; its existing `__typename == "Bot"` check already classifies correctly.

## Test plan

- [x] Verified against a live PR: the affected GitHub App resolves to `user.type == "Bot"` (REST) and `__typename == "Bot"` (GraphQL), confirming the deleted login-based example was stale.
- [x] `/pr-selfcheck` on this PR.
