### PR TITLE
Cover Claude Code harness behavior in external-tool-claims rule

### DIFF
--- a/claude/rules/external-tool-claims.md
+++ b/claude/rules/external-tool-claims.md
@@ -13,6 +13,16 @@ that behavior against primary sources before stating it.
 - Stating idempotency, safety, or side-effect properties
 - Recommending a workflow that depends on a tool doing something
   reliably under specific conditions
+- Stating how Claude Code itself behaves — skill auto-invocation
+  triggers, `model:` frontmatter effects, subagent context
+  inheritance, hook execution, permission evaluation, and what the
+  user actually sees of a turn (tool inputs and Write file contents
+  are not rendered to the user) — is exactly as fact-checkable as
+  third-party tool behavior, and just as often wrong from unverified
+  recall. For which model actually served a turn, the session
+  jsonl's `.message.model` is the ground truth; the environment
+  identity string ("You are powered by …") is injected branding and
+  can disagree with the runtime.
 
 ## Verification sources, in priority order
 
@@ -35,3 +45,7 @@ their time testing it on their host.
   source even when you "know" the answer
 - Layer multiple unverified workarounds on top of a tool whose behavior
   was never read; root-cause first by reading the source
+- Treat examples or assertions inside local rule/skill files as
+  primary sources for external-service behavior — rule prose
+  documents policy, not measured fact; measure the API response
+  itself

--- a/claude/rules/external-tool-claims.md
+++ b/claude/rules/external-tool-claims.md
@@ -15,14 +15,9 @@ that behavior against primary sources before stating it.
   reliably under specific conditions
 - Stating how Claude Code itself behaves — skill auto-invocation
   triggers, `model:` frontmatter effects, subagent context
-  inheritance, hook execution, permission evaluation, and what the
-  user actually sees of a turn (tool inputs and Write file contents
-  are not rendered to the user) — is exactly as fact-checkable as
-  third-party tool behavior, and just as often wrong from unverified
-  recall. For which model actually served a turn, the session
-  jsonl's `.message.model` is the ground truth; the environment
-  identity string ("You are powered by …") is injected branding and
-  can disagree with the runtime.
+  inheritance, hook execution, permission evaluation, or what the
+  user actually sees of a turn (e.g., whether tool inputs or Write
+  file contents are rendered to the user)
 
 ## Verification sources, in priority order
 
@@ -30,6 +25,10 @@ that behavior against primary sources before stating it.
 2. Source code of the tool itself (`gh search code`, `gh api`,
    `deepwiki`, `context7`)
 3. Issues / discussions with reproducible reports
+
+For which model served a turn, prefer the session jsonl's
+`.message.model` over the environment identity string ("You are
+powered by …"); the two can disagree.
 
 If none of these can be verified, mark the claim as `要検証 / unverified`
 and either ask the user to verify with a clear "I have not confirmed


### PR DESCRIPTION
## Purpose

Claims about Claude Code's own harness behavior (skill auto-invocation, `model:` frontmatter, subagent context inheritance, what the user actually sees of a turn) were asserted from unverified recall in four consecutive retrospective sessions (#257, #263, #264, #267). The countermeasure bullet was drafted in #257 but never landed; this PR lands it in the always-loaded external-tool-claims rule.

## Key changes

- "When this applies" now names Claude Code itself as a fact-checkable category (skill triggers, `model:` frontmatter, subagent context inheritance, hooks, permission evaluation, what the user actually sees of a turn)
- "Verification sources" now says to prefer the session jsonl's `.message.model` over the "You are powered by …" identity string for which model served a turn; the two were observed to disagree in the #263 session
- "Don't" now prohibits treating examples inside local rule/skill files as primary sources for external-service behavior (#267 finding 1: a stale login example in pr-reaction.md was taken as fact, skipping live API verification)

## Notes

Wording deviates from the issue drafts after in-flight code review: the drafts embedded unverified rendering/mechanism assertions as flat facts inside the rule — the exact failure family this rule targets — so the trigger bullet was reworded claim-free and the model-identity guidance moved to Verification sources with hedged wording.

## Verification

- [x] `pre-commit run --files claude/rules/external-tool-claims.md` → all hooks passed, check-rule-budget OK (50 / 100 lines)

## Related issues

Lands #257 finding 1, #263 finding 1, #264 finding 1(a), #267 findings 1(b) and 2. No issue is closable on this PR alone: #257 also needs the AIRULES batch PR, and #263 / #264 / #267 also need the git-workflow enforcement PR (both follow in this batch).
