### PR TITLE
Mechanize git-workflow enforcement with PreToolUse hooks

### DIFF
--- a/claude/hooks/block_excuse_phrases.py
+++ b/claude/hooks/block_excuse_phrases.py
@@ -6,9 +6,14 @@ AIRULES.md (the 「正直」「本当のところ」「ぶっちゃけ」 ban un
 or qualifies an opinion).
 The model knows the rule but slips. A literal substring match cannot
 disambiguate legitimate uses (名詞 like 「正直者」), so this hook does
-not try. It blocks at most once per Stop chain: the second invocation
-arrives with stop_hook_active=true and is allowed through, preventing
-infinite loops.
+not try. It does exclude one legitimate case: text inside backtick
+code spans (inline `...` or fenced ``` blocks) is a *mention*, not a
+*use*, of the phrase (e.g. quoting it in a retrospective Problem
+line), so it is stripped before matching. Other legitimate uses
+remain accepted false positives, pinned below. It blocks at most once
+per Stop chain: the second invocation arrives with
+stop_hook_active=true and is allowed through, preventing infinite
+loops.
 
 I/O failures (stdin parse, missing transcript_path, transcript read,
 poll timeout) are swallowed and the hook exits 0 — a Stop hook that
@@ -48,7 +53,10 @@ REASON = (
     "The damage is retroactive (it taints prior statements) and "
     "prospective (it taints future ones), and it cannot be unplanted. "
     "「本当のところ」「ぶっちゃけ」 carry the same structural harm.\n\n"
-    "Judge your own usage and rewrite if it was 断り書き."
+    "Judge your own usage and rewrite if it was 断り書き.\n\n"
+    "When you need to mention (not use) a banned phrase — e.g. quoting "
+    "it in a retrospective Problem line — wrap it in backticks so this "
+    "hook can tell mention from use."
 )
 
 
@@ -79,6 +87,73 @@ def is_forbidden(text):
     False
     """
     return bool(FORBIDDEN_PATTERN.search(text))
+
+
+_FENCE_RE = re.compile(r"^(```|~~~)")
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+
+
+def _strip_inline_code(line):
+    """Remove paired inline backtick spans from a single line.
+
+    A trailing unpaired backtick truncates the rest of the line —
+    there is no closing backtick to pair with, so everything after it
+    is inside an unterminated span and is dropped rather than risking
+    a false match on the fragment that follows.
+    """
+    line = _INLINE_CODE_RE.sub("", line)
+    if line.count("`") % 2 == 1:
+        line = line[: line.rfind("`")]
+    return line
+
+
+def strip_code_spans(text):
+    """Remove fenced code blocks and inline backtick spans from text.
+
+    Code spans are a *mention*, not a *use*, of a phrase — quoting a
+    banned phrase in backticks to talk about it (e.g. a retrospective
+    Problem line) should not trip the hook the way actually using it
+    as 断り書き would.
+
+    Banned phrase inside an inline backtick span is removed, the rest
+    of the line is kept:
+
+    >>> strip_code_spans("説明: `正直`は禁止らしい")
+    '説明: は禁止らしい'
+
+    Banned phrase inside a fenced code block is removed, fences
+    included:
+
+    >>> strip_code_spans("before\\n```\\n正直\\n```\\nafter")
+    'before\\nafter'
+
+    Banned phrase outside any code span is preserved:
+
+    >>> strip_code_spans("正直それは無理やと思う")
+    '正直それは無理やと思う'
+
+    An unpaired trailing fence is treated as an unterminated code
+    block: everything from the fence onward is dropped rather than
+    risking a false negative on unterminated content:
+
+    >>> strip_code_spans("before\\n```\\n正直")
+    'before'
+
+    An unpaired trailing backtick truncates the line at the backtick:
+
+    >>> strip_code_spans("正直 before ` after")
+    '正直 before '
+    """
+    out_lines = []
+    in_fence = False
+    for line in text.split("\n"):
+        if _FENCE_RE.match(line.strip()):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        out_lines.append(_strip_inline_code(line))
+    return "\n".join(out_lines)
 
 
 def collect_current_turn_assistant_text(events):
@@ -226,7 +301,7 @@ def main():
             )
             sys.exit(0)
 
-    if is_forbidden(text):
+    if is_forbidden(strip_code_spans(text)):
         print(json.dumps({"decision": "block", "reason": REASON}))
     sys.exit(0)
 

--- a/claude/hooks/block_excuse_phrases.py
+++ b/claude/hooks/block_excuse_phrases.py
@@ -157,11 +157,17 @@ def strip_code_spans(text):
 
 
 def collect_current_turn_assistant_text(events):
-    """Concatenate assistant text emitted since the last real user message.
+    """Collect assistant text blocks emitted since the last real user message.
 
     Walks events backward. Stops at a real user message. user events
     whose content is purely tool_result blocks are tool-call re-entries
     and are skipped, not treated as turn boundaries.
+
+    Returns a list of per-block strings (reverse-walk order) rather
+    than one joined string, so strip_code_spans can be applied per
+    block: joining first would let an unpaired fence in one block
+    silently swallow the prose — and any banned phrase — of every
+    other block.
 
     Single-turn capture:
 
@@ -172,7 +178,7 @@ def collect_current_turn_assistant_text(events):
     ...     ]}},
     ... ]
     >>> collect_current_turn_assistant_text(events)
-    '正直そう思う'
+    ['正直そう思う']
 
     Tool-call re-entry does not end the turn; both text blocks are
     captured (in reverse-walk order):
@@ -193,7 +199,7 @@ def collect_current_turn_assistant_text(events):
     ...     ]}},
     ... ]
     >>> collect_current_turn_assistant_text(events)
-    'second\\nfirst'
+    ['second', 'first']
 
     A real user message ends the scan; older turns are not captured:
 
@@ -207,12 +213,12 @@ def collect_current_turn_assistant_text(events):
     ...     ]}},
     ... ]
     >>> collect_current_turn_assistant_text(events)
-    'current'
+    ['current']
 
     Empty input:
 
     >>> collect_current_turn_assistant_text([])
-    ''
+    []
 
     Malformed events are skipped silently — system events, assistant
     messages with missing or null content, etc. — so the hook does not
@@ -230,7 +236,7 @@ def collect_current_turn_assistant_text(events):
     ...     ]}},
     ... ]
     >>> collect_current_turn_assistant_text(events)
-    '正直そう思う'
+    ['正直そう思う']
     """
     texts = []
     for event in reversed(events):
@@ -249,7 +255,7 @@ def collect_current_turn_assistant_text(events):
         for block in event.get("message", {}).get("content", []) or []:
             if isinstance(block, dict) and block.get("type") == "text":
                 texts.append(block.get("text", ""))
-    return "\n".join(texts)
+    return texts
 
 
 def main():
@@ -274,9 +280,9 @@ def main():
         print(f"block_excuse_phrases: transcript read failed: {e}", file=sys.stderr)
         sys.exit(0)
 
-    text = collect_current_turn_assistant_text(events)
+    blocks = collect_current_turn_assistant_text(events)
 
-    if not text:
+    if not blocks:
         poll_start = time.monotonic()
         last_err = None
         for _ in range(POLL_MAX_ITERATIONS):
@@ -287,11 +293,11 @@ def main():
             except (OSError, json.JSONDecodeError) as e:
                 last_err = e
                 continue
-            text = collect_current_turn_assistant_text(events)
-            if text:
+            blocks = collect_current_turn_assistant_text(events)
+            if blocks:
                 break
 
-        if not text:
+        if not blocks:
             elapsed_ms = int((time.monotonic() - poll_start) * 1000)
             err_suffix = f" last_err={last_err!r}" if last_err else ""
             print(
@@ -301,7 +307,7 @@ def main():
             )
             sys.exit(0)
 
-    if is_forbidden(strip_code_spans(text)):
+    if any(is_forbidden(strip_code_spans(block)) for block in blocks):
         print(json.dumps({"decision": "block", "reason": REASON}))
     sys.exit(0)
 

--- a/claude/hooks/block_raw_github_fetch.py
+++ b/claude/hooks/block_raw_github_fetch.py
@@ -49,7 +49,8 @@ def is_raw_github_fetch(command: str) -> bool:
 if __name__ == "__main__":
     try:
         data = json.load(sys.stdin)
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"block_raw_github_fetch: stdin parse failed: {e}", file=sys.stderr)
         sys.exit(0)
 
     tool_name = data.get("tool_name", "")

--- a/claude/hooks/block_raw_github_fetch.py
+++ b/claude/hooks/block_raw_github_fetch.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Deny curl/wget fetches of raw.githubusercontent.com in favor of ``gh``.
+
+AIRULES.md ("GitHubの操作は...`gh` コマンドを使う。ghが使えない環境や
+ghで実現できない操作の場合のみ...`raw.githubusercontent.com` 等を使って
+よい") only permits fetching raw.githubusercontent.com directly when
+``gh`` itself is unavailable. This PreToolUse hook mechanizes the
+default case: a Bash command that reaches for ``curl``/``wget`` against
+that domain is denied and pointed at the ``gh api`` equivalent instead.
+The predicate is narrowed to ``curl``/``wget`` invocations (not any
+mention of the domain) so commands that merely reference the domain in
+passing — a commit message, a comment, a grep pattern — are not
+tripped.
+
+Spec: https://code.claude.com/docs/en/hooks
+"""
+import json
+import re
+import sys
+
+_DOMAIN_RE = re.compile(r"raw\.githubusercontent\.com")
+_FETCH_TOOL_RE = re.compile(r"\b(curl|wget)\b")
+
+REASON = (
+    'Use gh instead: gh api repos/<owner>/<repo>/contents/<path> '
+    '-H "Accept: application/vnd.github.raw". Fall back to the raw URL '
+    "only if gh itself is unavailable — state that explicitly and ask "
+    "the user."
+)
+
+
+def is_raw_github_fetch(command: str) -> bool:
+    """Return True if command fetches raw.githubusercontent.com via curl/wget.
+
+    >>> is_raw_github_fetch("curl -sL https://raw.githubusercontent.com/a/b/main/x")
+    True
+    >>> is_raw_github_fetch("wget https://raw.githubusercontent.com/a/b/main/x")
+    True
+    >>> is_raw_github_fetch("git commit -m 'mentions raw.githubusercontent.com'")
+    False
+    >>> is_raw_github_fetch("curl -sL https://example.com/a/b")
+    False
+    >>> is_raw_github_fetch("")
+    False
+    """
+    return bool(_DOMAIN_RE.search(command) and _FETCH_TOOL_RE.search(command))
+
+
+if __name__ == "__main__":
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    command = data.get("tool_input", {}).get("command", "")
+
+    if tool_name == "Bash" and is_raw_github_fetch(command):
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": REASON,
+            },
+        }))
+
+    sys.exit(0)

--- a/claude/hooks/guard_default_branch_edits.py
+++ b/claude/hooks/guard_default_branch_edits.py
@@ -1,15 +1,25 @@
 #!/usr/bin/env python3
-"""Ask before Write/Edit/NotebookEdit touches a non-ignored path on the default branch.
+"""Deny once per session, then allow: guard default-branch edits.
 
 git-essentials.md ("Never create or edit files on the default branch")
 is a git-workflow precondition the model is expected to enforce on its
 own, but retrospectives found edits landing on main before a branch
-existed. This PreToolUse hook raises that case as a permission prompt
-rather than blocking it outright ("ask", not "deny"): the check fires
-in every repo, including ones where a user-instructed default-branch
-edit is genuinely intended (a quick fix directly on someone else's
-throwaway repo, a repo with no branching workflow at all, etc.), and
-denying outright would remove that legitimate path.
+existed. Some repos (this dotfiles repo included) also have sessions
+where the user genuinely wants direct default-branch work, so a
+permission prompt on every Write/Edit is the wrong shape — it would
+either interrupt the legitimate case repeatedly or train the user to
+reflexively approve it.
+
+This PreToolUse hook instead mirrors the UX of Claude Code's GitHub
+Actions security pre-check: the first Write/Edit/NotebookEdit that
+targets a non-ignored path on the default branch is denied outright,
+with branch-first guidance and a sanctioned-retry clause. A marker
+file then records that this session has already been warned for this
+repo; every later attempt in the same session, same repo, is allowed
+silently — covering the exceptional "yes, edit main directly" case
+without a user prompt. The marker is keyed on ``session_id`` plus a
+hash of the repo root and lives in ``tempfile.gettempdir()``, so it
+does not persist or leak across sessions or repos.
 
 Paths are resolved with ``os.path.realpath`` before any git check.
 Files under this repository are routinely edited through their
@@ -21,22 +31,28 @@ actually lands inside this repository's working tree.
 Every subprocess call is fail-open: a directory outside any git work
 tree, a detached HEAD, an unset ``origin/HEAD``, or a ``git`` binary
 that errors or times out all result in ``exit(0)`` rather than a false
-"ask". Expected fail-open cases (no work tree, detached HEAD, unset
+deny. Expected fail-open cases (no work tree, detached HEAD, unset
 ``origin/HEAD``) exit silently; anything unexpected (a bug in this
 hook, a git timeout) additionally prints a one-line stderr breadcrumb
 so hook logs can distinguish "rule not violated" from "hook broken".
-The target path may not exist yet (Write creates new files), so git
-commands are anchored at the nearest existing ancestor directory
-instead of the path itself.
+An unwritable temp directory does not suppress the deny — the marker
+write is best-effort, and the deny still fires even if the session
+cannot be remembered. The target path may not exist yet (Write
+creates new files), so git commands are anchored at the nearest
+existing ancestor directory instead of the path itself.
 
 Spec: https://code.claude.com/docs/en/hooks
 """
+import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
+import tempfile
 
 _ORIGIN_PREFIX = "refs/remotes/origin/"
+_SESSION_ID_SANITIZE_RE = re.compile(r"[^A-Za-z0-9-]")
 
 
 def strip_origin_prefix(ref: str) -> str:
@@ -54,6 +70,25 @@ def strip_origin_prefix(ref: str) -> str:
     if ref.startswith(_ORIGIN_PREFIX):
         return ref[len(_ORIGIN_PREFIX):]
     return ref
+
+
+def sanitize_session_id(session_id: str) -> str:
+    """Keep only ``[A-Za-z0-9-]`` characters from a session id.
+
+    Used to build a safe marker filename from a value that arrives
+    over stdin JSON and should not be trusted with path separators or
+    other filesystem-meaningful characters.
+
+    >>> sanitize_session_id("abc-123")
+    'abc-123'
+    >>> sanitize_session_id("abc/123 def")
+    'abc123def'
+    >>> sanitize_session_id("unknown")
+    'unknown'
+    >>> sanitize_session_id("")
+    ''
+    """
+    return _SESSION_ID_SANITIZE_RE.sub("", session_id)
 
 
 def nearest_existing_dir(path: str) -> str:
@@ -80,6 +115,15 @@ def _run_git(args, cwd):
     )
 
 
+def _marker_path(session_id: str, repo_root: str) -> str:
+    """Build the per-session, per-repo marker file path."""
+    sid = sanitize_session_id(session_id) or "unknown"
+    repokey = hashlib.sha1(repo_root.encode("utf-8")).hexdigest()[:12]
+    return os.path.join(
+        tempfile.gettempdir(), f"claude-guard-default-branch-{sid}-{repokey}"
+    )
+
+
 def main():
     try:
         data = json.load(sys.stdin)
@@ -94,6 +138,8 @@ def main():
     path = tool_input.get("file_path") or tool_input.get("notebook_path") or ""
     if not path:
         sys.exit(0)
+
+    session_id = data.get("session_id") or "unknown"
 
     try:
         real = os.path.realpath(path)
@@ -124,20 +170,32 @@ def main():
 
         result = _run_git(["rev-parse", "--show-toplevel"], start_dir)
         repo_root = result.stdout.strip() if result.returncode == 0 else start_dir
+
+        marker = _marker_path(session_id, repo_root)
+        if os.path.exists(marker):
+            sys.exit(0)
     except Exception as e:
         print(f"guard_default_branch_edits: check failed: {e!r}", file=sys.stderr)
         sys.exit(0)
 
+    try:
+        with open(marker, "x", encoding="utf-8"):
+            pass
+    except OSError:
+        pass
+
     print(json.dumps({
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": "ask",
+            "permissionDecision": "deny",
             "permissionDecisionReason": (
                 f"Write/Edit targets a non-ignored path on the default "
                 f"branch '{current}' of {repo_root}. git-essentials "
                 f"prohibits editing files on the default branch — branch "
-                f"first (invoke the git-workflow skill). Approve only if "
-                f"editing on the default branch is genuinely intended."
+                f"first (invoke the git-workflow skill). Only when the "
+                f"user has explicitly asked for work directly on the "
+                f"default branch, retry this edit: retries in this "
+                f"session are allowed for this repo."
             ),
         },
     }))

--- a/claude/hooks/guard_default_branch_edits.py
+++ b/claude/hooks/guard_default_branch_edits.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Ask before Write/Edit/NotebookEdit touches a tracked file on the default branch.
+"""Ask before Write/Edit/NotebookEdit touches a non-ignored path on the default branch.
 
 git-essentials.md ("Never create or edit files on the default branch")
 is a git-workflow precondition the model is expected to enforce on its
@@ -20,10 +20,14 @@ actually lands inside this repository's working tree.
 
 Every subprocess call is fail-open: a directory outside any git work
 tree, a detached HEAD, an unset ``origin/HEAD``, or a ``git`` binary
-that errors or times out all result in a silent ``exit(0)`` rather
-than a false "ask". The target path may not exist yet (Write creates
-new files), so git commands are anchored at the nearest existing
-ancestor directory instead of the path itself.
+that errors or times out all result in ``exit(0)`` rather than a false
+"ask". Expected fail-open cases (no work tree, detached HEAD, unset
+``origin/HEAD``) exit silently; anything unexpected (a bug in this
+hook, a git timeout) additionally prints a one-line stderr breadcrumb
+so hook logs can distinguish "rule not violated" from "hook broken".
+The target path may not exist yet (Write creates new files), so git
+commands are anchored at the nearest existing ancestor directory
+instead of the path itself.
 
 Spec: https://code.claude.com/docs/en/hooks
 """
@@ -79,7 +83,11 @@ def _run_git(args, cwd):
 def main():
     try:
         data = json.load(sys.stdin)
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError) as e:
+        print(
+            f"guard_default_branch_edits: stdin parse failed: {e}",
+            file=sys.stderr,
+        )
         sys.exit(0)
 
     tool_input = data.get("tool_input", {}) or {}
@@ -116,7 +124,8 @@ def main():
 
         result = _run_git(["rev-parse", "--show-toplevel"], start_dir)
         repo_root = result.stdout.strip() if result.returncode == 0 else start_dir
-    except Exception:
+    except Exception as e:
+        print(f"guard_default_branch_edits: check failed: {e!r}", file=sys.stderr)
         sys.exit(0)
 
     print(json.dumps({
@@ -124,11 +133,11 @@ def main():
             "hookEventName": "PreToolUse",
             "permissionDecision": "ask",
             "permissionDecisionReason": (
-                f"Write/Edit targets a tracked path on the default branch "
-                f"'{current}' of {repo_root}. git-essentials prohibits "
-                f"editing files on the default branch — branch first "
-                f"(invoke the git-workflow skill). Approve only if editing "
-                f"on the default branch is genuinely intended."
+                f"Write/Edit targets a non-ignored path on the default "
+                f"branch '{current}' of {repo_root}. git-essentials "
+                f"prohibits editing files on the default branch — branch "
+                f"first (invoke the git-workflow skill). Approve only if "
+                f"editing on the default branch is genuinely intended."
             ),
         },
     }))

--- a/claude/hooks/guard_default_branch_edits.py
+++ b/claude/hooks/guard_default_branch_edits.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Ask before Write/Edit/NotebookEdit touches a tracked file on the default branch.
+
+git-essentials.md ("Never create or edit files on the default branch")
+is a git-workflow precondition the model is expected to enforce on its
+own, but retrospectives found edits landing on main before a branch
+existed. This PreToolUse hook raises that case as a permission prompt
+rather than blocking it outright ("ask", not "deny"): the check fires
+in every repo, including ones where a user-instructed default-branch
+edit is genuinely intended (a quick fix directly on someone else's
+throwaway repo, a repo with no branching workflow at all, etc.), and
+denying outright would remove that legitimate path.
+
+Paths are resolved with ``os.path.realpath`` before any git check.
+Files under this repository are routinely edited through their
+``~/.claude/...`` symlinks (see this repo's CLAUDE.md, "Symlink
+Architecture"); without resolving the symlink first, a git check
+anchored at the symlink's own directory would miss that the write
+actually lands inside this repository's working tree.
+
+Every subprocess call is fail-open: a directory outside any git work
+tree, a detached HEAD, an unset ``origin/HEAD``, or a ``git`` binary
+that errors or times out all result in a silent ``exit(0)`` rather
+than a false "ask". The target path may not exist yet (Write creates
+new files), so git commands are anchored at the nearest existing
+ancestor directory instead of the path itself.
+
+Spec: https://code.claude.com/docs/en/hooks
+"""
+import json
+import os
+import subprocess
+import sys
+
+_ORIGIN_PREFIX = "refs/remotes/origin/"
+
+
+def strip_origin_prefix(ref: str) -> str:
+    """Strip a leading ``refs/remotes/origin/`` from a ref name.
+
+    >>> strip_origin_prefix("refs/remotes/origin/main")
+    'main'
+    >>> strip_origin_prefix("refs/remotes/origin/release/1.0")
+    'release/1.0'
+    >>> strip_origin_prefix("main")
+    'main'
+    >>> strip_origin_prefix("")
+    ''
+    """
+    if ref.startswith(_ORIGIN_PREFIX):
+        return ref[len(_ORIGIN_PREFIX):]
+    return ref
+
+
+def nearest_existing_dir(path: str) -> str:
+    """Return the nearest existing ancestor directory of ``path``.
+
+    Walks up from ``path`` until an existing directory is found. This
+    needs the filesystem, so it is not doctested here.
+    """
+    current = path
+    while current and not os.path.isdir(current):
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+    return current or os.sep
+
+
+def _run_git(args, cwd):
+    return subprocess.run(
+        ["git", "-C", cwd] + args,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    tool_input = data.get("tool_input", {}) or {}
+    path = tool_input.get("file_path") or tool_input.get("notebook_path") or ""
+    if not path:
+        sys.exit(0)
+
+    try:
+        real = os.path.realpath(path)
+        start_dir = nearest_existing_dir(real)
+
+        result = _run_git(["rev-parse", "--is-inside-work-tree"], start_dir)
+        if result.returncode != 0 or result.stdout.strip() != "true":
+            sys.exit(0)
+
+        result = _run_git(["check-ignore", "-q", real], start_dir)
+        if result.returncode == 0:
+            sys.exit(0)
+
+        result = _run_git(["symbolic-ref", "--quiet", "--short", "HEAD"], start_dir)
+        if result.returncode != 0:
+            sys.exit(0)
+        current = result.stdout.strip()
+
+        result = _run_git(
+            ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"], start_dir
+        )
+        if result.returncode != 0:
+            sys.exit(0)
+        default = strip_origin_prefix(result.stdout.strip())
+
+        if current != default:
+            sys.exit(0)
+
+        result = _run_git(["rev-parse", "--show-toplevel"], start_dir)
+        repo_root = result.stdout.strip() if result.returncode == 0 else start_dir
+    except Exception:
+        sys.exit(0)
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "ask",
+            "permissionDecisionReason": (
+                f"Write/Edit targets a tracked path on the default branch "
+                f"'{current}' of {repo_root}. git-essentials prohibits "
+                f"editing files on the default branch — branch first "
+                f"(invoke the git-workflow skill). Approve only if editing "
+                f"on the default branch is genuinely intended."
+            ),
+        },
+    }))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -357,6 +357,19 @@
           {
             "type": "command",
             "command": "f=~/.claude/hooks/warn_scripting_oneliners.py; if [ -f \"$f\" ] && command -v python3 >/dev/null; then python3 \"$f\"; fi"
+          },
+          {
+            "type": "command",
+            "command": "f=~/.claude/hooks/block_raw_github_fetch.py; if [ -f \"$f\" ] && command -v python3 >/dev/null; then python3 \"$f\"; fi"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=~/.claude/hooks/guard_default_branch_edits.py; if [ -f \"$f\" ] && command -v python3 >/dev/null; then python3 \"$f\"; fi"
           }
         ]
       }

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -6,7 +6,10 @@ description: Standard git/GitHub workflow - branch setup, implementation, draft 
 # Git Workflow
 
 Standard git/GitHub workflow for all projects.
-Follow each step in order. Skip steps that don't apply.
+Follow each step in order. Skip a step only when its precondition is
+structurally absent (e.g., no PR exists yet). Never skip a phase
+because the diff seems small or the step feels disproportionate — run
+it as-is.
 
 Prerequisite: the `agynio/gh-pr-review` gh extension is installed
 (used by Phase 5 review-thread reactions).
@@ -17,6 +20,9 @@ Prerequisite: the `agynio/gh-pr-review` gh extension is installed
   who initiated the task. Do not pause between steps to ask for
   confirmation unless blocked by an error or ambiguity. Execute the
   full flow continuously and report results at the end.
+- Phase 2 code review and Phase 5 Monitor arming are pre-authorized —
+  run them without pausing for confirmation. The only user decision
+  point in the flow is flipping the PR from draft to ready for review.
 - Never create or edit files on the default branch. Always move into the
   worktree (or feature branch) first. Creating files before branching
   leads to redundant copy-and-delete work.
@@ -39,6 +45,12 @@ Note: `.worktrees/` is covered by the global gitignore.
 ## 2. Implement, commit, push
 
 The implementation work for this branch happens here.
+
+When the commit message or PR body will claim an exhaustive
+replacement or update ("replaced all X with Y"), run
+`git grep -n '<old pattern>'` before committing and confirm zero
+remaining matches — `replace_all` misses occurrences that differ in
+formatting or indentation.
 
 ## 3. Create a PR
 

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -43,8 +43,9 @@ escalate to Must Fix.
 
 When the implementation-summary section exceeds ~10 lines, or the
 whole body (excluding template-mandated sections) exceeds ~30 lines,
-re-examine the body against the signals above before deciding their
-severity.
+report the overrun itself as Should Fix (pr-guidelines: Length
+budget), and re-examine the body against the signals above to decide
+what to cut and whether to escalate.
 
 ### Hard-wrap detection (GitHub-posted markdown)
 


### PR DESCRIPTION
## Purpose

Three retrospectives found the git-workflow skill improvised or skipped rather than followed: files edited on main before branching (#263), a PR body drafted without pr-guidelines in context (#264), and the code-review phase skipped as "disproportionate to the diff" (#265). Prose alone did not prevent any of these, so this PR mechanizes the enforceable parts as PreToolUse hooks and tightens the skill wording.

## Key changes

- New hook guard_default_branch_edits.py denies the first default-branch Write/Edit of a session with branch-first guidance, then allows retries for that repo silently — deny-once was chosen over a per-edit permission prompt so user-requested direct default-branch work proceeds without interrupting anyone (#263 finding 3, #264 finding 2)
- New hook block_raw_github_fetch.py: denies curl/wget fetches of raw.githubusercontent.com with gh api guidance (#265 finding 1)
- block_excuse_phrases.py strips backtick code spans per text block before matching, so quoting a banned phrase in backticks no longer trips the Stop hook (#263 finding 2)
- git-workflow SKILL.md: steps may be skipped only when their precondition is structurally absent — never because the diff seems small (#265 finding 2)
- git-workflow SKILL.md: Phase 2 review and Phase 5 monitor arming are named pre-authorized; the only user decision point is flipping draft to ready (#265 finding 2)
- git-workflow SKILL.md: exhaustiveness claims in commit/PR text require a git grep zero-match check before committing (#265 finding 3)
- pr-selfcheck SKILL.md reports length-budget overruns as Should Fix, aligning with pr-guidelines which already promised that (#267 finding 3, #227)

## Verification

- [x] guard hook, PreToolUse JSON piped against a throwaway default-branch repo: first run with session_id testsession1 → deny JSON ending "retries in this session are allowed for this repo."; identical rerun → exit 0, no output (marker claude-guard-default-branch-testsession1-252041b4ea43 present); session_id testsession2 → deny JSON again; feature-branch and /private/tmp payloads → exit 0, no output
- [x] raw-fetch hook: payload with `curl -sL https://raw.githubusercontent.com/a/b/main/x` → deny JSON with gh api guidance; payload with a git commit message mentioning the domain → exit 0, no output

New hooks activate for sessions that load them via settings.json; activation timing for already-running sessions is not claimed here.

## Related issues

Lands #263 findings 2 and 3, #264 finding 2, #265 findings 1-3, #267 finding 3. Closable once this merges: #227 (its redundancy-signal proposal landed earlier; this adds the missing Should Fix severity), and — now that #268 and #270 are merged — #263, #264, #265, #267 as well.
