### PR TITLE
Apply retrospective countermeasures from session 2026-07-07

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ pre-commit run --all-files
 
 ## Git Workflow
 
-- Always create a branch before making changes (direct commits to main are prohibited)
+- Always create a branch before making changes. When the user explicitly requests direct work on main, proceed after the default-branch guard hook's first deny — its retry is sanctioned for the rest of the session
 - Do NOT create git worktrees — branch only, no worktree
 - Clean up unused local branches (merged, squash-merged, or upstream gone) and stale worktree entries with `bin/git-cleanup-branches`. Plain `git branch -d` rejects squash-merged branches as "not fully merged"
 - The working tree may be shared by multiple concurrent Claude Code

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -54,20 +54,13 @@ formatting or indentation.
 
 ## 3. Create a PR
 
-1. Generate a unique temp file path:
-   `mktemp --suffix=.md`
-   Run this as a standalone Bash command (no command substitution).
-   Read the output to obtain the generated path.
-   Then call the Read tool on that path once — `mktemp` creates an empty
-   file, and the Write tool requires the file be Read first if it exists.
-   The Read returns a "shorter than offset" warning, which is expected;
-   the subsequent Write succeeds.
-1. Write the PR body to the generated path using the Write tool:
-   `Write(<path from mktemp>)`
+1. Write the PR body to a fresh file under the session scratchpad
+   directory using the Write tool (new filename per revision — a new
+   file needs no prior Read step)
    - Follow the repository's PR template if one exists
    - Follow the PR Body Checklist
 1. Create the PR as a draft:
-   `gh pr create --draft --body-file <path from mktemp>`
+   `gh pr create --draft --body-file <body file path>`
    - Never use `--body` for PR creation. The `#`-prefixed lines in the body
      trigger Claude Code's security pre-check, which cannot be bypassed by
      hooks. Always go through `--body-file`.
@@ -117,6 +110,10 @@ Once the review finishes, review the results:
 The code review is single-pass — do not re-run after fixes.
 `/pr-selfcheck` runs again in Phase 3 to catch inconsistencies
 introduced by review fix changes.
+
+When a fix is delegated to a subagent, arm a Monitor on the branch
+head (event-driven) instead of a fixed-delay wakeup, and tell the
+user what is being awaited before going idle.
 
 ### Phase 4: Finalize PR for review readiness
 
@@ -219,17 +216,12 @@ routine CI / comment events.
      (or `gh issue view <number> --json body --jq .body` for issues)
   1. Output a diff between the current body and the new body in the
      conversation (so what changed is visible and recoverable).
-  1. Generate a unique temp file path:
-     `mktemp --suffix=.md`
-     Run this as a standalone Bash command and read the output.
-     Then call the Read tool on that path once — `mktemp` creates an
-     empty file, and the Write tool requires the file be Read first if
-     it exists.
-  1. Write the new body to the generated path:
-     `Write(<path from mktemp>)`
+  1. Write the new body to a fresh file under the session scratchpad
+     directory using the Write tool (new filename per revision — no
+     temp-file generation, no Read of an empty file)
   1. Execute the edit:
-     `gh pr edit <number> --body-file <path from mktemp>`
-     (or `gh issue edit <number> --body-file <path from mktemp>`)
+     `gh pr edit <number> --body-file <body file path>`
+     (or `gh issue edit <number> --body-file <body file path>`)
   The goal is observability — always show the diff so the user can see
   what changed and recover manually-written content if accidentally
   overwritten.

--- a/claude/skills/retrospective/analysis.md
+++ b/claude/skills/retrospective/analysis.md
@@ -102,6 +102,9 @@ Choose the placement based on who benefits:
 - Personal habits or preferences → global `AIRULES.md` or `~/.claude/rules/` (tag: global)
 - Memory is for recording facts only. It must not be used as a mechanism
   for behavior change (see Prohibited Countermeasures below).
+- Choose placement by scope only. When the scope-correct file is at
+  its line budget, propose raising the budget or trimming that file —
+  never relocate the rule to a different tier to fit the budget
 
 ## Prohibited Countermeasures
 


### PR DESCRIPTION
## Purpose

Same-day follow-up landing the countermeasures filed in #271 (user asked to apply the quick ones immediately) plus the AGENTS.md exception that resolves the contradiction between the deny-once default-branch guard shipped in #269 and the unconditional branch-first rule.

## Key changes

- retrospective analysis.md gains the scope-only placement rule so future retro countermeasures stop inheriting budget-driven placement from their issue drafts — the failure that required a user editorial pass on PR #270 today (#271 finding 1)
- git-workflow SKILL.md prescribes event-driven Monitor waits for delegated fixes because fixed-delay wakeups left the session silently idle and prompted a "did it stall?" nudge (#271 finding 2)
- git-workflow SKILL.md writes PR body files straight to the session scratchpad with a fresh filename, replacing the temp-file / empty-file-Read / Write loop repeated 8+ times today (#271 finding 3)
- AGENTS.md: branch-first stays the default; user-requested direct main work proceeds after the guard hook's first deny via its sanctioned retry (project-scope finding; rides in the user's own commit 59f61de)

## Verification

- [x] The temp-file procedure is fully gone from the skill (zero remaining matches for the old temp-file command in SKILL.md)
- [x] The AGENTS.md exception was exercised live in this session: first Edit on main → hook deny with branch-first guidance; sanctioned retry → pass

## Related issues

Lands all three #271 findings plus the session's project-scope finding; #271 is closable once this merges.
