### PR TITLE
Replace guardrail-target commands in claude/skills/

### DIFF
--- a/claude/skills/git-workflow/pr-reaction.md
+++ b/claude/skills/git-workflow/pr-reaction.md
@@ -31,6 +31,10 @@ gh pr-review review view -R <owner>/<repo> <number> \
   --unresolved --not_outdated --include-comment-node-id
 ```
 
+`gh api` is required here: the `gh pr-review` extension does not
+expose `user.type` on review comments (no equivalent flag), and no
+high-level `gh pr` subcommand returns per-line review comments.
+
 ```bash
 gh api /repos/<owner>/<repo>/pulls/<number>/comments \
   --jq '.[] | {node_id, user_login: .user.login, user_type: .user.type}'

--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -29,7 +29,7 @@ Compute the current session's transcript path. The Session ID is
 already substituted below when this SKILL.md loads:
 
 - Session ID: `${CLAUDE_SESSION_ID}`
-- Munged cwd: run `pwd | sed 's|/|-|g'` (every `/` becomes `-`, so a
+- Munged cwd: run `pwd | tr '/' '-'` (every `/` becomes `-`, so a
   leading `/` becomes a leading `-`)
 - Full path: `$HOME/.claude/projects/<munged-cwd>/<session-id>.jsonl`
 


### PR DESCRIPTION
## Summary

Sweep `claude/skills/` for occurrences of Bash commands that the planned `claude-narrower-bash` plugin (see #278) would soft-deny, and either replace them with the narrower dedicated tool or document why the swiss-army form is unavoidable.

Motivated by a self-collision this session: the retrospective skill's `SKILL.md` used `pwd | sed 's|/|-|g'` and tripped a session-local prototype of the guardrail while running the skill itself.

## Changes

- `claude/skills/retrospective/SKILL.md`: `tr` is the dedicated tool for single-character translation, needs no regex delimiters, and is the alternative the guardrail's own reason text points to.
- `claude/skills/git-workflow/pr-reaction.md`: added an inline note explaining that the `gh api /pulls/N/comments` call cannot be replaced. Verified via `gh pr view --json` field list (no per-line review comments) and `gh pr-review review view --help` (no flag exposes `user.type`). This falls under the guardrail's documented escape hatch for cases where high-level `gh` cannot express the operation, but a future reader shouldn't have to re-derive that.

## Verification

- pre-commit hooks pass on both commits; CI (bootstrap ubuntu / macos, shellcheck, python-doctest, Socket Security) all green.
- Retrospective SKILL Step 1 exercised this session — `pwd | tr '/' '-'` produced `-Users-ikuwow-dotfiles`, matching the transcript directory Claude Code actually writes to.
- pr-reaction note verified against live `gh` today: `gh pr-review review view --help` exposes no flag for `user.type` / actor kind, and `gh pr view --json` field list has `reviews` / `comments` but nothing that returns per-line review comments with author metadata.

## Notes

- Explore sweep also found `retrospective/analysis.md:156` mentions `tail` in prose. That is documentation text, not a Bash invocation, so no change.

Refs: #278 (plugin design), #277 (existing `warn_gh_api` hook).
