### PR TITLE
Pin BIZ UDGothic Bold as ghostty CJK fallback

### DIFF
--- a/xdg-config/ghostty/config
+++ b/xdg-config/ghostty/config
@@ -19,6 +19,7 @@ quick-terminal-position = center
 quick-terminal-size = 1080px, 50%
 
 font-family = "Monaco"
+font-family = "BIZ UDGothic Bold"
 font-style = Regular
 font-size = 12
 # Disable ligatures


### PR DESCRIPTION
## Summary

Pin `BIZ UDGothic Bold` as an explicit CJK fallback for ghostty by adding a second `font-family` line to `xdg-config/ghostty/config`.

## Why

Without an explicit CJK fallback, ghostty's runtime font discovery on macOS 26.5 is unstable: CJK codepoints (notably `の`) render with different faces after display switches. Root cause is documented upstream in [ghostty-org/ghostty#12916](https://github.com/ghostty-org/ghostty/issues/12916) (with related [#8712](https://github.com/ghostty-org/ghostty/issues/8712), [#707](https://github.com/ghostty-org/ghostty/issues/707)).

Pinning locks the CJK cascade to a deterministic face across sessions and display changes.

## Why BIZ UDGothic Bold specifically

- `ghostty +show-face --string="のあ情報"` on the unpinned state reported `BIZ UDGothic` as the family ghostty was already selecting most of the time
- Cross-check via Morisawa Fonts image search (fontsjourney.morisawafonts.com) on a screenshot of the rendered CJK matched `TBUD Gothic Std B` (79% for the round sibling, 70% for the base). TBUD Gothic is what BIZ UDGothic is the OFL public release of ([Google Fonts specimen](https://fonts.google.com/specimen/BIZ+UDGothic/about))
- Pinning `BIZ UDGothic Bold` reproduces the pre-change appearance more faithfully than pinning the Regular face (Regular face changes weight/shape enough to be noticeable)

## Verification

`ghostty +show-face --string="のあ情報実際ABCabc0123!@#-_=+()"` after the change:

- All CJK codepoints (`の`, `あ`, `情`, `報`, `実`, `際`) resolve to `BIZ UDGothic`
- All ASCII codepoints (`A-C`, `a-c`, `0-3`, punctuation) resolve to `Monaco`
- No cross-family bleed for the primary text style

Config took effect on the running ghostty instance without a restart. No visible regression in existing terminal workloads (shell prompts, Claude Code, tmux).

## Side effect (follow-up: #281)

Bold ASCII (SGR 1, markdown emphasis) is drawn using `BIZ UDGothic Bold`'s Latin glyphs, not Monaco. This is because Monaco has no Bold face (`system_profiler SPFontsDataType` confirms `Style: Regular` only), so ghostty's per-codepoint fallback picks the first face in the cascade that has both the codepoint and Bold weight, and `BIZ UDGothic Bold` fits that requirement for ASCII too. This matches the pre-change behavior — ghostty was already routing Bold ASCII through the same font before the pin, so no regression here.
