### PR TITLE
Rewrite retrospective routing and destination taxonomy

### DIFF
--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -90,19 +90,27 @@ context.
 For each finding, ask via AskUserQuestion using the choices below.
 
 - Project-specific finding: `apply now` / `create issue` / `skip` / `Other`
-- Global finding: `create issue` / `skip` / `Other` — no `apply now`,
-  because the weekly-improvement routine consumes global issues, and
-  editing dotfiles-managed files from a project session would bypass
-  the dotfiles branch/PR workflow; when the session cwd is the
-  dotfiles repo itself the bypass rationale does not hold, but keep
-  the ban for consistency and use `Other` for a manual dotfiles-side edit
+- Global finding: `create issue` / `skip` / `Other` — no `apply now`
+  - The weekly-improvement routine consumes global issues, so
+    silently applying them here would skip that queue
+  - Editing dotfiles-managed files from an arbitrary project
+    session would bypass the dotfiles branch/PR workflow
+  - When the session cwd is the dotfiles repo itself, the bypass
+    rationale does not hold; keep the ban for consistency and use
+    `Other` for a manual dotfiles-side edit
 
 `apply now` branch gate (project-specific only):
 
-- Refuse when HEAD is on the default branch of the current repo
-  (detect via `git symbolic-ref refs/remotes/origin/HEAD` and compare
-  to `git rev-parse --abbrev-ref HEAD`), and tell the user to
+- Refuse when HEAD is on the default branch of the current repo,
+  detected with the two commands below (both emit the short branch
+  name, so a direct string equality holds), and tell the user to
   `create issue` or `skip` instead
+
+```
+current=$(git rev-parse --abbrev-ref HEAD)
+default=$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's|^origin/||')
+[ "$current" = "$default" ] && refuse
+```
 - On a feature branch, write files but do NOT commit, then print
   the exact paths written and warn that the changes land in the
   current branch's working tree — commit or discard per the branch's
@@ -140,9 +148,9 @@ For each finding, ask via AskUserQuestion using the choices below.
   weekly-improvement routine (or the project's own maintainers) can
   act on each item directly
 
-`skip`: drop the finding, no record.
+`skip` — drop the finding with no record.
 
-`Other`: follow the user's free-text instruction.
+`Other` — follow the user's free-text instruction.
 
 ### Prompt fatigue mitigation
 

--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -60,40 +60,78 @@ Inputs:
 
 Output: return the analysis findings in the format specified in
 analysis.md. For each finding, include a `Scope:` tag with value
-`global` or `project-specific`. Do not create GitHub issues and do
+`global` or `project-specific`, and a `Destination:` tag with one of
+`existing-rule-edit` / `existing-skill-update` / `mechanize` /
+`new-rule` / `new-skill`. Do not create GitHub issues and do
 not invoke AskUserQuestion — the orchestrator handles routing after
 you return. Do not add preamble or closing remarks.
 ```
 
 ## Step 2: Route findings by scope
 
-Take the subagent's output verbatim and act on each finding based on
-its Scope tag.
+Take the subagent's output verbatim. Each finding carries a `Scope`
+(`global` / `project-specific`) tag and a `Destination`
+(`existing-rule-edit` / `existing-skill-update` / `mechanize` /
+`new-rule` / `new-skill`) tag from Step 1. Ask the user how to route
+each finding — do not auto-file or auto-apply anything.
 
-### Global-scope findings
+### Sanitize global findings before filing as an issue
 
-ikuwow/dotfiles is a public repository. Before filing, sanitize the
-global-scope problem/countermeasure pairs: do not include the names
-of private repositories, their PR/issue numbers, their code, or
-quoted text from their rule files. Describe each problem by its
-behavior pattern (e.g., "a work project's Terraform PR review") so
-the countermeasure stays understandable without the private context.
+This applies only when a global-scope finding is being filed as an
+issue below. ikuwow/dotfiles is a public repository: do not include
+the names of private repositories, their PR/issue numbers, their
+code, or quoted text from their rule files. Describe each problem by
+its behavior pattern (e.g., "a work project's Terraform PR review")
+so the countermeasure stays understandable without the private
+context.
 
-Create one GitHub issue in ikuwow/dotfiles holding the sanitized
-pairs via `--body-file` (never `--body`), title
-`Retrospective: <date> <one-line session summary>` (sanitized as
-above), label `retrospective`. The label is provisioned once at
-setup; if `gh issue create` fails because it is missing, run
-`gh label create retrospective --repo ikuwow/dotfiles --force` and retry.
-Skip issue creation when there are no global-scope findings.
+### Ask the user how to route each finding
 
-The weekly-improvement routine consumes these issues — do not
-implement global countermeasures in this session unless the user asks.
+For each finding, ask via AskUserQuestion using the choices below.
 
-### Project-scope findings
+- Project-specific finding: `apply now` / `create issue` / `skip` / `Other`
+- Global finding: `create issue` / `skip` / `Other` — no `apply now`,
+  because the weekly-improvement routine consumes global issues, and
+  editing dotfiles-managed files from a project session would bypass
+  the dotfiles branch/PR workflow
 
-Never file these as retrospective issues in ikuwow/dotfiles. Present
-them in the session and ask the user how to handle them
-(AskUserQuestion), offering these choices for each finding: apply to
-the project's rule files now / create an issue in the project's own
-repository / drop.
+`apply now` (project-specific only), by destination:
+
+- `existing-rule-edit` / `existing-skill-update` → Edit the target file
+- `mechanize` → Write the hook script or CI config; extend
+  `.claude/settings.json`'s hooks section if the countermeasure needs
+  a new hook entry
+- `new-rule` → Write the new rule file; add a 1-line pointer in the
+  parent rule if applicable
+- `new-skill` → Create the skill directory with a `SKILL.md` skeleton
+  and frontmatter; the content is fleshed out in a later session
+
+`create issue`:
+
+- Global → `ikuwow/dotfiles`, label `retrospective`, via
+  `--body-file` (never `--body`), title
+  `Retrospective: <date> <one-line session summary>` (sanitized as
+  above). The label is provisioned once at setup; if
+  `gh issue create` fails because it is missing, run
+  `gh label create retrospective --repo ikuwow/dotfiles --force` and
+  retry
+- Project-specific → the current cwd's repository, via
+  `--body-file`, no label
+- Either way, the issue body includes the finding's `Destination:`
+  tag and the concrete countermeasure content so the
+  weekly-improvement routine (or the project's own maintainers) can
+  act on it directly
+
+`skip`: drop the finding, no record.
+
+`Other`: follow the user's free-text instruction.
+
+### Prompt fatigue mitigation
+
+- 4 or fewer findings: ask about all of them in a single
+  AskUserQuestion call (max 4 questions per call)
+- 5 or more findings: keep only `medium` and `high` severity findings
+  for AskUserQuestion; auto-`skip` `low` severity findings and
+  announce it in one line ("auto-skipped N low-severity findings")
+- If the remaining `medium`+`high` findings still exceed 4, split
+  them across multiple AskUserQuestion calls of up to 4 questions each

--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -93,7 +93,20 @@ For each finding, ask via AskUserQuestion using the choices below.
 - Global finding: `create issue` / `skip` / `Other` — no `apply now`,
   because the weekly-improvement routine consumes global issues, and
   editing dotfiles-managed files from a project session would bypass
-  the dotfiles branch/PR workflow
+  the dotfiles branch/PR workflow; when the session cwd is the
+  dotfiles repo itself the bypass rationale does not hold, but keep
+  the ban for consistency and use `Other` for a manual dotfiles-side edit
+
+`apply now` branch gate (project-specific only):
+
+- Refuse when HEAD is on the default branch of the current repo
+  (detect via `git symbolic-ref refs/remotes/origin/HEAD` and compare
+  to `git rev-parse --abbrev-ref HEAD`), and tell the user to
+  `create issue` or `skip` instead
+- On a feature branch, write files but do NOT commit, then print
+  the exact paths written and warn that the changes land in the
+  current branch's working tree — commit or discard per the branch's
+  PR intent
 
 `apply now` (project-specific only), by destination:
 
@@ -108,6 +121,11 @@ For each finding, ask via AskUserQuestion using the choices below.
 
 `create issue`:
 
+- Batch by scope: all approved global findings become one issue in
+  `ikuwow/dotfiles`, and all approved project findings become one
+  issue in the current cwd's repo — never one issue per finding,
+  since the weekly-improvement routine and project maintainers
+  consume session-level issues
 - Global → `ikuwow/dotfiles`, label `retrospective`, via
   `--body-file` (never `--body`), title
   `Retrospective: <date> <one-line session summary>` (sanitized as
@@ -117,10 +135,10 @@ For each finding, ask via AskUserQuestion using the choices below.
   retry
 - Project-specific → the current cwd's repository, via
   `--body-file`, no label
-- Either way, the issue body includes the finding's `Destination:`
-  tag and the concrete countermeasure content so the
+- The issue body lists each included finding with its `Destination:`
+  tag and the concrete countermeasure content, so the
   weekly-improvement routine (or the project's own maintainers) can
-  act on it directly
+  act on each item directly
 
 `skip`: drop the finding, no record.
 

--- a/claude/skills/retrospective/analysis.md
+++ b/claude/skills/retrospective/analysis.md
@@ -24,25 +24,21 @@ Keep each entry to 1-2 lines. Skip behaviors that had no real impact.
 ## Step 2: Propose structural countermeasures
 
 For each problem, identify the governing rule first, then pick the
-highest applicable countermeasure in this order:
+highest applicable destination in this order:
 
-1. Fix the existing rule that failed to prevent the behavior.
-   Diagnose why it failed — wording too vague, wrong loading tier
-   (not in context when needed), or no enforcement — and propose
-   editing, splitting, relocating, or mechanizing that rule.
-   Never add a parallel rule next to a failed one.
-1. Delete or merge rules when overlap, contradiction, or sheer
-   volume contributed to the failure.
-1. Mechanize (hook, CI check, pre-commit, script, permission
-   setting, template) when the behavior is mechanically checkable.
-   A mechanized check may replace the prose rule it enforces.
-1. Add a new rule only when no existing rule covers the problem.
-   State the net context cost: lines added, target loading tier
-   (always-loaded rule vs on-demand skill), and what compensating
-   trim keeps the tier within budget.
+1. `existing-rule-edit` — an existing rule failed to prevent the behavior (vague wording, wrong loading tier, or no enforcement); edit, split, relocate, or mechanize it, never add a parallel rule next to a failed one
+1. `existing-skill-update` — an existing skill file (`SKILL.md`, `analysis.md`, etc.) failed to guide the behavior; edit it directly
+1. `mechanize` — the behavior is mechanically checkable; add a hook, CI check, pre-commit, script, permission setting, or template, which may replace the prose rule it enforces
+1. `new-rule` — no existing rule covers the problem; state the net context cost (lines added, target loading tier, compensating trim)
+1. `new-skill` — no existing skill covers the problem and it needs a new on-demand workflow; scaffold a new skill
 
-Format as a numbered list of pairs. Include a severity rating and a
-scope tag (global / project-specific) for each:
+A countermeasure that deletes or merges existing rules or skills is an
+orthogonal edit operation, not a destination of its own — apply it
+alongside whichever destination above the finding routes to, when
+overlap, contradiction, or sheer volume contributed to the failure.
+
+Format as a numbered list of pairs. Include a severity rating, a
+scope tag (global / project-specific), and a destination tag for each:
 
 ```
 ## 1. <short title>
@@ -50,6 +46,7 @@ scope tag (global / project-specific) for each:
 Problem: <what happened>
 Severity: high / medium / low (with brief justification)
 Scope: global / project-specific
+Destination: existing-rule-edit / existing-skill-update / mechanize / new-rule / new-skill
 Countermeasure: <structural fix>
 ```
 


### PR DESCRIPTION
## Summary

The `retrospective` skill used to auto-file every global-scope finding as a `ikuwow/dotfiles` issue with no user gate, while project-scope findings had a 3-choice `AskUserQuestion` (`apply now` / `create issue` / `drop`) that only covered rule edits. This PR gates every finding — global included — through per-finding `AskUserQuestion` (no silent writes) and expands the action set to match `analysis.md`'s countermeasure taxonomy (`mechanize`, `new-rule`, `new-skill` in addition to rule and skill edits), so a finding can materialize as more than a rule tweak.

## Why the shape it took

Per-scope action asymmetry: global findings drop `apply now`. The weekly-improvement routine already consumes global issues, and letting an arbitrary project session edit dotfiles-managed files would bypass the dotfiles branch/PR workflow. Project-scope findings keep `apply now`, but only on a non-default branch and without auto-commit, so the writes surface in the current working tree for the user to reconcile with the branch's intended diff.

Issue batching: approved findings are grouped by scope into one session-level issue each, matching the current title format (`Retrospective: <date> …`) and keeping the weekly-routine consumption model intact.

Prompt fatigue: `AskUserQuestion` caps at 4 questions per call (the tool schema's `questions.maxItems` field, surfaced by `ToolSearch select:AskUserQuestion`). At ≥5 findings, `low`-severity ones auto-`skip` and the rest are batched across multiple ≤4-question calls, so a user who has already left the session isn't hit with N sequential prompts.

## Verification

Static:

- `pre-commit run --files claude/skills/retrospective/SKILL.md claude/skills/retrospective/analysis.md` → all applicable hooks `Passed`; JSON/YAML/line-count budget hooks `Skipped` as N/A
- `git grep -n 'Global-scope findings\|Project-scope findings' claude/skills/retrospective/` → no output (removed sections have no lingering references)
- `AskUserQuestion` schema still has `questions: { minItems: 1, maxItems: 4 }` and each question's `options` still `minItems: 2, maxItems: 4` — the 4-choice-per-finding fits comfortably

End-to-end:

- [x] Ran `/retrospective` from a separate Claude Code session against this branch before merge — the skill walked Step 0 → Step 1 (Fable subagent analysis, ~6 min) → Step 2 (per-finding `AskUserQuestion` routing) to completion without error. Symlinked skill mutation and real-issue side effects were accepted for that run because the alternative (reviewing without executing the flow) would leave the routing rewrite unexercised

## Follow-up

#284 restructures the flow so the main session produces first-pass findings and Fable reviews them, instead of Fable re-reading the whole transcript. Taxonomy and routing established here are its prerequisites.
