### PR TITLE
Split retrospective analysis into main first-pass and Fable review

### DIFF
--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -175,9 +175,15 @@ Take the finalized findings from Step 3. Each finding carries a
 (`existing-rule-edit` / `existing-skill-update` / `mechanize` /
 `new-rule` / `new-skill`) tag — originally set in Step 1 and possibly
 adjusted in Steps 2-3. Ask the user how to route each finding — do
-not auto-file or auto-apply anything. Where a finding carries recorded
-Fable dissent (main kept a version Fable rejected or adjusted), show
-both versions in the AskUserQuestion so the user arbitrates.
+not auto-file or auto-apply anything.
+
+Every AskUserQuestion prompt for a finding must include a compact
+Fable summary line — verdict plus the one-line reason from Step 2 —
+regardless of whether main accepted or overrode the verdict, so the
+user sees the outside review before choosing the route. When main
+kept a version Fable rejected or adjusted (recorded dissent), also
+show Fable's proposed version alongside main's kept version so the
+user arbitrates between the two.
 
 ### Sanitize global findings before filing as an issue
 

--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -97,11 +97,12 @@ For each initial finding, return one of these verdicts:
 - confirm — the finding and the digest line up with the sampled transcript; keep as-is
 - adjust — the finding is directionally right but severity, scope, destination, or countermeasure needs a change; state the change
 - reject — the finding is not supported by the sampled transcript or the digest misrepresents what happened; state why
+- unverifiable — the digest attributes the finding to the currently-in-progress turn (the one that triggered this retrospective), which is not yet in the transcript; withhold judgment rather than reject on missing evidence
 
 Format each verdict as:
 
 ## <finding number/title>
-Verdict: confirm / adjust / reject
+Verdict: confirm / adjust / reject / unverifiable
 Reason: <one line>
 Adjusted finding: <only when Verdict is adjust — state the corrected fields>
 
@@ -128,6 +129,7 @@ Apply each Step 2 verdict to its finding:
 - confirm — keep the finding as-is
 - reject — drop the finding
 - adjust — replace the finding with Fable's adjusted version
+- unverifiable — keep the finding as-is and tag it as unverifiable so Step 4 can note the caveat in AskUserQuestion; do not treat this as dissent
 
 When main disagrees with a reject or adjust and keeps a version
 closer to its own Step 1 finding, record Fable's dissent (its verdict

--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -90,19 +90,27 @@ context.
 For each finding, ask via AskUserQuestion using the choices below.
 
 - Project-specific finding: `apply now` / `create issue` / `skip` / `Other`
-- Global finding: `create issue` / `skip` / `Other` — no `apply now`,
-  because the weekly-improvement routine consumes global issues, and
-  editing dotfiles-managed files from a project session would bypass
-  the dotfiles branch/PR workflow; when the session cwd is the
-  dotfiles repo itself the bypass rationale does not hold, but keep
-  the ban for consistency and use `Other` for a manual dotfiles-side edit
+- Global finding: `create issue` / `skip` / `Other` — no `apply now`
+  - The weekly-improvement routine consumes global issues, so
+    silently applying them here would skip that queue
+  - Editing dotfiles-managed files from an arbitrary project
+    session would bypass the dotfiles branch/PR workflow
+  - When the session cwd is the dotfiles repo itself, the bypass
+    rationale does not hold; keep the ban for consistency and use
+    `Other` for a manual dotfiles-side edit
 
 `apply now` branch gate (project-specific only):
 
-- Refuse when HEAD is on the default branch of the current repo
-  (detect via `git symbolic-ref refs/remotes/origin/HEAD` and compare
-  to `git rev-parse --abbrev-ref HEAD`), and tell the user to
+- Refuse when HEAD is on the default branch of the current repo,
+  detected with the two commands below (both emit the short branch
+  name, so a direct string equality holds), and tell the user to
   `create issue` or `skip` instead
+
+```
+current=$(git rev-parse --abbrev-ref HEAD)
+default=$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's|^origin/||')
+[ "$current" = "$default" ] && refuse
+```
 - On a feature branch, write files but do NOT commit, then print
   the exact paths written and warn that the changes land in the
   current branch's working tree — commit or discard per the branch's
@@ -140,9 +148,9 @@ For each finding, ask via AskUserQuestion using the choices below.
   weekly-improvement routine (or the project's own maintainers) can
   act on each item directly
 
-`skip`: drop the finding, no record.
+`skip` — drop the finding with no record.
 
-`Other`: follow the user's free-text instruction.
+`Other` — follow the user's free-text instruction.
 
 ### Prompt fatigue mitigation
 

--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -168,11 +168,14 @@ additions, each carrying dissent where present) move to Step 4.
 
 ## Step 4: Route findings by scope
 
-Take the subagent's output verbatim. Each finding carries a `Scope`
-(`global` / `project-specific`) tag and a `Destination`
+Take the finalized findings from Step 3. Each finding carries a
+`Scope` (`global` / `project-specific`) tag and a `Destination`
 (`existing-rule-edit` / `existing-skill-update` / `mechanize` /
-`new-rule` / `new-skill`) tag from Step 1. Ask the user how to route
-each finding — do not auto-file or auto-apply anything.
+`new-rule` / `new-skill`) tag — originally set in Step 1 and possibly
+adjusted in Steps 2-3. Ask the user how to route each finding — do
+not auto-file or auto-apply anything. Where a finding carries recorded
+Fable dissent (main kept a version Fable rejected or adjusted), show
+both versions in the AskUserQuestion so the user arbitrates.
 
 ### Sanitize global findings before filing as an issue
 

--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -60,40 +60,78 @@ Inputs:
 
 Output: return the analysis findings in the format specified in
 analysis.md. For each finding, include a `Scope:` tag with value
-`global` or `project-specific`. Do not create GitHub issues and do
+`global` or `project-specific`, and a `Destination:` tag with one of
+`existing-rule-edit` / `existing-skill-update` / `mechanize` /
+`new-rule` / `new-skill`. Do not create GitHub issues and do
 not invoke AskUserQuestion — the orchestrator handles routing after
 you return. Do not add preamble or closing remarks.
 ```
 
 ## Step 2: Route findings by scope
 
-Take the subagent's output verbatim and act on each finding based on
-its Scope tag.
+Take the subagent's output verbatim. Each finding carries a `Scope`
+(`global` / `project-specific`) tag and a `Destination`
+(`existing-rule-edit` / `existing-skill-update` / `mechanize` /
+`new-rule` / `new-skill`) tag from Step 1. Ask the user how to route
+each finding — do not auto-file or auto-apply anything.
 
-### Global-scope findings
+### Sanitize global findings before filing as an issue
 
-ikuwow/dotfiles is a public repository. Before filing, sanitize the
-global-scope problem/countermeasure pairs: do not include the names
-of private repositories, their PR/issue numbers, their code, or
-quoted text from their rule files. Describe each problem by its
-behavior pattern (e.g., "a work project's Terraform PR review") so
-the countermeasure stays understandable without the private context.
+This applies only when a global-scope finding is being filed as an
+issue below. ikuwow/dotfiles is a public repository: do not include
+the names of private repositories, their PR/issue numbers, their
+code, or quoted text from their rule files. Describe each problem by
+its behavior pattern (e.g., "a work project's Terraform PR review")
+so the countermeasure stays understandable without the private
+context.
 
-Create one GitHub issue in ikuwow/dotfiles holding the sanitized
-pairs via `--body-file` (never `--body`), title
-`Retrospective: <date> <one-line session summary>` (sanitized as
-above), label `retrospective`. The label is provisioned once at
-setup; if `gh issue create` fails because it is missing, run
-`gh label create retrospective --repo ikuwow/dotfiles --force` and retry.
-Skip issue creation when there are no global-scope findings.
+### Ask the user how to route each finding
 
-The weekly-improvement routine consumes these issues — do not
-implement global countermeasures in this session unless the user asks.
+For each finding, ask via AskUserQuestion using the choices below.
 
-### Project-scope findings
+- Project-specific finding: `apply now` / `create issue` / `skip` / `Other`
+- Global finding: `create issue` / `skip` / `Other` — no `apply now`,
+  because the weekly-improvement routine consumes global issues, and
+  editing dotfiles-managed files from a project session would bypass
+  the dotfiles branch/PR workflow
 
-Never file these as retrospective issues in ikuwow/dotfiles. Present
-them in the session and ask the user how to handle them
-(AskUserQuestion), offering these choices for each finding: apply to
-the project's rule files now / create an issue in the project's own
-repository / drop.
+`apply now` (project-specific only), by destination:
+
+- `existing-rule-edit` / `existing-skill-update` → Edit the target file
+- `mechanize` → Write the hook script or CI config; extend
+  `.claude/settings.json`'s hooks section if the countermeasure needs
+  a new hook entry
+- `new-rule` → Write the new rule file; add a 1-line pointer in the
+  parent rule if applicable
+- `new-skill` → Create the skill directory with a `SKILL.md` skeleton
+  and frontmatter; the content is fleshed out in a later session
+
+`create issue`:
+
+- Global → `ikuwow/dotfiles`, label `retrospective`, via
+  `--body-file` (never `--body`), title
+  `Retrospective: <date> <one-line session summary>` (sanitized as
+  above). The label is provisioned once at setup; if
+  `gh issue create` fails because it is missing, run
+  `gh label create retrospective --repo ikuwow/dotfiles --force` and
+  retry
+- Project-specific → the current cwd's repository, via
+  `--body-file`, no label
+- Either way, the issue body includes the finding's `Destination:`
+  tag and the concrete countermeasure content so the
+  weekly-improvement routine (or the project's own maintainers) can
+  act on it directly
+
+`skip`: drop the finding, no record.
+
+`Other`: follow the user's free-text instruction.
+
+### Prompt fatigue mitigation
+
+- 4 or fewer findings: ask about all of them in a single
+  AskUserQuestion call (max 4 questions per call)
+- 5 or more findings: keep only `medium` and `high` severity findings
+  for AskUserQuestion; auto-`skip` `low` severity findings and
+  announce it in one line ("auto-skipped N low-severity findings")
+- If the remaining `medium`+`high` findings still exceed 4, split
+  them across multiple AskUserQuestion calls of up to 4 questions each

--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -93,7 +93,20 @@ For each finding, ask via AskUserQuestion using the choices below.
 - Global finding: `create issue` / `skip` / `Other` — no `apply now`,
   because the weekly-improvement routine consumes global issues, and
   editing dotfiles-managed files from a project session would bypass
-  the dotfiles branch/PR workflow
+  the dotfiles branch/PR workflow; when the session cwd is the
+  dotfiles repo itself the bypass rationale does not hold, but keep
+  the ban for consistency and use `Other` for a manual dotfiles-side edit
+
+`apply now` branch gate (project-specific only):
+
+- Refuse when HEAD is on the default branch of the current repo
+  (detect via `git symbolic-ref refs/remotes/origin/HEAD` and compare
+  to `git rev-parse --abbrev-ref HEAD`), and tell the user to
+  `create issue` or `skip` instead
+- On a feature branch, write files but do NOT commit, then print
+  the exact paths written and warn that the changes land in the
+  current branch's working tree — commit or discard per the branch's
+  PR intent
 
 `apply now` (project-specific only), by destination:
 
@@ -108,6 +121,11 @@ For each finding, ask via AskUserQuestion using the choices below.
 
 `create issue`:
 
+- Batch by scope: all approved global findings become one issue in
+  `ikuwow/dotfiles`, and all approved project findings become one
+  issue in the current cwd's repo — never one issue per finding,
+  since the weekly-improvement routine and project maintainers
+  consume session-level issues
 - Global → `ikuwow/dotfiles`, label `retrospective`, via
   `--body-file` (never `--body`), title
   `Retrospective: <date> <one-line session summary>` (sanitized as
@@ -117,10 +135,10 @@ For each finding, ask via AskUserQuestion using the choices below.
   retry
 - Project-specific → the current cwd's repository, via
   `--body-file`, no label
-- Either way, the issue body includes the finding's `Destination:`
-  tag and the concrete countermeasure content so the
+- The issue body lists each included finding with its `Destination:`
+  tag and the concrete countermeasure content, so the
   weekly-improvement routine (or the project's own maintainers) can
-  act on it directly
+  act on each item directly
 
 `skip`: drop the finding, no record.
 

--- a/claude/skills/retrospective/SKILL.md
+++ b/claude/skills/retrospective/SKILL.md
@@ -5,9 +5,10 @@ description: Use when the user wants to reflect on AI communication quality and 
 
 # Session Retrospective
 
-Delegate the transcript analysis to a Fable subagent (stronger
-reasoning, session-independent perspective), then route the findings
-from the main session.
+Main session produces first-pass findings from in-memory context, a
+Fable subagent (stronger reasoning, session-independent perspective)
+reviews them against spot-checked transcript slices, then main routes
+the finalized findings.
 
 The Fable subagent runs via the Agent tool's `model:` override, which
 works in Claude Code v2.1.202. Do not rely on this SKILL.md's own
@@ -23,7 +24,32 @@ gh issue list --repo ikuwow/dotfiles --label retrospective --state all --limit 1
 
 Keep the JSON output for Step 1.
 
-## Step 1: Delegate analysis to a Fable subagent
+## Step 1: Main first-pass analysis
+
+Read `${CLAUDE_SKILL_DIR}/analysis.md` and follow it to produce
+initial findings from the current session's in-memory context — do
+not read the transcript file for this step. Substitute the Step 0
+JSON output for `<PAST_RETROSPECTIVES>` where analysis.md's
+cross-session recurrence check needs it (or the literal string `[]`
+if Step 0 returned no issues).
+
+Alongside the findings, produce a factual digest of what the analysis
+drew on:
+
+- User-turn references: a paraphrase (not a verbatim quote) of each
+  user turn that informed a finding
+- Hook / Stop events: any hook rejection, permission denial, or
+  Stop-hook trigger observed in the session
+- Decisions consulted: plan approvals, explicit user confirmations, or
+  routing choices referenced by a finding
+- Tool calls: any tool call whose result produced signal for a
+  finding, named by command, not full output
+
+The digest is what Fable uses in Step 2 to spot-check coverage — keep
+each item specific enough that Fable can verify it against a
+transcript slice.
+
+## Step 2: Fable review
 
 Compute the current session's transcript path. The Session ID is
 already substituted below when this SKILL.md loads:
@@ -37,37 +63,110 @@ Confirm the file exists with `ls -la <full-path>` before spawning.
 If it does not exist (rare, e.g. the transcript is still buffered),
 fall back to the newest `*.jsonl` in `$HOME/.claude/projects/<munged-cwd>/`.
 
-Then invoke the Agent tool with:
+Invoke the Agent tool with:
 
 - `subagent_type`: `general-purpose`
 - `model`: `fable`
-- `description`: `retrospective analysis`
+- `description`: `retrospective review`
 - `prompt`: paste the template below, substituting `<TRANSCRIPT_PATH>`
-  with the resolved absolute path and `<PAST_RETROSPECTIVES>` with the
-  JSON output from Step 0 (or the literal string `[]` if empty).
+  with the resolved absolute path, `<FINDINGS>` with Step 1's
+  findings, and `<DIGEST>` with Step 1's factual digest
 
 Prompt template:
 
 ```
-You are performing a session retrospective on the outside.
+You are reviewing a session retrospective's first-pass findings from
+the outside.
 
 Instructions: Read the analysis instructions at
-${CLAUDE_SKILL_DIR}/analysis.md and follow them exactly.
+${CLAUDE_SKILL_DIR}/analysis.md — they define the severity, taxonomy,
+and output format for both the first pass and this review.
 
 Inputs:
+- Initial findings (produced by the main session from in-memory context): <FINDINGS>
+- Factual digest (what the main session drew on to produce the findings): <DIGEST>
 - Session transcript (jsonl, one JSON object per line): <TRANSCRIPT_PATH>
-- Past retrospectives on this project (for cross-session recurrence detection): <PAST_RETROSPECTIVES>
 
-Output: return the analysis findings in the format specified in
-analysis.md. For each finding, include a `Scope:` tag with value
-`global` or `project-specific`, and a `Destination:` tag with one of
-`existing-rule-edit` / `existing-skill-update` / `mechanize` /
-`new-rule` / `new-skill`. Do not create GitHub issues and do
-not invoke AskUserQuestion — the orchestrator handles routing after
-you return. Do not add preamble or closing remarks.
+Mandatory: before returning verdicts, sample the transcript with `jq`
+/ `grep` regardless of digest quality — around 5-10 slices, under
+~20 KB total. Pick slices that let you check digest coverage: a few
+user turns, a few tool-call sequences, one or two hook/stop events. Do
+not read the whole transcript.
+
+For each initial finding, return one of these verdicts:
+- confirm — the finding and the digest line up with the sampled transcript; keep as-is
+- adjust — the finding is directionally right but severity, scope, destination, or countermeasure needs a change; state the change
+- reject — the finding is not supported by the sampled transcript or the digest misrepresents what happened; state why
+
+Format each verdict as:
+
+## <finding number/title>
+Verdict: confirm / adjust / reject
+Reason: <one line>
+Adjusted finding: <only when Verdict is adjust — state the corrected fields>
+
+If the mandatory slice sample reveals a behavior the digest omitted,
+list it separately as a proposed addition, using analysis.md's finding
+format plus a Reason line citing the transcript evidence:
+
+## Add missing: <short title>
+Problem: <what happened>
+Severity: high / medium / low
+Scope: global / project-specific
+Destination: existing-rule-edit / existing-skill-update / mechanize / new-rule / new-skill
+Countermeasure: <structural fix>
+Reason: <transcript evidence for this addition>
+
+Do not read the whole transcript. Do not invoke AskUserQuestion or gh
+— the orchestrator handles both. Do not add preamble or closing
+remarks.
 ```
 
-## Step 2: Route findings by scope
+## Step 3: Apply verdicts + delta round 2
+
+Apply each Step 2 verdict to its finding:
+- confirm — keep the finding as-is
+- reject — drop the finding
+- adjust — replace the finding with Fable's adjusted version
+
+When main disagrees with a reject or adjust and keeps a version
+closer to its own Step 1 finding, record Fable's dissent (its verdict
+and reason) alongside the kept finding — Step 4's AskUserQuestion
+surfaces both versions so the user arbitrates.
+
+If Step 2 returned any "Add missing" proposals, send a delta-only
+round 2 to the same Fable subagent via SendMessage, asking it to
+defend each addition with concrete transcript evidence. Do not re-run
+the Step 1 findings in round 2 — only the delta.
+
+Round 2 prompt template:
+
+```
+Defend the "Add missing" findings from your previous review with
+concrete transcript evidence.
+
+Additions to defend: <ADD_MISSING_FINDINGS>
+
+For each addition, cite the specific evidence that supports it — a
+line range, the jq/grep query used, or a short quoted snippet. If you
+cannot produce concrete evidence for an addition, withdraw it.
+
+Format each response as:
+
+## <addition title>
+Evidence: <line range / query / quoted snippet, or "withdrawn">
+```
+
+Accept or reject each defended addition based on the evidence
+quality. Surface dissent the same way as above when main rejects a
+defended addition it disagrees with.
+
+This round is the last one — 2 total Fable rounds is the hard cap.
+
+The finalized findings (Step 1 confirmed/adjusted, plus any accepted
+additions, each carrying dissent where present) move to Step 4.
+
+## Step 4: Route findings by scope
 
 Take the subagent's output verbatim. Each finding carries a `Scope`
 (`global` / `project-specific`) tag and a `Destination`

--- a/claude/skills/retrospective/analysis.md
+++ b/claude/skills/retrospective/analysis.md
@@ -7,8 +7,10 @@ in-memory session context during the first pass, and a Fable
 subagent, which applies it to spot-checked transcript slices during
 review.
 
-Analyze the provided session transcript and past retrospective issues,
-then produce a list of problem behaviors with structural countermeasures.
+Analyze the session's interaction record — in-memory session context
+for the main first pass, sampled transcript slices for the Fable
+review — and past retrospective issues, then produce a list of
+problem behaviors with structural countermeasures.
 
 Focus on the interaction process, not on the task content itself.
 
@@ -155,15 +157,16 @@ This section applies to Fable during Step 2; the main session does
 not read the transcript in Step 1.
 
 The jsonl is one JSON object per line and can be large (hundreds of
-KB) with verbose noise — full tool outputs, injected CLAUDE.md /
-system-reminder blocks, permission prompts. Do not let the noise bury
-the reasoning.
+KB to several MB) with verbose noise — full tool outputs, injected
+CLAUDE.md / system-reminder blocks, permission prompts. Do not read
+the whole file, regardless of size — always slice-sample.
 
-- For a small file, read it directly
-- For a large file, use Bash (`wc -l`, `jq`, `tail`) to extract the
-  signal: user turns, the assistant's own text and reasoning, tool
-  calls and their key results. Skip or skim bulk tool output and
-  repeated system reminders
+- Use Bash (`wc -l`, `jq`, `grep`, `tail`) to extract targeted slices
+  covering user turns, the assistant's own text and reasoning, tool
+  calls and their key results, and hook / Stop events
+- Skip or skim bulk tool output and repeated system reminders
 - The transcript may not include the currently-in-progress turn (the
-  one that triggered this retrospective). If so, note it in your
-  output; do not fabricate content for it.
+  one that triggered this retrospective); when the digest describes
+  behavior from that turn but the sampled slices do not confirm it,
+  return `unverifiable` for that finding rather than `reject` — see
+  the verdict schema in SKILL.md's Step 2

--- a/claude/skills/retrospective/analysis.md
+++ b/claude/skills/retrospective/analysis.md
@@ -1,5 +1,12 @@
 # Retrospective analysis instructions
 
+## Reader context
+
+This file has two consumers: the main session, which applies it to
+in-memory session context during the first pass, and a Fable
+subagent, which applies it to spot-checked transcript slices during
+review.
+
 Analyze the provided session transcript and past retrospective issues,
 then produce a list of problem behaviors with structural countermeasures.
 
@@ -143,6 +150,9 @@ If there are no significant problem behaviors in the session, say so in
 one line and stop.
 
 ## Reading the transcript
+
+This section applies to Fable during Step 2; the main session does
+not read the transcript in Step 1.
 
 The jsonl is one JSON object per line and can be large (hundreds of
 KB) with verbose noise — full tool outputs, injected CLAUDE.md /

--- a/claude/skills/retrospective/analysis.md
+++ b/claude/skills/retrospective/analysis.md
@@ -24,25 +24,21 @@ Keep each entry to 1-2 lines. Skip behaviors that had no real impact.
 ## Step 2: Propose structural countermeasures
 
 For each problem, identify the governing rule first, then pick the
-highest applicable countermeasure in this order:
+highest applicable destination in this order:
 
-1. Fix the existing rule that failed to prevent the behavior.
-   Diagnose why it failed — wording too vague, wrong loading tier
-   (not in context when needed), or no enforcement — and propose
-   editing, splitting, relocating, or mechanizing that rule.
-   Never add a parallel rule next to a failed one.
-1. Delete or merge rules when overlap, contradiction, or sheer
-   volume contributed to the failure.
-1. Mechanize (hook, CI check, pre-commit, script, permission
-   setting, template) when the behavior is mechanically checkable.
-   A mechanized check may replace the prose rule it enforces.
-1. Add a new rule only when no existing rule covers the problem.
-   State the net context cost: lines added, target loading tier
-   (always-loaded rule vs on-demand skill), and what compensating
-   trim keeps the tier within budget.
+1. `existing-rule-edit` — an existing rule failed to prevent the behavior (vague wording, wrong loading tier, or no enforcement); edit, split, relocate, or mechanize it, never add a parallel rule next to a failed one
+1. `existing-skill-update` — an existing skill file (`SKILL.md`, `analysis.md`, etc.) failed to guide the behavior; edit it directly
+1. `mechanize` — the behavior is mechanically checkable; add a hook, CI check, pre-commit, script, permission setting, or template, which may replace the prose rule it enforces
+1. `new-rule` — no existing rule covers the problem; state the net context cost (lines added, target loading tier, compensating trim)
+1. `new-skill` — no existing skill covers the problem and it needs a new on-demand workflow; scaffold a new skill
 
-Format as a numbered list of pairs. Include a severity rating and a
-scope tag (global / project-specific) for each:
+A countermeasure that deletes or merges existing rules or skills is an
+orthogonal edit operation, not a destination of its own — apply it
+alongside whichever destination above the finding routes to, when
+overlap, contradiction, or sheer volume contributed to the failure.
+
+Format as a numbered list of pairs. Include a severity rating, a
+scope tag (global / project-specific), and a destination tag for each:
 
 ```
 ## 1. <short title>
@@ -50,6 +46,7 @@ scope tag (global / project-specific) for each:
 Problem: <what happened>
 Severity: high / medium / low (with brief justification)
 Scope: global / project-specific
+Destination: existing-rule-edit / existing-skill-update / mechanize / new-rule / new-skill
 Countermeasure: <structural fix>
 ```
 


### PR DESCRIPTION
## Summary

PR 1 (#283) kept the original executor: a Fable subagent reads the whole session jsonl from disk and produces findings one-shot. That duplicates work — the main session already has the same context in memory — and re-pays the read cost on every session end even though the jsonl is typically several MB. This PR flips the executor so main does the first pass in-memory, and Fable reviews the resulting findings against a small mandatory sample of transcript slices instead of the whole file.

## Why the shape it took

Splitting analyst from reviewer moves total transcript I/O from "whole file every time" to "a few slices plus targeted spot-checks", while keeping an outside perspective that catches motivated severity-downgrading. Main owns the initial slate and the final decision; Fable is the challenger with a hard 2-round cap and delta-only round 2 (Fable's "add missing" proposals get one defense pass, not a full re-review).

Self-bias mitigation: any finding where main overrides Fable's `reject` or `adjust` carries Fable's dissent into Step 4's `AskUserQuestion`, so the user arbitrates disputed cases explicitly. The rubber-stamp path stays only on `confirm`.

Compaction handling: an earlier reviewer suggestion to detect compaction via an `isCompactSummary` jsonl field was dropped after `grep` across all local `~/.claude/projects/**/*.jsonl` returned zero matches for that field name. Instead Fable's slice sample is mandatory every session, so the coverage check runs whether the digest is complete or lossy.

## Verification

Static:

- `pre-commit run --files claude/skills/retrospective/SKILL.md claude/skills/retrospective/analysis.md` → all applicable hooks `Passed`; JSON/YAML/line-count budget hooks `Skipped` as N/A
- `git grep -n 'Step 1\|Step 2\|Step 3\|Step 4' claude/skills/retrospective/SKILL.md` → step cross-references all consistent, no dangling references to the deleted old Step 1 delegation template
- `SendMessage` tool schema verified against the current session's `ToolSearch select:SendMessage` result — the round-2 continuation mechanism exists at time of writing

End-to-end:

- [ ] Run `/retrospective` once from a throwaway session with all findings routed as `skip`, and confirm (a) the 2-round cap fires when Fable emits `add missing`, (b) Fable's mandatory slice sample actually happens, (c) dissent surfaces to `AskUserQuestion` when main overrides a Fable verdict. Deferred out of this PR because `claude/skills/retrospective/*` is symlinked into `~/.claude/`, so any real invocation mutates the live skill for every concurrent Claude Code session on this host, and non-`skip` paths would open real GitHub issues

## Base branch

Stacked on `retrospective-routing` (PR #283) — merge #283 first, then this. GitHub will re-target the base to `main` automatically after #283 lands.
