### PR TITLE
Broaden warn_gh_api hook allowlist and close write-flag bypasses

### DIFF
--- a/AIRULES.md
+++ b/AIRULES.md
@@ -79,7 +79,7 @@
 - 通常のWebサイトよりもプレーンテキスト・Markdownファイルの取得を優先する
 - GitHubの操作はコーディングタスクの場合 `gh` コマンドを使う。ghが使えない環境やghで実現できない操作の場合のみ `raw.githubusercontent.com` 等を使ってよい
 - `gh` の中では高レベルサブコマンド（`gh pr view` / `gh pr diff` / `gh pr checks` / `gh issue view` / `gh run view` 等）を優先する。特にPRレビュー・レビューコメント・レビュースレッドの取得や操作は `gh pr-review` 拡張（`agynio/gh-pr-review`）を使う
-- 他リポのファイル本文取得は `gh api repos/OWNER/REPO/contents/PATH -H "Accept: application/vnd.github.raw"` を使う（`?ref=<branch>` でref指定可）。これは `gh` の高レベルサブコマンドで表現できない代表例で、他の `gh api` 用途（`gh api graphql -f query=...` 等）はこれらで実現できない操作に限定する
+- 他リポのファイル本文取得は `gh api repos/OWNER/REPO/contents/PATH -H "Accept: application/vnd.github.raw"` を使う（`?ref=<branch>` でref指定可）。これは `gh` の高レベルサブコマンドで表現できない代表例で、他の `gh api` 用途（`gh api graphql -f query=...` 等）は高レベルサブコマンド・`gh pr-review`・この contents shape のいずれでも表現できない操作に限定する
 - IDE連携のMCPサーバー（コードインデックス・シンボル解決・静的解析等）が接続されている時は、コード検索・ナビゲーション・解析にその読み取り系ツールを優先する（ユーザーの明示は不要）
 - OSS・ライブラリ・ツール等を提案・採用する前にGitHubリポジトリ等で最終コミット・リリース・archive有無・issue/PR対応を確認する（README・履歴レベルで止める）。3年以上更新なし / archive済みは積極採用せず、確認結果を採用可否の根拠とし未確認なら「未確認」とする。用途が単純なら自前実装・forkも選択肢に含める
 

--- a/AIRULES.md
+++ b/AIRULES.md
@@ -78,7 +78,8 @@
 - Web検索よりMCPサーバー等の外部情報ツールを優先する
 - 通常のWebサイトよりもプレーンテキスト・Markdownファイルの取得を優先する
 - GitHubの操作はコーディングタスクの場合 `gh` コマンドを使う。ghが使えない環境やghで実現できない操作の場合のみ `raw.githubusercontent.com` 等を使ってよい
-- `gh` の中では高レベルサブコマンド（`gh pr view` / `gh pr diff` / `gh pr checks` / `gh issue view` / `gh run view` 等）を優先する。特にPRレビュー・レビューコメント・レビュースレッドの取得や操作は `gh pr-review` 拡張（`agynio/gh-pr-review`）を使う。`gh api`（特に `gh api graphql -f query=...`）はこれらで実現できない操作に限定する
+- `gh` の中では高レベルサブコマンド（`gh pr view` / `gh pr diff` / `gh pr checks` / `gh issue view` / `gh run view` 等）を優先する。特にPRレビュー・レビューコメント・レビュースレッドの取得や操作は `gh pr-review` 拡張（`agynio/gh-pr-review`）を使う
+- 他リポのファイル本文取得は `gh api repos/OWNER/REPO/contents/PATH -H "Accept: application/vnd.github.raw"` を使う（`?ref=<branch>` でref指定可）。これは `gh` の高レベルサブコマンドで表現できない代表例で、他の `gh api` 用途（`gh api graphql -f query=...` 等）はこれらで実現できない操作に限定する
 - IDE連携のMCPサーバー（コードインデックス・シンボル解決・静的解析等）が接続されている時は、コード検索・ナビゲーション・解析にその読み取り系ツールを優先する（ユーザーの明示は不要）
 - OSS・ライブラリ・ツール等を提案・採用する前にGitHubリポジトリ等で最終コミット・リリース・archive有無・issue/PR対応を確認する（README・履歴レベルで止める）。3年以上更新なし / archive済みは積極採用せず、確認結果を採用可否の根拠とし未確認なら「未確認」とする。用途が単純なら自前実装・forkも選択肢に含める
 

--- a/claude/hooks/warn_gh_api.py
+++ b/claude/hooks/warn_gh_api.py
@@ -15,6 +15,10 @@ whitespace collapsed to a single space).
 Session state is tracked in ``~/.claude/state/gh_api_warned_<session_id>.json``.
 Set ``ENABLE_GH_API_WARNING=0`` to disable.
 
+Commands where every ``gh api`` segment is a read of the contents endpoint
+(``gh api repos/OWNER/REPO/contents/PATH``, no write flags) are allowlisted
+and pass through without a deny on the first occurrence.
+
 Spec: https://docs.anthropic.com/en/docs/claude-code/hooks
 """
 import hashlib
@@ -22,6 +26,7 @@ import json
 import os
 import random
 import re
+import shlex
 import sys
 from datetime import datetime
 
@@ -159,6 +164,88 @@ def detect_gh_api(command: str) -> bool:
     return False
 
 
+_CONTENTS_RE = re.compile(r"repos/[^/\s]+/[^/\s]+/contents/[^\s]+")
+_WRITE_FLAGS = {"-X", "--method", "-f", "--field", "-F", "--raw-field", "--input"}
+
+
+def is_contents_read(command: str) -> bool:
+    """Return True if every ``gh api`` segment is a read of the contents endpoint.
+
+    Detected — plain contents read:
+    >>> is_contents_read("gh api repos/foo/bar/contents/README.md")
+    True
+    >>> is_contents_read(
+    ...     'gh api repos/foo/bar/contents/path/to/file.py -H '
+    ...     '"Accept: application/vnd.github.raw"'
+    ... )
+    True
+    >>> is_contents_read("gh api repos/foo/bar/contents/README.md?ref=trunk")
+    True
+
+    NOT detected — non-contents endpoint, or graphql:
+    >>> is_contents_read("gh api repos/foo/bar/pulls/123")
+    False
+    >>> is_contents_read("gh api graphql -f query='...'")
+    False
+
+    NOT detected — write flags present:
+    >>> is_contents_read(
+    ...     "gh api repos/foo/bar/contents/x.md -X PUT "
+    ...     "-f message=... -f content=..."
+    ... )
+    False
+    >>> is_contents_read("gh api repos/foo/bar/contents/x.md -f sha=abc")
+    False
+
+    NOT detected — not a gh api command at all, or empty:
+    >>> is_contents_read("gh pr view 123")
+    False
+    >>> is_contents_read("")
+    False
+
+    Compound commands — every gh api segment must qualify:
+    >>> is_contents_read("mkdir d && gh api repos/foo/bar/contents/README.md")
+    True
+    >>> is_contents_read(
+    ...     "gh api repos/foo/bar/contents/README.md && "
+    ...     "gh api repos/foo/bar/pulls/1"
+    ... )
+    False
+    """
+    found_gh_api = False
+    for seg in _split_outside_quotes(command):
+        seg = seg.strip()
+        if not seg:
+            continue
+        if not re.match(r"gh(\s|$)", seg):
+            continue
+        try:
+            tokens = shlex.split(seg)
+        except ValueError:
+            return False
+        if len(tokens) < 2:
+            continue
+
+        api_index = None
+        for idx, token in enumerate(tokens[1:], start=1):
+            if token.startswith("-"):
+                continue
+            if token == "api":
+                api_index = idx
+            break
+        if api_index is None:
+            continue
+
+        found_gh_api = True
+        rest = tokens[api_index + 1:]
+        if any(tok in _WRITE_FLAGS for tok in rest):
+            return False
+        if not any(_CONTENTS_RE.fullmatch(tok) for tok in rest):
+            return False
+
+    return found_gh_api
+
+
 def _state_path(session_id: str) -> str:
     return os.path.join(_STATE_DIR, f"{_STATE_PREFIX}{session_id}.json")
 
@@ -232,6 +319,9 @@ def main() -> None:
         sys.exit(0)
 
     if not detect_gh_api(command):
+        sys.exit(0)
+
+    if is_contents_read(command):
         sys.exit(0)
 
     session_id = data.get("session_id", "default")

--- a/claude/hooks/warn_gh_api.py
+++ b/claude/hooks/warn_gh_api.py
@@ -15,9 +15,10 @@ whitespace collapsed to a single space).
 Session state is tracked in ``~/.claude/state/gh_api_warned_<session_id>.json``.
 Set ``ENABLE_GH_API_WARNING=0`` to disable.
 
-Commands where every ``gh api`` segment is a read of the contents endpoint
-(``gh api repos/OWNER/REPO/contents/PATH``, no write flags) are allowlisted
-and pass through without a deny on the first occurrence.
+Commands where every ``gh api`` segment is either a read of the contents
+endpoint (``gh api repos/OWNER/REPO/contents/PATH``, no write flags) or a
+help query (``gh api --help`` / ``gh api -h``) are allowlisted and skip the
+warning entirely.
 
 Spec: https://docs.anthropic.com/en/docs/claude-code/hooks
 """
@@ -165,7 +166,95 @@ def detect_gh_api(command: str) -> bool:
 
 
 _CONTENTS_RE = re.compile(r"repos/[^/\s]+/[^/\s]+/contents/[^\s]+")
-_WRITE_FLAGS = {"-X", "--method", "-f", "--field", "-F", "--raw-field", "--input"}
+_WRITE_SHORT = ("-X", "-f", "-F")
+_WRITE_LONG = ("--method", "--field", "--raw-field", "--input")
+_HELP_FLAGS = {"-h", "--help"}
+
+
+def _is_write_flag(tok: str) -> bool:
+    """Return True if ``tok`` is a ``gh api`` write flag in any form pflag accepts.
+
+    Handles space-separated (``-X PUT``, ``--method PUT``), attached short
+    (``-XPUT``, ``-fkey=val``), and ``=``-suffixed long (``--method=PUT``,
+    ``--field=key=val``) forms.
+
+    >>> _is_write_flag("-X")
+    True
+    >>> _is_write_flag("-XPUT")
+    True
+    >>> _is_write_flag("-fmessage=abc")
+    True
+    >>> _is_write_flag("-Fcontent=@file")
+    True
+    >>> _is_write_flag("--method")
+    True
+    >>> _is_write_flag("--method=PUT")
+    True
+    >>> _is_write_flag("--field=key=val")
+    True
+    >>> _is_write_flag("--raw-field=k=v")
+    True
+    >>> _is_write_flag("--input=-")
+    True
+    >>> _is_write_flag("-H")
+    False
+    >>> _is_write_flag("repos/foo/bar/contents/x")
+    False
+    """
+    for sf in _WRITE_SHORT:
+        if tok == sf or (tok.startswith(sf) and len(tok) > len(sf)):
+            return True
+    for lf in _WRITE_LONG:
+        if tok == lf or tok.startswith(lf + "="):
+            return True
+    return False
+
+
+def _iter_gh_api_rest(command: str):
+    """Yield the token list after ``api`` for each ``gh api`` segment in ``command``.
+
+    Yields ``None`` on a shlex parse failure to signal the caller should
+    bail. Segments that are not ``gh api`` invocations are skipped
+    silently. Mirrors ``detect_gh_api``'s walker semantics (first token
+    ``gh``, then skipping ``-``-prefixed flag tokens until the first
+    non-flag token equals ``api``).
+
+    >>> list(_iter_gh_api_rest("gh api repos/foo/bar"))
+    [['repos/foo/bar']]
+    >>> list(_iter_gh_api_rest('gh api -H "Accept: x" repos/foo/bar'))
+    [['-H', 'Accept: x', 'repos/foo/bar']]
+    >>> list(_iter_gh_api_rest("gh pr view 1"))
+    []
+    >>> list(_iter_gh_api_rest("mkdir d && gh api repos/foo/bar"))
+    [['repos/foo/bar']]
+    >>> list(_iter_gh_api_rest("gh api 'unterminated"))
+    [None]
+    """
+    for seg in _split_outside_quotes(command):
+        seg = seg.strip()
+        if not seg:
+            continue
+        if not re.match(r"gh(\s|$)", seg):
+            continue
+        try:
+            tokens = shlex.split(seg)
+        except ValueError:
+            yield None
+            return
+        if len(tokens) < 2:
+            continue
+
+        api_index = None
+        for idx, token in enumerate(tokens[1:], start=1):
+            if token.startswith("-"):
+                continue
+            if token == "api":
+                api_index = idx
+            break
+        if api_index is None:
+            continue
+
+        yield tokens[api_index + 1:]
 
 
 def is_contents_read(command: str) -> bool:
@@ -185,16 +274,30 @@ def is_contents_read(command: str) -> bool:
     NOT detected — non-contents endpoint, or graphql:
     >>> is_contents_read("gh api repos/foo/bar/pulls/123")
     False
-    >>> is_contents_read("gh api graphql -f query='...'")
+    >>> is_contents_read("gh api graphql")
     False
 
-    NOT detected — write flags present:
+    NOT detected — write flags present (space-separated forms):
     >>> is_contents_read(
     ...     "gh api repos/foo/bar/contents/x.md -X PUT "
     ...     "-f message=... -f content=..."
     ... )
     False
     >>> is_contents_read("gh api repos/foo/bar/contents/x.md -f sha=abc")
+    False
+    >>> is_contents_read("gh api repos/foo/bar/contents/x.md --method PUT")
+    False
+
+    NOT detected — write flags present (attached-value / ``=`` forms):
+    >>> is_contents_read("gh api repos/foo/bar/contents/x.md -XDELETE")
+    False
+    >>> is_contents_read("gh api repos/foo/bar/contents/x.md -fmessage=y")
+    False
+    >>> is_contents_read("gh api repos/foo/bar/contents/x.md -Fcontent=@file")
+    False
+    >>> is_contents_read("gh api repos/foo/bar/contents/x.md --method=PUT")
+    False
+    >>> is_contents_read("gh api repos/foo/bar/contents/x.md --field=key=val")
     False
 
     NOT detected — not a gh api command at all, or empty:
@@ -212,38 +315,51 @@ def is_contents_read(command: str) -> bool:
     ... )
     False
     """
-    found_gh_api = False
-    for seg in _split_outside_quotes(command):
-        seg = seg.strip()
-        if not seg:
-            continue
-        if not re.match(r"gh(\s|$)", seg):
-            continue
-        try:
-            tokens = shlex.split(seg)
-        except ValueError:
+    found = False
+    for rest in _iter_gh_api_rest(command):
+        if rest is None:
             return False
-        if len(tokens) < 2:
-            continue
-
-        api_index = None
-        for idx, token in enumerate(tokens[1:], start=1):
-            if token.startswith("-"):
-                continue
-            if token == "api":
-                api_index = idx
-            break
-        if api_index is None:
-            continue
-
-        found_gh_api = True
-        rest = tokens[api_index + 1:]
-        if any(tok in _WRITE_FLAGS for tok in rest):
+        found = True
+        if any(_is_write_flag(tok) for tok in rest):
             return False
         if not any(_CONTENTS_RE.fullmatch(tok) for tok in rest):
             return False
+    return found
 
-    return found_gh_api
+
+def is_help_query(command: str) -> bool:
+    """Return True if every ``gh api`` segment is a help query.
+
+    Detected:
+    >>> is_help_query("gh api --help")
+    True
+    >>> is_help_query("gh api -h")
+    True
+    >>> is_help_query("gh api graphql --help")
+    True
+
+    NOT detected — no help flag, not a gh api call, or empty:
+    >>> is_help_query("gh api repos/foo/bar/contents/x")
+    False
+    >>> is_help_query("gh pr view --help")
+    False
+    >>> is_help_query("")
+    False
+
+    Compound — every gh api segment must carry help:
+    >>> is_help_query("gh api --help && gh api -h")
+    True
+    >>> is_help_query("gh api --help && gh api repos/foo/bar")
+    False
+    """
+    found = False
+    for rest in _iter_gh_api_rest(command):
+        if rest is None:
+            return False
+        found = True
+        if not any(tok in _HELP_FLAGS for tok in rest):
+            return False
+    return found
 
 
 def _state_path(session_id: str) -> str:
@@ -321,7 +437,7 @@ def main() -> None:
     if not detect_gh_api(command):
         sys.exit(0)
 
-    if is_contents_read(command):
+    if is_contents_read(command) or is_help_query(command):
         sys.exit(0)
 
     session_id = data.get("session_id", "default")


### PR DESCRIPTION
## Summary

- Allowlist `gh api repos/OWNER/REPO/contents/PATH` reads and `gh api --help` / `gh api -h` queries in `claude/hooks/warn_gh_api.py` so they pass the hook on first try instead of being denied and forcing a retry.
- Update `AIRULES.md` to name the contents-read shape as the canonical way to read a file from another repository.
- No changes to `claude/settings.json` — the existing `Bash(gh api *)` allow rule is sufficient; only the hook was blocking.

## Why

`claude/hooks/block_raw_github_fetch.py` already denies `curl`/`wget` against `raw.githubusercontent.com` and its denial message recommends `gh api repos/<owner>/<repo>/contents/<path> -H "Accept: application/vnd.github.raw"`. But that recommended shape then hit `warn_gh_api.py`, which denies the first `gh api` per session per distinct command to push toward high-level subcommands. There is no high-level `gh` subcommand equivalent for reading a file from another repo, so the deny gate produced friction on the one `gh api` invocation intended to be the primary path. `gh api --help` has the same shape of problem: no substantive API call to gate, but the first-try deny still blocks it.

The allowlist keeps every other `gh api` invocation (including `gh api graphql`, and any contents-endpoint call that carries write flags such as `-X`/`--method`/`-f`/`-F`/`--field`/`--raw-field`/`--input` in any pflag-accepted form) on the existing deny-then-retry behavior.

## Design notes

- `shlex.split` per segment is required so that quoted header values (`-H "Accept: application/vnd.github.raw"`) tokenize as one argument; a plain `.split()` would break them across tokens and misread positional-argument order.
- Write-flag detection uses `_is_write_flag`, which matches short flags by prefix (`-XPUT`, `-fmessage=abc`, `-Fcontent=@file`) and long flags by exact match or `<flag>=` prefix (`--method=PUT`, `--field=key=val`). pflag / cobra accept all these forms as first-class equivalents to the space-separated ones; an exact-token set would leave a bypass path for a DELETE/PUT masquerading as a contents read.
- In compound commands (`&&`, `||`, `;`, pipe, newline), every `gh api` segment must qualify for allowlisting. A single non-qualifying segment forces the whole command back onto the deny-then-retry path, so the retry signal is never bypassed by chaining a legitimate read with a write.
- `is_contents_read` and `is_help_query` share `_iter_gh_api_rest`, a per-segment walker that yields the token list after the `api` keyword. Keeps the two allowlist predicates aligned on what counts as a `gh api` segment.

## Verification

Behavior verified by end-to-end hook simulation on stdin (`printf '%s' '<json>' | python3 claude/hooks/warn_gh_api.py`), fresh `session_id` per case:

- `gh api repos/jparise/gh-cat/contents/README.md -H "Accept: application/vnd.github.raw"` — allowlisted.
- `gh api repos/foo/bar/contents/x.md -XDELETE -fmessage=y -fsha=z` — denied (attached-value short-flag bypass closed).
- `gh api repos/foo/bar/contents/x.md --method=PUT --field=message=abc` — denied (`=`-suffixed long-flag bypass closed).
- `gh api --help` / `gh api -h` — allowlisted.
- `gh api graphql -f query='{...}'` — denied (not a contents endpoint or help query).
- `gh pr view 123` — passthrough (not a `gh api` command).

## Test plan

- [ ] Post-merge: in a fresh session, run `gh api repos/jparise/gh-cat/contents/README.md -H "Accept: application/vnd.github.raw"` and `gh api --help` and confirm no deny on first try.
