### PR TITLE
Add gh-sub-issue extension for in-repo sub-issue management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           shellcheck -- **/*.sh
           find bin/ -type f ! -name '*.md' -exec shellcheck {} +
           find xdg-config/git/hooks/ -type f -exec shellcheck {} +
+          find gh-extensions/ -type f ! -name '*.md' ! -name 'LICENSE' -exec shellcheck {} +
           shellcheck --exclude SC2148 .bash_profile .bashrc
   python-doctest:
     runs-on: ubuntu-latest

--- a/AIRULES.md
+++ b/AIRULES.md
@@ -79,7 +79,7 @@
 - Web検索よりMCPサーバー等の外部情報ツールを優先する
 - 通常のWebサイトよりもプレーンテキスト・Markdownファイルの取得を優先する
 - GitHubの操作はコーディングタスクの場合 `gh` コマンドを使う。ghが使えない環境やghで実現できない操作の場合のみ `raw.githubusercontent.com` 等を使ってよい
-- `gh` の中では高レベルサブコマンド（`gh pr view` / `gh pr diff` / `gh pr checks` / `gh issue view` / `gh run view` 等）を優先する。特にPRレビュー・レビューコメント・レビュースレッドの取得や操作は `gh pr-review` 拡張（`agynio/gh-pr-review`）を使う。`gh api`（特に `gh api graphql -f query=...`）はこれらで実現できない操作に限定する
+- `gh` の中では高レベルサブコマンド（`gh pr view` / `gh pr diff` / `gh pr checks` / `gh issue view` / `gh run view` 等）を優先する。特にPRレビュー・レビューコメント・レビュースレッドの取得や操作は `gh pr-review` 拡張（`agynio/gh-pr-review`）を使う。sub-issue の list/add/remove は `gh sub-issue` 拡張を使う。`gh api`（特に `gh api graphql -f query=...`）はこれらで実現できない操作に限定する
 - IDE連携のMCPサーバー（コードインデックス・シンボル解決・静的解析等）が接続されている時は、コード検索・ナビゲーション・解析にその読み取り系ツールを優先する（ユーザーの明示は不要）
 - OSS・ライブラリ・ツール等を提案・採用する前にGitHubリポジトリ等で最終コミット・リリース・archive有無・issue/PR対応を確認する（README・履歴レベルで止める）。3年以上更新なし / archive済みは積極採用せず、確認結果を採用可否の根拠とし未確認なら「未確認」とする。用途が単純なら自前実装・forkも選択肢に含める
 

--- a/bootstrap/main.sh
+++ b/bootstrap/main.sh
@@ -68,6 +68,7 @@ echo
 
 gh extension install agynio/gh-pr-review
 gh extension install dlvhdr/gh-dash
+(cd gh-extensions/gh-sub-issue && gh extension install .)
 echo
 
 scripts/configure_brew.sh

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -54,6 +54,7 @@
       "Bash(gh issue list *)",
       "Bash(gh issue create *)",
       "Bash(gh api repos/*/contents/*)",
+      "Bash(gh sub-issue list *)",
       "Bash(gh extension list)",
       "Bash(docker compose ps *)",
       "Bash(docker network ls)",

--- a/gh-extensions/gh-sub-issue/LICENSE
+++ b/gh-extensions/gh-sub-issue/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 ikuwow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/gh-extensions/gh-sub-issue/README.md
+++ b/gh-extensions/gh-sub-issue/README.md
@@ -6,16 +6,16 @@ built-in subcommand for.
 
 ## Installation
 
-Registered by `bootstrap/main.sh` on a fresh host. To install manually
-(e.g., on a host that has never run bootstrap), run from within this
-directory:
+From within this directory:
 
 ```sh
 gh extension install .
 ```
 
 `gh extension install` only accepts a local repo via the literal `.`
-argument, run from inside the extension directory.
+argument, run from inside the extension directory (verified against
+cli/cli's `pkg/cmd/extension/command.go`, where the install handler
+exact-matches `args[0] == "."`).
 
 ## Usage
 

--- a/gh-extensions/gh-sub-issue/README.md
+++ b/gh-extensions/gh-sub-issue/README.md
@@ -6,7 +6,9 @@ built-in subcommand for.
 
 ## Installation
 
-Register with `gh` once by running the following from within this directory:
+Registered by `bootstrap/main.sh` on a fresh host. To install manually
+(e.g., on a host that has never run bootstrap), run from within this
+directory:
 
 ```sh
 gh extension install .

--- a/gh-extensions/gh-sub-issue/README.md
+++ b/gh-extensions/gh-sub-issue/README.md
@@ -1,0 +1,32 @@
+# gh-sub-issue
+
+A `gh` CLI extension for listing, adding, and removing GitHub sub-issues,
+wrapping the `/issues/{number}/sub_issues` REST endpoints that `gh` has no
+built-in subcommand for.
+
+## Installation
+
+Installed automatically by this repo's `scripts/deploy.sh`, which registers
+every directory under `gh-extensions/` with `gh extension install`. No manual
+step is needed once the dotfiles are deployed.
+
+## Usage
+
+```sh
+# List the sub-issues of issue #123
+gh sub-issue list 123
+
+# Add issue #456 as a sub-issue of #123
+gh sub-issue add 123 --sub-issue-number 456
+
+# Add issue #456 as a sub-issue of #123, replacing its current parent
+gh sub-issue add 123 --sub-issue-number 456 --replace-parent
+
+# Remove issue #456 from #123's sub-issues
+gh sub-issue remove 123 --sub-issue-number 456
+```
+
+## Notes
+
+This is an independent implementation written for this repo; it does not
+share code with any upstream `gh-sub-issue` extension.

--- a/gh-extensions/gh-sub-issue/README.md
+++ b/gh-extensions/gh-sub-issue/README.md
@@ -6,9 +6,14 @@ built-in subcommand for.
 
 ## Installation
 
-Installed automatically by this repo's `scripts/deploy.sh`, which registers
-every directory under `gh-extensions/` with `gh extension install`. No manual
-step is needed once the dotfiles are deployed.
+Register with `gh` once by running the following from within this directory:
+
+```sh
+gh extension install .
+```
+
+`gh extension install` only accepts a local repo via the literal `.`
+argument, run from inside the extension directory.
 
 ## Usage
 

--- a/gh-extensions/gh-sub-issue/gh-sub-issue
+++ b/gh-extensions/gh-sub-issue/gh-sub-issue
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# gh-sub-issue: manage GitHub sub-issues (list/add/remove) via the REST
+# endpoints under /issues/{number}/sub_issues, which gh has no built-in
+# subcommand for. Independent implementation; nothing vendored.
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage:
+  gh sub-issue list <parent-issue-number>
+  gh sub-issue add <parent-issue-number> --sub-issue-number <child-issue-number> [--replace-parent]
+  gh sub-issue remove <parent-issue-number> --sub-issue-number <child-issue-number>
+EOF
+}
+
+die() {
+  echo "gh sub-issue: $1" >&2
+  exit 1
+}
+
+require_number() {
+  local label="$1" value="$2"
+  [[ "$value" =~ ^[0-9]+$ ]] || die "$label must be a positive integer, got: $value"
+}
+
+# The sub_issues API addresses children by their numeric database id, not
+# their repo-local issue number, so resolve that first.
+child_issue_id() {
+  local number="$1" id
+  id=$(gh api "/repos/{owner}/{repo}/issues/$number" --jq '.id // empty')
+  [ -n "$id" ] || die "could not resolve issue #$number to an id (does it exist?)"
+  echo "$id"
+}
+
+cmd_list() {
+  [ $# -eq 1 ] || { usage >&2; exit 1; }
+  local parent="$1"
+  require_number "parent issue number" "$parent"
+  gh api "/repos/{owner}/{repo}/issues/$parent/sub_issues" --template \
+    '{{range .}}{{tablerow (printf "#%v" .number) .title (join ", " (pluck "name" .labels)) (timeago .updated_at)}}{{end}}{{tablerender}}'
+}
+
+cmd_add() {
+  [ $# -ge 1 ] || { usage >&2; exit 1; }
+  local parent="$1"
+  shift
+  require_number "parent issue number" "$parent"
+
+  local sub_number="" replace_parent=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --sub-issue-number)
+        [ $# -ge 2 ] || die "--sub-issue-number requires a value"
+        sub_number="$2"
+        shift 2
+        ;;
+      --replace-parent)
+        replace_parent=1
+        shift
+        ;;
+      *)
+        die "unknown flag: $1"
+        ;;
+    esac
+  done
+  [ -n "$sub_number" ] || die "--sub-issue-number is required"
+  require_number "sub-issue number" "$sub_number"
+
+  local sub_id
+  sub_id=$(child_issue_id "$sub_number")
+
+  if [ "$replace_parent" -eq 1 ]; then
+    gh api "/repos/{owner}/{repo}/issues/$parent/sub_issues" \
+      -F sub_issue_id="$sub_id" -F replace_parent=true
+  else
+    gh api "/repos/{owner}/{repo}/issues/$parent/sub_issues" \
+      -F sub_issue_id="$sub_id"
+  fi
+}
+
+cmd_remove() {
+  [ $# -ge 1 ] || { usage >&2; exit 1; }
+  local parent="$1"
+  shift
+  require_number "parent issue number" "$parent"
+
+  local sub_number=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --sub-issue-number)
+        [ $# -ge 2 ] || die "--sub-issue-number requires a value"
+        sub_number="$2"
+        shift 2
+        ;;
+      *)
+        die "unknown flag: $1"
+        ;;
+    esac
+  done
+  [ -n "$sub_number" ] || die "--sub-issue-number is required"
+  require_number "sub-issue number" "$sub_number"
+
+  local sub_id
+  sub_id=$(child_issue_id "$sub_number")
+
+  gh api -X DELETE "/repos/{owner}/{repo}/issues/$parent/sub_issue" \
+    -F sub_issue_id="$sub_id"
+}
+
+if [ $# -eq 0 ]; then
+  usage >&2
+  exit 1
+fi
+
+case "$1" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  list)
+    shift
+    cmd_list "$@"
+    ;;
+  add)
+    shift
+    cmd_add "$@"
+    ;;
+  remove)
+    shift
+    cmd_remove "$@"
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -84,7 +84,9 @@ if command -v gh >/dev/null; then
     [ -d "$ext_src" ] || continue
     ext_name=$(basename "$ext_src")
     if [ ! -e "$HOME/.local/share/gh/extensions/$ext_name" ]; then
-      gh extension install "$ext_src"
+      # `gh extension install` only accepts a local repo via literal "."
+      # run from within it; it rejects an absolute path directly.
+      (cd "$ext_src" && gh extension install .)
     fi
   done
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -78,19 +78,6 @@ mkdir -p "$HOME/.claude/rules"
 find "$HOME/.claude/rules/" -maxdepth 1 -type l ! -exec test -e {} \; -print
 find "$DOTPATH/claude/rules" -maxdepth 1 -mindepth 1 -type f -name '*.md' -exec ln -fvns {} "$HOME/.claude/rules/" \;
 
-# GitHub CLI extensions (register via gh so `gh extension list` shows them)
-if command -v gh >/dev/null; then
-  for ext_src in "$DOTPATH/gh-extensions"/gh-*; do
-    [ -d "$ext_src" ] || continue
-    ext_name=$(basename "$ext_src")
-    if [ ! -e "$HOME/.local/share/gh/extensions/$ext_name" ]; then
-      # `gh extension install` only accepts a local repo via literal "."
-      # run from within it; it rejects an absolute path directly.
-      (cd "$ext_src" && gh extension install .)
-    fi
-  done
-fi
-
 # Codex CLI
 link AIRULES.md  "$HOME/.codex/AGENTS.md"
 mkdir -p "$HOME/.codex/rules"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -78,6 +78,17 @@ mkdir -p "$HOME/.claude/rules"
 find "$HOME/.claude/rules/" -maxdepth 1 -type l ! -exec test -e {} \; -print
 find "$DOTPATH/claude/rules" -maxdepth 1 -mindepth 1 -type f -name '*.md' -exec ln -fvns {} "$HOME/.claude/rules/" \;
 
+# GitHub CLI extensions (register via gh so `gh extension list` shows them)
+if command -v gh >/dev/null; then
+  for ext_src in "$DOTPATH/gh-extensions"/gh-*; do
+    [ -d "$ext_src" ] || continue
+    ext_name=$(basename "$ext_src")
+    if [ ! -e "$HOME/.local/share/gh/extensions/$ext_name" ]; then
+      gh extension install "$ext_src"
+    fi
+  done
+fi
+
 # Codex CLI
 link AIRULES.md  "$HOME/.codex/AGENTS.md"
 mkdir -p "$HOME/.codex/rules"


### PR DESCRIPTION
## Summary

Adds an in-tree `gh sub-issue` extension so listing / adding / removing GitHub sub-issues no longer needs a direct `gh api /repos/{owner}/{repo}/issues/N/sub_issues` call. Since #287 narrowed the `gh api` allow to `Bash(gh api repos/*/contents/*)` only, even a read-only sub-issue list drops to an implicit ask; giving it its own subcommand lets a single `Bash(gh sub-issue list *)` allow cover the read path while `add`/`remove` fall through to the default ask.

- New extension at `gh-extensions/gh-sub-issue/` (script + LICENSE + README). Independent implementation — no upstream vendored.
- `bootstrap/main.sh` runs `(cd gh-extensions/gh-sub-issue && gh extension install .)` alongside the existing `agynio/gh-pr-review` and `dlvhdr/gh-dash` installs, so a fresh host gets it registered automatically.
- `.github/workflows/ci.yml` shellcheck job extended with a `find gh-extensions/ ...` so future extension scripts get linted (gh extensions have no `.sh` suffix and aren't under `bin/`).
- `claude/settings.json` allow: `Bash(gh sub-issue list *)`. `add`/`remove` intentionally left to the default ask, matching the read-only-allow / write-ask split #287 established for `gh api`.
- `AIRULES.md` names `gh sub-issue` alongside `gh pr-review` so the AI reaches for the extension before falling to `gh api` and the soft-deny hook.

## Verification

- `shellcheck gh-extensions/gh-sub-issue/gh-sub-issue` — pass (also covered by the extended CI shellcheck job)
- `shellcheck bootstrap/main.sh` — pass
- `bash -n gh-extensions/gh-sub-issue/gh-sub-issue` — pass
- `./gh-extensions/gh-sub-issue/gh-sub-issue` (no args) — usage, exit 1
- `./gh-extensions/gh-sub-issue/gh-sub-issue --help` — usage, exit 0
- `./gh-extensions/gh-sub-issue/gh-sub-issue list foo` — rejects non-numeric parent, exit 1
- `(cd gh-extensions/gh-sub-issue && gh extension install .)` — registers cleanly; `readlink ~/.local/share/gh/extensions/gh-sub-issue` → dotfiles path; `gh extension list` shows `gh sub-issue`
- `gh sub-issue list 285` (real issue with zero sub-issues) — exit 0, empty output; API call succeeded
- `pre-commit run --files ...` on each edited file — pass
- Not tested end-to-end (would mutate GitHub state): `gh sub-issue add` / `remove` against a live issue. Structurally verified via arg validation and the settings.json entry only.

## Notes

- `gh extension install <absolute-path>` refuses to install on gh 2.96.0 (`expected the [HOST/]OWNER/REPO format`). The install handler exact-matches `args[0] == "."` and uses `os.Getwd()` for the local path — verified in cli/cli's `pkg/cmd/extension/command.go`. Hence the subshell `cd` in bootstrap and the "run from within this directory" instruction in the README.
- `gh` discovery does not scan `$PATH`; extensions must live under `~/.local/share/gh/extensions/gh-<name>/gh-<name>` (verified against `pkg/cmd/extension/manager.go` — `Manager.list` L145 / `Manager.InstallLocal` L208).
