### PR TITLE
Cap git-workflow cleanup at one git-cleanup-branches invocation

### DIFF
--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -242,11 +242,16 @@ After the PR is merged (or the task is fully done):
 
 1. Move back to the repository root:
    `cd <repository root>`
-1. Delete unused local branches (merged, squash-merged, or upstream
-   gone) along with their worktrees, and prune stale worktree entries:
-   `git cleanup-branches`
+1. Run `git cleanup-branches` once. That completes this step.
    - Use the space form (`git cleanup-branches`); it is already covered
      by the `Bash(git *)` allow rule, so no extra permission is needed.
-   - Plain `git branch -d` rejects squash-merged branches as "not fully
-     merged", so a custom sweep is needed for repos that squash on
-     merge.
+   - It sweeps local branches that are merged, squash-merged, or
+     upstream-gone, removes their worktrees, and prunes stale worktree
+     entries. Plain `git branch -d` rejects squash-merged branches as
+     "not fully merged", which is why this custom sweep exists.
+   - Branches the sweep leaves behind (uncommitted work in the
+     worktree, PR closed without merge, etc.) stay behind. Do not
+     follow up with `git branch -d` / `git branch -D` /
+     `git push origin --delete` / `git worktree remove --force` or
+     similar to force them out. Only act on an explicit user request
+     to delete a specific branch.

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -242,16 +242,4 @@ After the PR is merged (or the task is fully done):
 
 1. Move back to the repository root:
    `cd <repository root>`
-1. Run `git cleanup-branches` once. That completes this step.
-   - Use the space form (`git cleanup-branches`); it is already covered
-     by the `Bash(git *)` allow rule, so no extra permission is needed.
-   - It sweeps local branches that are merged, squash-merged, or
-     upstream-gone, removes their worktrees, and prunes stale worktree
-     entries. Plain `git branch -d` rejects squash-merged branches as
-     "not fully merged", which is why this custom sweep exists.
-   - Branches the sweep leaves behind (uncommitted work in the
-     worktree, PR closed without merge, etc.) stay behind. Do not
-     follow up with `git branch -d` / `git branch -D` /
-     `git push origin --delete` / `git worktree remove --force` or
-     similar to force them out. Only act on an explicit user request
-     to delete a specific branch.
+1. Run `git cleanup-branches` once.


### PR DESCRIPTION
## Summary

Rewrite Step 6 (Cleanup After Task Completion) of the git-workflow skill so it reads, in full, `Run git cleanup-branches once.`

Previously the step said "delete unused local branches … : `git cleanup-branches`" and combined with the skill's global "never skip a phase" / "steps are pre-authorized" language pushed Claude to treat any branch the sweep left behind as unfinished work and reach for `git branch -D` / `git push origin --delete` / `git worktree remove --force`. The typical trigger is a PR closed without merge — the branch is neither merged, squash-merged, nor upstream-gone, so the sweep correctly skips it and Claude keeps grinding.

`git-cleanup-branches` already enforces its own safety (uncommitted-work check, `--force` absent from worktree removal, default-branch checkout guard), so the skill just needs to point at it in one line. Removing the surrounding rationale, permission notes, and follow-up-command deny list means the model has less to reason about at cleanup time.

## Verification

- `pre-commit run --files claude/skills/git-workflow/SKILL.md` passes (Trim Trailing Whitespace, Fix End of Files, large-file check)
