### PR TITLE
Extend symlink-first rule to cover investigation and discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,12 +12,11 @@ are symlinks pointing to files in this repository.
 - Files under `claude/` are symlinked into `~/.claude/` — always look at `claude/` in this repo first for Claude Code configuration (settings, hooks, MCP, skills, etc.)
 - `AIRULES.md` is also symlinked to `~/.codex/AGENTS.md` (Codex CLI) and `~/.junie/AGENTS.md` (Junie CLI) for their global instructions
 - When investigating, reading, or editing files managed by this repository,
-  always start from the path within this repo (e.g., `bin/foo` not
-  `~/bin/foo`, `claude/settings.json` not `~/.claude/settings.json`). This
-  applies to discovery too — list `claude/hooks/` rather than
-  `~/.claude/hooks/`, cat `AIRULES.md` rather than `~/.claude/CLAUDE.md`.
-  Deploy targets under `$HOME` (`~/.claude/`, `~/.codex/`, etc.) generally
-  require a permission prompt and add nothing over the source in this repo
+  always start from the path within this repo. Examples: `bin/foo` not
+  `~/bin/foo`, `claude/settings.json` not `~/.claude/settings.json`,
+  `ls claude/hooks/` not `ls ~/.claude/hooks/`, `cat AIRULES.md` not
+  `cat ~/.claude/CLAUDE.md`. Deploy targets under `$HOME` (`~/.claude/`,
+  `~/.codex/`, etc.) generally require a permission prompt
 - Check `scripts/deploy.sh` for the full list of symlink mappings
 
 ## Key Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,13 @@ are symlinks pointing to files in this repository.
 
 - Files under `claude/` are symlinked into `~/.claude/` — always look at `claude/` in this repo first for Claude Code configuration (settings, hooks, MCP, skills, etc.)
 - `AIRULES.md` is also symlinked to `~/.codex/AGENTS.md` (Codex CLI) and `~/.junie/AGENTS.md` (Junie CLI) for their global instructions
-- When reading or editing files managed by this repository, always use the
-  path within this repo (e.g., `bin/foo` not `~/bin/foo`,
-  `claude/settings.json` not `~/.claude/settings.json`)
+- When investigating, reading, or editing files managed by this repository,
+  always start from the path within this repo (e.g., `bin/foo` not
+  `~/bin/foo`, `claude/settings.json` not `~/.claude/settings.json`). This
+  applies to discovery too — list `claude/hooks/` rather than
+  `~/.claude/hooks/`, cat `AIRULES.md` rather than `~/.claude/CLAUDE.md`.
+  Deploy targets under `$HOME` (`~/.claude/`, `~/.codex/`, etc.) generally
+  require a permission prompt and add nothing over the source in this repo
 - Check `scripts/deploy.sh` for the full list of symlink mappings
 
 ## Key Commands


### PR DESCRIPTION
## Summary

Extend the "symlink-first" rule in the project `AGENTS.md` so it also covers investigation and discovery (ls, cat), not just reading and editing specific files. The prior wording let listings of `~/.claude/` slip through — those trigger permission prompts and return nothing new over the source in this repo.

## Context

In a session about enabling a plugin only on specific machines, the assistant reflexively ran `ls -la ~/.claude/` as its first investigation step, even though `claude/` in this repo is the source of truth. The user pointed out that this is exactly the case the existing rule was meant to prevent, but the wording only named "reading or editing" and didn't obviously cover directory listing.

## Follow-up (out of scope for this PR)

Rule text alone did not stop the reflex — a PreToolUse soft-deny hook that warns when a `Bash(ls ~/.claude/...)` or similar targets a deploy mirror could be more reliable. Consider adding one under `claude/hooks/` in a separate PR.

## Test plan

- [ ] Manual read-through of the updated bullet by the user
