### PR TITLE
Rename gitconfig include from secrets to local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,13 @@ pre-commit run --all-files
 - All scripts must pass shellcheck validation
 - Use `set -eu` for error handling in critical scripts
 
+## Machine-local Git Config
+
+Machine-specific git settings (host-only URL rewrites, per-repo
+credentials, work-account overrides) go in `~/.gitconfig.local`,
+which `xdg-config/git/config` includes. Do not add these to the
+tracked config.
+
 ## Personal Tool Defaults
 
 This repository is a personal dotfiles repo. Scripts here may assume:

--- a/xdg-config/git/config
+++ b/xdg-config/git/config
@@ -45,7 +45,7 @@
     required = true
 	process = git-lfs filter-process
 [include]
-    path = ~/.gitconfig.secrets
+    path = ~/.gitconfig.local
 [push]
 	default = current
 [pull]


### PR DESCRIPTION
## Summary

- Rename the machine-local git include target from `~/.gitconfig.secrets` to `~/.gitconfig.local` so it clearly holds non-secret host-specific settings (URL rewrites, per-repo credentials, work-account overrides).
- Add an `AGENTS.md` section so agents route machine-only settings to `~/.gitconfig.local` instead of the tracked `xdg-config/git/config`.

## Motivation

Started with a `url.insteadOf` for `tacoms-inc-dev` that only applies on this machine. The existing include was named `secrets`, which no longer fits the broader machine-local use case. `git include` treats a missing path as a silent no-op, so the include line remains safe on machines where the file does not exist.

## Test plan

- [x] `git config --get-all url.git@github.com:tacoms-inc-dev/.insteadOf` returns the rewrite via the new include path on this host
- [x] pre-commit hooks pass at commit time