### PR TITLE
Add parallel implementer dispatch rule for multi-PR plans

### DIFF
--- a/claude/rules/implementation-delegation.md
+++ b/claude/rules/implementation-delegation.md
@@ -24,6 +24,24 @@ of implementing in the main session.
 - Complete branch setup (pull the default branch, create the feature
   branch) before dispatching; the subagent must not create branches or
   worktrees
+- Applies to single-implementer dispatch. Multi-PR parallel dispatch
+  follows the next section instead
+
+## Parallel dispatch for multi-PR plans
+
+- When an approved plan decomposes into multiple PRs with no
+  interdependencies (each can be merged independently against the
+  default branch), dispatch one implementer per PR in parallel (send
+  the Agent calls in a single message)
+- Each implementer runs the git-workflow skill end-to-end for its own
+  PR — creating its own worktree and branch. The parent does NOT
+  pre-create branches or worktrees in this mode (the Ordering rule
+  above is overridden)
+- PRs with a dependency chain (B rebases on A's merge, C reviews A's
+  design decision) stay sequential
+- In projects whose rules prohibit worktrees, parallel dispatch is
+  unavailable — fall back to sequential single-implementer dispatch
+- Review each PR independently per the section below
 
 ## Review of the subagent's work
 

--- a/claude/rules/implementation-delegation.md
+++ b/claude/rules/implementation-delegation.md
@@ -22,26 +22,28 @@ of implementing in the main session.
 ## Ordering
 
 - Complete branch setup (pull the default branch, create the feature
-  branch) before dispatching; the subagent must not create branches or
-  worktrees
-- Applies to single-implementer dispatch. Multi-PR parallel dispatch
-  follows the next section instead
+  branch — one worktree+branch per implementer when running parallel
+  dispatch) before dispatching; the subagent must not create branches
+  or worktrees
 
 ## Parallel dispatch for multi-PR plans
 
 - When an approved plan decomposes into multiple PRs with no
-  interdependencies (each can be merged independently against the
-  default branch), dispatch one implementer per PR in parallel (send
-  the Agent calls in a single message)
-- Each implementer runs the git-workflow skill end-to-end for its own
-  PR — creating its own worktree and branch. The parent does NOT
-  pre-create branches or worktrees in this mode (the Ordering rule
-  above is overridden)
-- PRs with a dependency chain (B rebases on A's merge, C reviews A's
-  design decision) stay sequential
-- In projects whose rules prohibit worktrees, parallel dispatch is
-  unavailable — fall back to sequential single-implementer dispatch
-- Review each PR independently per the section below
+  interdependencies (no merge-order dependency, no file/section
+  overlap that would conflict when the sibling merges first), run
+  the git-workflow skill once per PR in parallel, each dispatching
+  its own implementer
+- Send the parallel implementer Agent calls in a single message so
+  they execute concurrently
+- Parallel implementers require worktree isolation per the implementer
+  agent's Concurrency rule; in projects that prohibit worktrees, fall
+  back to sequential single-implementer dispatch
+- Dependent PR chains (B rebases on A's merge, C reviews A's design
+  decision) stay sequential
+- The parent still owns push, PR creation, review, and monitor for
+  each PR; the implementer's role is unchanged (implement + local
+  commits in its assigned worktree)
+- Apply the section below once per dispatched implementer
 
 ## Review of the subagent's work
 


### PR DESCRIPTION
## Summary

Add a "Parallel dispatch for multi-PR plans" section to `implementation-delegation.md`. When an approved plan decomposes into independent PRs, run the git-workflow skill once per PR in parallel, each dispatching its own implementer for the implement+commit portion. The parent retains push, PR creation, review, and monitor for each PR — matching the implementer agent's existing constraints (no branches, no push, no PR, no spawning other agents).

The Ordering rule's branch-setup line is extended inline to note the parallel-dispatch variant creates one worktree+branch per implementer, so the single and parallel cases coexist without an override paragraph.

## Motivation

The prior rule was written around a single implementer, so multi-PR plans defaulted to sequential execution even when the PRs were fully independent. Encoding the parallel trigger closes that gap.

## Verification

- Read the updated file end-to-end; the new section slots between Ordering and Review, terminology (implementer / worktree / PR) matches the surrounding rule and the git-workflow skill, and the described behavior is consistent with `claude/agents/implementer.md` Concurrency + Constraints (implementer runs in a parent-owned worktree, does not push or open PRs)
- Local pre-commit `check-rule-budget` (`scripts/check_rule_budget.sh`, not covered by GitHub Actions): passes at 56 / 100 lines for the edited file
