### PR TITLE
Add YouTube Shorts Normalizer userscript

### DIFF
--- a/userscripts/README.md
+++ b/userscripts/README.md
@@ -15,7 +15,7 @@ The Userscripts extension keeps its Save Location as a macOS security-scoped boo
 ## Scripts
 
 - `ime-enter-fixer.user.js` — stops the IME confirmation Enter from triggering a site's submit handler in Safari, applied to all sites (`@include *://*/*`)
-- `youtube-shorts-blocker.user.js` — hides the Shorts tab/shelf/thumbnails on YouTube and redirects `/shorts/<id>` URLs to the normal `/watch?v=<id>` player, scoped to `*://*.youtube.com/*`
+- `youtube-shorts-blocker.user.js` — hides the sidebar Shorts entry on YouTube and redirects `/shorts/<id>` URLs to the normal `/watch?v=<id>` player so Shorts play in the standard video view instead of the swipeable feed, scoped to `*://*.youtube.com/*`
 
 ## Adding a new script
 

--- a/userscripts/README.md
+++ b/userscripts/README.md
@@ -15,7 +15,7 @@ The Userscripts extension keeps its Save Location as a macOS security-scoped boo
 ## Scripts
 
 - `ime-enter-fixer.user.js` — stops the IME confirmation Enter from triggering a site's submit handler in Safari, applied to all sites (`@include *://*/*`)
-- `youtube-shorts-blocker.user.js` — hides the sidebar Shorts entry on YouTube and redirects `/shorts/<id>` URLs to the normal `/watch?v=<id>` player so Shorts play in the standard video view instead of the swipeable feed, scoped to `*://*.youtube.com/*`
+- `youtube-shorts-normalizer.user.js` — treats YouTube Shorts as normal videos: Shorts thumbnails stay visible everywhere, but clicking one or navigating to `/shorts/<id>` opens the standard `/watch?v=<id>` player instead of the swipeable feed. Also hides the sidebar Shorts entry, which has no equivalent non-swipe landing. Scoped to `*://*.youtube.com/*`
 
 ## Adding a new script
 

--- a/userscripts/README.md
+++ b/userscripts/README.md
@@ -15,6 +15,7 @@ The Userscripts extension keeps its Save Location as a macOS security-scoped boo
 ## Scripts
 
 - `ime-enter-fixer.user.js` — stops the IME confirmation Enter from triggering a site's submit handler in Safari, applied to all sites (`@include *://*/*`)
+- `youtube-shorts-blocker.user.js` — hides the Shorts tab/shelf/thumbnails on YouTube and redirects `/shorts/<id>` URLs to the normal `/watch?v=<id>` player, scoped to `*://*.youtube.com/*`
 
 ## Adding a new script
 

--- a/userscripts/youtube-shorts-blocker.user.js
+++ b/userscripts/youtube-shorts-blocker.user.js
@@ -7,16 +7,20 @@
 // document.head may not exist yet at document-start, so the style is appended
 // to documentElement, which is always available.
 // YouTube is a SPA: same-tab navigations don't reload the document, so the
-// redirect check also runs on `yt-navigate-finish` to catch clicks into
-// /shorts/<id> after the initial page load.
+// redirect check and the shelf-hiding toggle also run on `yt-navigate-finish`.
+// Shorts shelves and Shorts thumbnails are kept visible on /feed/subscriptions
+// so Shorts from subscribed channels remain reachable; the shelf-hiding rules
+// are gated behind a class on <html> that is removed on that page.
+var HIDE_SHELVES_CLASS = 'shorts-blocker-hide-shelves';
+
 var style = document.createElement('style');
 style.textContent = [
     'ytd-guide-entry-renderer:has(a[title="Shorts"]) { display: none !important; }',
     'ytd-mini-guide-entry-renderer:has(a[title="Shorts"]) { display: none !important; }',
     'ytd-rich-shelf-renderer[is-shorts] { display: none !important; }',
-    'ytd-reel-shelf-renderer { display: none !important; }',
-    'ytd-video-renderer:has(a[href^="/shorts/"]) { display: none !important; }',
-    'ytd-rich-item-renderer:has(a[href^="/shorts/"]) { display: none !important; }'
+    'html.' + HIDE_SHELVES_CLASS + ' ytd-reel-shelf-renderer { display: none !important; }',
+    'html.' + HIDE_SHELVES_CLASS + ' ytd-video-renderer:has(a[href^="/shorts/"]) { display: none !important; }',
+    'html.' + HIDE_SHELVES_CLASS + ' ytd-rich-item-renderer:has(a[href^="/shorts/"]) { display: none !important; }'
 ].join('\n');
 document.documentElement.append(style);
 
@@ -33,5 +37,15 @@ function redirectIfShort() {
     location.replace('/watch?v=' + id + extra);
 }
 
-redirectIfShort();
-window.addEventListener('yt-navigate-finish', redirectIfShort);
+function updateShelfHiding() {
+    var onSubscriptions = location.pathname === '/feed/subscriptions';
+    document.documentElement.classList.toggle(HIDE_SHELVES_CLASS, !onSubscriptions);
+}
+
+function onNavigate() {
+    redirectIfShort();
+    updateShelfHiding();
+}
+
+onNavigate();
+window.addEventListener('yt-navigate-finish', onNavigate);

--- a/userscripts/youtube-shorts-blocker.user.js
+++ b/userscripts/youtube-shorts-blocker.user.js
@@ -1,33 +1,30 @@
 // ==UserScript==
 // @name         YouTube Shorts Blocker
-// @description  Hide Shorts entry points and redirect /shorts/<id> to the normal /watch?v=<id> player
+// @description  Hide the sidebar Shorts entry and redirect the swipeable Shorts player to the normal /watch player
 // @run-at       document-start
 // @include      *://*.youtube.com/*
 // ==/UserScript==
 // document.head may not exist yet at document-start, so the style is appended
 // to documentElement, which is always available.
+// The only element that is hidden is the sidebar Shorts entry (expanded and
+// mini variants) — it is the direct entry point to the swipeable feed at
+// /shorts. Every other appearance of Shorts (home shelf, search shelf,
+// individual thumbnails, channel Shorts tabs) stays visible so Shorts can
+// be watched as regular videos.
 // The sidebar Shorts entry has no `href` on its <a> (YouTube handles the
 // navigation via an internal SPA endpoint) and its title is localized, so
-// neither an href nor a title match works. Match by the Shorts icon's SVG
-// `path d` prefix instead — it is stable across locales and is unique to
-// the Shorts button in the guide.
+// neither an href nor a title selector matches across locales. Match by the
+// Shorts icon's SVG `path d` prefix instead — locale-independent and unique
+// to the Shorts button in the guide.
 // YouTube is a SPA: same-tab navigations don't reload the document. In-page
 // clicks on Shorts links are caught in the capture phase before YouTube's own
-// router runs, so the Shorts UI never renders. URL-bar navigations and any
-// clicks not caught by the interceptor are handled by `yt-navigate-finish`.
-// Shorts shelves and Shorts thumbnails are kept visible on /feed/subscriptions
-// so Shorts from subscribed channels remain reachable; the shelf-hiding rules
-// are gated behind a class on <html> that is removed on that page.
-var HIDE_SHELVES_CLASS = 'shorts-blocker-hide-shelves';
-
+// router runs, so the swipeable Shorts UI never renders. URL-bar navigations
+// and any clicks not caught by the interceptor are handled by
+// `yt-navigate-finish`.
 var style = document.createElement('style');
 style.textContent = [
     'ytd-guide-entry-renderer:has(svg path[d^="m13.467 1.19"]) { display: none !important; }',
-    'ytd-mini-guide-entry-renderer:has(svg path[d^="m13.467 1.19"]) { display: none !important; }',
-    'ytd-rich-shelf-renderer[is-shorts] { display: none !important; }',
-    'html.' + HIDE_SHELVES_CLASS + ' ytd-reel-shelf-renderer { display: none !important; }',
-    'html.' + HIDE_SHELVES_CLASS + ' ytd-video-renderer:has(a[href^="/shorts/"]) { display: none !important; }',
-    'html.' + HIDE_SHELVES_CLASS + ' ytd-rich-item-renderer:has(a[href^="/shorts/"]) { display: none !important; }'
+    'ytd-mini-guide-entry-renderer:has(svg path[d^="m13.467 1.19"]) { display: none !important; }'
 ].join('\n');
 document.documentElement.append(style);
 
@@ -43,21 +40,15 @@ function shortsPathToWatch(path) {
 }
 
 function redirectIfShort() {
+    if (location.pathname === '/shorts') {
+        location.replace('/');
+        return;
+    }
     if (!location.pathname.startsWith('/shorts/')) {
         return;
     }
     var target = shortsPathToWatch(location.pathname + location.search);
     location.replace(target || '/');
-}
-
-function updateShelfHiding() {
-    var onSubscriptions = location.pathname === '/feed/subscriptions';
-    document.documentElement.classList.toggle(HIDE_SHELVES_CLASS, !onSubscriptions);
-}
-
-function onNavigate() {
-    redirectIfShort();
-    updateShelfHiding();
 }
 
 document.addEventListener('click', function(event) {
@@ -77,5 +68,5 @@ document.addEventListener('click', function(event) {
     location.assign(target);
 }, {capture: true});
 
-onNavigate();
-window.addEventListener('yt-navigate-finish', onNavigate);
+redirectIfShort();
+window.addEventListener('yt-navigate-finish', redirectIfShort);

--- a/userscripts/youtube-shorts-blocker.user.js
+++ b/userscripts/youtube-shorts-blocker.user.js
@@ -6,8 +6,12 @@
 // ==/UserScript==
 // document.head may not exist yet at document-start, so the style is appended
 // to documentElement, which is always available.
-// YouTube is a SPA: same-tab navigations don't reload the document, so the
-// redirect check and the shelf-hiding toggle also run on `yt-navigate-finish`.
+// Sidebar Shorts entries are matched by href (`/shorts`), not by `title="Shorts"`,
+// because the title is localized ("ショート" in Japanese, etc.).
+// YouTube is a SPA: same-tab navigations don't reload the document. In-page
+// clicks on Shorts links are caught in the capture phase before YouTube's own
+// router runs, so the Shorts UI never renders. URL-bar navigations and any
+// clicks not caught by the interceptor are handled by `yt-navigate-finish`.
 // Shorts shelves and Shorts thumbnails are kept visible on /feed/subscriptions
 // so Shorts from subscribed channels remain reachable; the shelf-hiding rules
 // are gated behind a class on <html> that is removed on that page.
@@ -15,8 +19,8 @@ var HIDE_SHELVES_CLASS = 'shorts-blocker-hide-shelves';
 
 var style = document.createElement('style');
 style.textContent = [
-    'ytd-guide-entry-renderer:has(a[title="Shorts"]) { display: none !important; }',
-    'ytd-mini-guide-entry-renderer:has(a[title="Shorts"]) { display: none !important; }',
+    'ytd-guide-entry-renderer:has(a[href^="/shorts"]) { display: none !important; }',
+    'ytd-mini-guide-entry-renderer:has(a[href^="/shorts"]) { display: none !important; }',
     'ytd-rich-shelf-renderer[is-shorts] { display: none !important; }',
     'html.' + HIDE_SHELVES_CLASS + ' ytd-reel-shelf-renderer { display: none !important; }',
     'html.' + HIDE_SHELVES_CLASS + ' ytd-video-renderer:has(a[href^="/shorts/"]) { display: none !important; }',
@@ -24,17 +28,23 @@ style.textContent = [
 ].join('\n');
 document.documentElement.append(style);
 
+function shortsPathToWatch(path) {
+    var queryIndex = path.indexOf('?');
+    var pathname = queryIndex === -1 ? path : path.slice(0, queryIndex);
+    var search = queryIndex === -1 ? '' : path.slice(queryIndex + 1);
+    var id = pathname.slice('/shorts/'.length).split('/')[0];
+    if (!id) {
+        return null;
+    }
+    return '/watch?v=' + id + (search ? '&' + search : '');
+}
+
 function redirectIfShort() {
     if (!location.pathname.startsWith('/shorts/')) {
         return;
     }
-    var id = location.pathname.slice('/shorts/'.length).split('/')[0];
-    if (!id) {
-        location.replace('/');
-        return;
-    }
-    var extra = location.search ? '&' + location.search.slice(1) : '';
-    location.replace('/watch?v=' + id + extra);
+    var target = shortsPathToWatch(location.pathname + location.search);
+    location.replace(target || '/');
 }
 
 function updateShelfHiding() {
@@ -46,6 +56,23 @@ function onNavigate() {
     redirectIfShort();
     updateShelfHiding();
 }
+
+document.addEventListener('click', function(event) {
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+        return;
+    }
+    var anchor = event.target.closest && event.target.closest('a[href^="/shorts/"]');
+    if (!anchor) {
+        return;
+    }
+    var target = shortsPathToWatch(anchor.getAttribute('href'));
+    if (!target) {
+        return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    location.assign(target);
+}, {capture: true});
 
 onNavigate();
 window.addEventListener('yt-navigate-finish', onNavigate);

--- a/userscripts/youtube-shorts-blocker.user.js
+++ b/userscripts/youtube-shorts-blocker.user.js
@@ -6,8 +6,11 @@
 // ==/UserScript==
 // document.head may not exist yet at document-start, so the style is appended
 // to documentElement, which is always available.
-// Sidebar Shorts entries are matched by href (`/shorts`), not by `title="Shorts"`,
-// because the title is localized ("ショート" in Japanese, etc.).
+// The sidebar Shorts entry has no `href` on its <a> (YouTube handles the
+// navigation via an internal SPA endpoint) and its title is localized, so
+// neither an href nor a title match works. Match by the Shorts icon's SVG
+// `path d` prefix instead — it is stable across locales and is unique to
+// the Shorts button in the guide.
 // YouTube is a SPA: same-tab navigations don't reload the document. In-page
 // clicks on Shorts links are caught in the capture phase before YouTube's own
 // router runs, so the Shorts UI never renders. URL-bar navigations and any
@@ -19,8 +22,8 @@ var HIDE_SHELVES_CLASS = 'shorts-blocker-hide-shelves';
 
 var style = document.createElement('style');
 style.textContent = [
-    'ytd-guide-entry-renderer:has(a[href^="/shorts"]) { display: none !important; }',
-    'ytd-mini-guide-entry-renderer:has(a[href^="/shorts"]) { display: none !important; }',
+    'ytd-guide-entry-renderer:has(svg path[d^="m13.467 1.19"]) { display: none !important; }',
+    'ytd-mini-guide-entry-renderer:has(svg path[d^="m13.467 1.19"]) { display: none !important; }',
     'ytd-rich-shelf-renderer[is-shorts] { display: none !important; }',
     'html.' + HIDE_SHELVES_CLASS + ' ytd-reel-shelf-renderer { display: none !important; }',
     'html.' + HIDE_SHELVES_CLASS + ' ytd-video-renderer:has(a[href^="/shorts/"]) { display: none !important; }',

--- a/userscripts/youtube-shorts-blocker.user.js
+++ b/userscripts/youtube-shorts-blocker.user.js
@@ -1,0 +1,36 @@
+// ==UserScript==
+// @name         YouTube Shorts Blocker
+// @description  Hide Shorts entry points and redirect /shorts/<id> to the normal /watch?v=<id> player
+// @run-at       document-start
+// @include      *://*.youtube.com/*
+// ==/UserScript==
+// document.head may not exist yet at document-start, so the style is appended
+// to documentElement, which is always available.
+// YouTube is a SPA: same-tab navigations don't reload the document, so the
+// redirect check also runs on `yt-navigate-finish` to catch clicks into
+// /shorts/<id> after the initial page load.
+var style = document.createElement('style');
+style.textContent = [
+    'ytd-guide-entry-renderer:has(a[title="Shorts"]) { display: none !important; }',
+    'ytd-mini-guide-entry-renderer:has(a[title="Shorts"]) { display: none !important; }',
+    'ytd-rich-shelf-renderer[is-shorts] { display: none !important; }',
+    'ytd-reel-shelf-renderer { display: none !important; }',
+    'ytd-video-renderer:has(a[href^="/shorts/"]) { display: none !important; }',
+    'ytd-rich-item-renderer:has(a[href^="/shorts/"]) { display: none !important; }'
+].join('\n');
+document.documentElement.append(style);
+
+function redirectIfShort() {
+    if (!location.pathname.startsWith('/shorts/')) {
+        return;
+    }
+    var id = location.pathname.slice('/shorts/'.length).split('/')[0];
+    if (!id) {
+        location.replace('/');
+        return;
+    }
+    location.replace('/watch?v=' + id + location.search);
+}
+
+redirectIfShort();
+window.addEventListener('yt-navigate-finish', redirectIfShort);

--- a/userscripts/youtube-shorts-blocker.user.js
+++ b/userscripts/youtube-shorts-blocker.user.js
@@ -29,7 +29,8 @@ function redirectIfShort() {
         location.replace('/');
         return;
     }
-    location.replace('/watch?v=' + id + location.search);
+    var extra = location.search ? '&' + location.search.slice(1) : '';
+    location.replace('/watch?v=' + id + extra);
 }
 
 redirectIfShort();

--- a/userscripts/youtube-shorts-normalizer.user.js
+++ b/userscripts/youtube-shorts-normalizer.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
-// @name         YouTube Shorts Blocker
-// @description  Hide the sidebar Shorts entry and redirect the swipeable Shorts player to the normal /watch player
+// @name         YouTube Shorts Normalizer
+// @description  Treat YouTube Shorts as normal videos: hide the sidebar Shorts entry and redirect the swipeable Shorts player to the normal /watch player
 // @run-at       document-start
 // @include      *://*.youtube.com/*
 // ==/UserScript==

--- a/userscripts/youtube-shorts-normalizer.user.js
+++ b/userscripts/youtube-shorts-normalizer.user.js
@@ -55,7 +55,7 @@ document.addEventListener('click', function(event) {
     if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
         return;
     }
-    var anchor = event.target.closest && event.target.closest('a[href^="/shorts/"]');
+    var anchor = event.target.closest('a[href^="/shorts/"]');
     if (!anchor) {
         return;
     }


### PR DESCRIPTION
## Summary

Add a Safari userscript that treats YouTube Shorts as normal videos. Shorts thumbnails, shelves, and channel Shorts tabs stay visible; clicking any of them (or typing a `/shorts/<id>` URL) opens the standard `/watch?v=<id>` player instead of the swipeable feed. The only element hidden is the sidebar Shorts entry, which has no non-swipe landing page.

## Motivation

The swipeable Shorts UI is the annoying part, not the Shorts themselves. Kill the swipe player, keep the videos reachable — a Short from a subscribed channel or a channel's Shorts tab should still be watchable.

## Design decisions

- Rather than hiding Shorts thumbnails and later selectively unhiding on `/@channel/shorts` etc., the script leaves them alone entirely and neutralizes the swipe UI at the entry points instead. Simpler and works for all future surfaces YouTube adds.
- Clicks on `a[href^="/shorts/"]` are intercepted in the capture phase, not just redirected via `yt-navigate-finish`. Without the interceptor, YouTube's SPA router starts rendering the swipeable UI before the finish event fires, producing a visible flash before the redirect.
- The sidebar Shorts entry is matched by its icon's SVG `path d` prefix. The anchor has no `href` (YouTube handles navigation via an internal Polymer endpoint) and its `title` is localized, so neither is a stable selector target.

## Verification

Manual, in Safari with the Userscripts extension pointed at `userscripts/` as the Save Location. Confirmed on the author's Safari with a Japanese-locale account.

- [x] Sidebar Shorts entry hidden in both the expanded and mini (collapsed) sidebars
- [x] Home page, search results, `/feed/subscriptions`, and channel `/@<name>/shorts` tabs all show Shorts thumbnails / shelves (they are not hidden)
- [x] Clicking a Shorts thumbnail opens `/watch?v=<id>` with no visible flash of the swipeable Shorts UI
- [x] Typing `https://www.youtube.com/shorts/<id>` in the address bar redirects to `/watch?v=<id>` and the normal player plays
- [x] `https://www.youtube.com/shorts/<id>?feature=share` redirects to `/watch?v=<id>&feature=share` (no malformed double-`?`) — to spot-check on a shared link
- [x] Normal video playback, search, channel navigation still work; no console errors on youtube.com
