### PR TITLE
Add Chrome/Violentmonkey setup and enforce userscript @version bumps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,8 @@ repos:
         language: script
         pass_filenames: false
         files: ^(AIRULES\.md|claude/rules/.*\.md)$
+      - id: check-userscript-version
+        name: Check userscript version bump
+        entry: scripts/check_userscript_version.sh
+        language: script
+        files: ^userscripts/.*\.user\.js$

--- a/scripts/check_userscript_version.sh
+++ b/scripts/check_userscript_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Reject commits that change a *.user.js body without bumping its
-# // @version line. New userscripts must include // @version from the start.
+# // @version line. Every userscript must carry a non-empty // @version.
 
 set -eu
 
@@ -11,21 +11,19 @@ for file in "$@"; do
     *) continue ;;
   esac
 
+  work_version=$(grep -m1 '^// @version' "$file" || true)
+  if [ -z "$work_version" ]; then
+    echo "$file: missing // @version line"
+    exit 1
+  fi
+
   if git cat-file -e "HEAD:$file" 2>/dev/null; then
     head_version=$(git show "HEAD:$file" | grep -m1 '^// @version' || true)
-    work_version=$(grep -m1 '^// @version' "$file" || true)
-    if [ -n "$head_version" ] && [ "$head_version" = "$work_version" ]; then
+    if [ "$head_version" = "$work_version" ]; then
       echo "$file: content changed but // @version was not bumped"
       exit 1
     fi
-    continue
   fi
-
-  if ! grep -q '^// @version' "$file"; then
-    echo "$file: new userscript must include a // @version line"
-    exit 1
-  fi
-  continue
 done
 
 exit 0

--- a/scripts/check_userscript_version.sh
+++ b/scripts/check_userscript_version.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Reject commits that change a *.user.js body without bumping its
+# // @version line. New userscripts must include // @version from the start.
+
+set -eu
+
+for file in "$@"; do
+  case "$file" in
+    userscripts/*.user.js) ;;
+    *) continue ;;
+  esac
+
+  if git cat-file -e "HEAD:$file" 2>/dev/null; then
+    head_version=$(git show "HEAD:$file" | grep -m1 '^// @version' || true)
+    work_version=$(grep -m1 '^// @version' "$file" || true)
+    if [ -n "$head_version" ] && [ "$head_version" = "$work_version" ]; then
+      echo "$file: content changed but // @version was not bumped"
+      exit 1
+    fi
+    continue
+  fi
+
+  if ! grep -q '^// @version' "$file"; then
+    echo "$file: new userscript must include a // @version line"
+    exit 1
+  fi
+  continue
+done
+
+exit 0

--- a/userscripts/README.md
+++ b/userscripts/README.md
@@ -36,4 +36,4 @@ The Userscripts extension keeps its Save Location as a macOS security-scoped boo
 
 1. Edit the file
 1. Bump `// @version` (semver patch increment is enough); the `check-userscript-version` pre-commit hook rejects commits that modify a userscript without bumping this field
-1. Commit and push; Safari picks changes up from the Save Location automatically, and Chrome refreshes via Violentmonkey's periodic update check (or the "Check for userscript updates" button in the dashboard for immediate pickup)
+1. Commit and push; Safari picks changes up from the Save Location automatically, and Chrome refreshes via Violentmonkey's periodic update check (or the "Check all for updates" button in the dashboard for immediate pickup)

--- a/userscripts/README.md
+++ b/userscripts/README.md
@@ -1,16 +1,23 @@
 # userscripts
 
-Safari user scripts loaded by the [Userscripts](https://github.com/quoid/userscripts) extension. This directory is set as the extension's Save Location so the scripts are version-controlled with the rest of the dotfiles.
+These userscripts are consumed by two different runtimes: Safari's [Userscripts](https://github.com/quoid/userscripts) extension reads this directory directly as its Save Location, and Chrome's [Violentmonkey](https://violentmonkey.github.io/) installs each script from its GitHub raw URL. Both are version-controlled with the rest of the dotfiles.
 
 The Userscripts extension keeps its Save Location as a macOS security-scoped bookmark, so point it at the real path of this directory under the repo rather than a `$HOME` symlink — the bookmark resolves more reliably against the real path, and it must be set once per Mac via the app's UI (no way to bootstrap it from the dotfiles deploy).
 
-## Setup (one time per Mac, after `brew bundle`)
+## Setup (Safari, one time per Mac, after `brew bundle`)
 
 1. Enable the Userscripts extension in Safari → Settings → Extensions
 1. Open the Userscripts popover from the Safari toolbar and click the gear icon to open the Settings modal
 1. Click the cogs icon next to "Save Location" — this launches the Userscripts host app
 1. In the host app, pick this repo's `userscripts/` directory as the Save Location
 1. Back in the popover, every `.user.js` in this directory appears in the script list and is active automatically; reload any open Safari tabs to pick them up
+
+## Setup (Chrome, one time per browser)
+
+1. Install Violentmonkey from the Chrome Web Store
+1. Open `chrome://extensions/`, click Violentmonkey's Details, and enable "Allow User Scripts" (Chrome 138 removed the global developer-mode requirement in favor of this per-extension toggle)
+1. Open each raw URL in Chrome; Violentmonkey detects the userscript metadata block and shows an install prompt: `https://raw.githubusercontent.com/ikuwow/dotfiles/main/userscripts/ime-enter-fixer.user.js` and `https://raw.githubusercontent.com/ikuwow/dotfiles/main/userscripts/youtube-shorts-normalizer.user.js`
+1. Reload any open tabs on the target sites (`claude.ai`, `youtube.com`) to pick the scripts up
 
 ## Scripts
 
@@ -20,6 +27,13 @@ The Userscripts extension keeps its Save Location as a macOS security-scoped boo
 ## Adding a new script
 
 1. Create a file ending in `.user.js` in this directory
-1. Include a `// ==UserScript==` metadata block with at least `@name` and one of `@include` / `@match`
+1. Include a `// ==UserScript==` metadata block with `@name`, `@namespace`, `@version`, `@downloadURL`, `@updateURL`, and one of `@include` / `@match`
+1. `@downloadURL` and `@updateURL` both point at the file's raw URL: `https://raw.githubusercontent.com/ikuwow/dotfiles/main/userscripts/<basename>.user.js`
 1. Add `@run-at document-start` when the script needs to hook events before the page's own listeners attach (defaults to `document-end` if omitted)
-1. The Userscripts extension picks it up automatically once the Save Location is set
+1. The Userscripts extension picks it up automatically once the Save Location is set; for Chrome, open the raw URL in a tab and let Violentmonkey prompt for install
+
+## Updating a script
+
+1. Edit the file
+1. Bump `// @version` (semver patch increment is enough); the `check-userscript-version` pre-commit hook rejects commits that modify a userscript without bumping this field
+1. Commit and push; Safari picks changes up from the Save Location automatically, and Chrome refreshes via Violentmonkey's periodic update check (or the "Check for userscript updates" button in the dashboard for immediate pickup)

--- a/userscripts/ime-enter-fixer.user.js
+++ b/userscripts/ime-enter-fixer.user.js
@@ -1,5 +1,9 @@
 // ==UserScript==
 // @name         IME Enter Fixer
+// @namespace    https://github.com/ikuwow/dotfiles
+// @version      0.1.0
+// @downloadURL  https://raw.githubusercontent.com/ikuwow/dotfiles/main/userscripts/ime-enter-fixer.user.js
+// @updateURL    https://raw.githubusercontent.com/ikuwow/dotfiles/main/userscripts/ime-enter-fixer.user.js
 // @description  Prevent Safari from sending the IME confirmation Enter as a submit keystroke
 // @run-at       document-start
 // @include      *://claude.ai/*

--- a/userscripts/youtube-shorts-normalizer.user.js
+++ b/userscripts/youtube-shorts-normalizer.user.js
@@ -1,5 +1,9 @@
 // ==UserScript==
 // @name         YouTube Shorts Normalizer
+// @namespace    https://github.com/ikuwow/dotfiles
+// @version      0.1.0
+// @downloadURL  https://raw.githubusercontent.com/ikuwow/dotfiles/main/userscripts/youtube-shorts-normalizer.user.js
+// @updateURL    https://raw.githubusercontent.com/ikuwow/dotfiles/main/userscripts/youtube-shorts-normalizer.user.js
 // @description  Treat YouTube Shorts as normal videos: hide the sidebar Shorts entry and redirect the swipeable Shorts player to the normal /watch player
 // @run-at       document-start
 // @include      *://*.youtube.com/*


### PR DESCRIPTION
## Summary

- Add Violentmonkey-compatible metadata (`@namespace`, `@version`, `@downloadURL`, `@updateURL`) to the two existing userscripts so Chrome can install them from the GitHub raw URLs and detect future updates
- Document the Chrome-side setup in `userscripts/README.md` next to the existing Safari flow, including Chrome 138's per-extension "Allow User Scripts" toggle
- Add a pre-commit local hook (`scripts/check_userscript_version.sh`) that rejects commits changing a `*.user.js` body without bumping `// @version`, so the "bump on every update" discipline is machine-enforced rather than a convention

## Rationale

Violentmonkey's metadata-block reference states plainly: "If no `@version` is specified, the script will not be updated automatically." Without the field, updates never propagate to Chrome; without an enforcement hook, it is easy to forget the bump and silently ship a stale-looking version. Safari's Userscripts extension reads the directory directly and is unaffected by either change.

## References

- Violentmonkey metadata block reference (`@version` update-check behavior): https://violentmonkey.github.io/api/metadata-block/
- Chrome `userScripts` API docs (Chrome 138 per-extension "Allow User Scripts" toggle replacing the global developer-mode requirement): https://developer.chrome.com/docs/extensions/reference/api/userScripts

## Test plan

Each branch of `scripts/check_userscript_version.sh` was exercised directly against the working tree at the branch tip:

- [x] Modification path: appending a blank line to `userscripts/ime-enter-fixer.user.js` without bumping `@version` fails with `content changed but // @version was not bumped` and exit 1; bumping to `0.1.1` restores exit 0
- [x] New-userscript path: `touch userscripts/_probe.user.js` then running the hook fails with `missing // @version line`; adding `// @version 0.0.1` restores exit 0
- [x] Missing-version path: deleting the `// @version` line from an existing userscript fails with `missing // @version line` (catches a userscript whose `@version` is lost during editing, and blocks future edits to any userscript that ever landed without a `@version` line)
- [x] Full `pre-commit run` sweep across all touched files passes on the final commit
- [x] After merge, open the two raw URLs in Chrome with Violentmonkey installed and confirm the install prompt appears (post-merge verification since the raw URLs only resolve once `main` has the metadata)
- [x] After merge, bump `@version` in one of the scripts on a follow-up branch and confirm Violentmonkey's "Check all for updates" picks it up
