### PR TITLE
Add opus tier and delegation economy to subagent-model rule

### DIFF
--- a/claude/rules/subagent-model.md
+++ b/claude/rules/subagent-model.md
@@ -12,12 +12,12 @@ For general-purpose subagents:
 |---|---|
 | Search, file reading, data gathering, formatting | `"sonnet"` |
 | Writing code for well-defined, straightforward tasks | `"sonnet"` |
-| Multi-file implementation, non-trivial investigation | `"opus"` |
-| Hardest delegated reasoning (deep debugging, adversarial review) | omit (inherit the session model) |
+| Multi-file implementation, non-trivial investigation, deep debugging, adversarial review | `"opus"` |
 
-Omit the model parameter only when lower tiers demonstrably fall
-short (inheriting spends the session model, typically the most
-expensive tier).
+Run a subagent on `"fable"` — including by omitting `model` under a
+Fable session — only on explicit user instruction; agents and skills
+that pin `fable` in their own definition (e.g. fable-advisor) are
+exempt.
 
 ## Delegation economy
 

--- a/claude/rules/subagent-model.md
+++ b/claude/rules/subagent-model.md
@@ -13,18 +13,18 @@ For general-purpose subagents:
 | Search, file reading, data gathering, formatting | `"sonnet"` |
 | Writing code for well-defined, straightforward tasks | `"sonnet"` |
 | Multi-file implementation, non-trivial investigation | `"opus"` |
-| Architecture decisions, deep debugging, final review | omit (inherit the session model) |
+| Hardest delegated reasoning (deep debugging, adversarial review) | omit (inherit the session model) |
 
-Inheriting the session model is a deliberate spend decision — the
-session model is typically the most expensive tier. Reserve it for
-work where lower tiers demonstrably fall short.
+Omit the model parameter only when lower tiers demonstrably fall
+short (inheriting spends the session model, typically the most
+expensive tier).
 
 ## Delegation economy
 
-- Delegate independent, fan-out-able subtasks (multi-file reads,
-  parallel investigations, independent implementations) to subagents
-  instead of running them inline; keep the main session for
-  orchestration, design decisions, and final review
+- Delegate independent, fan-out-able subtasks to subagents instead of
+  running them inline
+- Keep the main session for orchestration, design decisions, and
+  final review
 - Write delegation briefs goal-first: state the outcome and
   constraints, not step-by-step procedures
 

--- a/claude/rules/subagent-model.md
+++ b/claude/rules/subagent-model.md
@@ -14,8 +14,9 @@ For general-purpose subagents:
 | Writing code for well-defined, straightforward tasks | `"sonnet"` |
 | Multi-file implementation, non-trivial investigation, deep debugging, adversarial review | `"opus"` |
 
-Run a subagent on `"fable"` — including by omitting `model` under a
-Fable session — only on explicit user instruction; agents and skills
+Omitting `model` inherits the session model, whatever it currently
+is. Run a subagent on `"fable"` — whether by explicit `model` or by
+inheritance — only on explicit user instruction; agents and skills
 that pin `fable` in their own definition (e.g. fable-advisor) are
 exempt.
 

--- a/claude/rules/subagent-model.md
+++ b/claude/rules/subagent-model.md
@@ -4,7 +4,7 @@ When spawning subagents via the Agent tool, select the model based
 on task complexity to balance cost and capability.
 
 Built-in subagent types have their own defaults — do not override
-them (Explore defaults to Haiku; Plan inherits the session model).
+them.
 
 For general-purpose subagents:
 
@@ -12,7 +12,21 @@ For general-purpose subagents:
 |---|---|
 | Search, file reading, data gathering, formatting | `"sonnet"` |
 | Writing code for well-defined, straightforward tasks | `"sonnet"` |
-| Architecture decisions, complex reasoning, large-scale code generation | omit (inherit the session model) |
+| Multi-file implementation, non-trivial investigation | `"opus"` |
+| Architecture decisions, deep debugging, final review | omit (inherit the session model) |
+
+Inheriting the session model is a deliberate spend decision — the
+session model is typically the most expensive tier. Reserve it for
+work where lower tiers demonstrably fall short.
+
+## Delegation economy
+
+- Delegate independent, fan-out-able subtasks (multi-file reads,
+  parallel investigations, independent implementations) to subagents
+  instead of running them inline; keep the main session for
+  orchestration, design decisions, and final review
+- Write delegation briefs goal-first: state the outcome and
+  constraints, not step-by-step procedures
 
 Do not set the `CLAUDE_CODE_SUBAGENT_MODEL` env var (it overrides
 per-invocation model parameters). Skills define their own model in


### PR DESCRIPTION
## Why

The session model is now the most expensive tier (Claude Fable 5). Under the previous two-tier table ("sonnet" or omit-and-inherit), every moderately complex subagent task defaulted to inheriting the session model, which now consumes the costliest usage — and an implicit inherit multiplies across parallel fan-outs. Official Fable guidance also recommends providing explicit guidance about when delegation is appropriate and writing delegation briefs goal-first.

## What

- Add an intermediate `"opus"` tier covering multi-file implementation, non-trivial investigation, deep debugging, and adversarial review
- State the omission semantics model-agnostically (omitting `model` inherits whatever the session model currently is) and add a guard: a subagent runs on `"fable"` — by explicit `model` or by inheritance — only when the user asks for it; agents and skills that pin `fable` in their own definition (e.g. fable-advisor) are exempt
- Add a "Delegation economy" section: delegate independent fan-out-able subtasks instead of running them inline, keep the main session for orchestration / design decisions / final review, and write delegation briefs goal-first
- Drop the "(Explore defaults to Haiku; Plan inherits the session model)" parenthetical: it drifted from measured behavior — in a session on 2026-07-18 the Explore agent ran on `claude-opus-4-8` (single observation, measured via the session's `subagents/*.jsonl` `.message.model`). The instruction itself ("do not override built-in defaults") remains

## Policy-loss check

Per the AIRULES rule-editing policy, every sentence of the previous version was cross-checked against the revision:

| Previous | Revision |
| --- | --- |
| Select model by task complexity (intro) | Kept verbatim |
| Built-in defaults — do not override | Kept; drifted parenthetical removed (see above) |
| Search/reading/formatting → sonnet | Kept verbatim |
| Straightforward code → sonnet | Kept verbatim |
| Architecture / complex reasoning / large-scale codegen → omit | Re-tiered: these now map to the opus tier, and fable escalation requires explicit user instruction (intended change) |
| Do not set CLAUDE_CODE_SUBAGENT_MODEL; skills use frontmatter | Kept verbatim |

## Sources

- [Prompting Claude Fable 5](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5) — "Parallel subagents": use subagents frequently with explicit guidance on when delegation is appropriate; "Recommended scaffolding changes": prior-model prompts are often too prescriptive, prefer stating the goal over enumerating steps

## Verification

- [x] `pre-commit run --files claude/rules/subagent-model.md` — all applicable hooks passed: Trim Trailing Whitespace / Fix End of Files / Check for added large files / Enforce line-count budget on always-loaded AI rule files all report Passed; JSON, YAML, symlink, deploy-verify, and userscript hooks Skipped (no files to check)
- [x] Diff review against the approved plan is recorded as the Policy-loss check table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxxdLvcFJSCbG4YRUSTsWx
