### PR TITLE
Add claude-subagent-models script

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -7,6 +7,7 @@ Custom executable scripts deployed to `~/bin/` via symlinks.
 | Script | Description |
 | --- | --- |
 | `aws-mfa` | Automate AWS session token acquisition via MFA |
+| `claude-subagent-models` | Show which model each Claude Code subagent ran on, from session transcripts |
 | `install-aimsg-hook.sh` | Symlink `~/.config/git/hooks/prepare-commit-msg` into the current repo's `.git/hooks/` to enable the AI commit-message drafter |
 | `git-cleanup-branches` | Delete unused local branches (merged, squash-merged, upstream gone) and prune stale worktree entries |
 | `git-worktree-create` | Create a git worktree under `.worktrees/`. Defaults to branching from `origin/<default>`; pass a second argument to override the base |

--- a/bin/claude-subagent-models
+++ b/bin/claude-subagent-models
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Show which model each Claude Code subagent (Agent tool task) actually ran
+# on for a given session, since Claude Code itself does not surface this.
+# Ground truth lives in the session transcript directory's subagents/:
+# agent-<id>.jsonl (assistant messages carry .message.model and
+# .message.usage.output_tokens) and agent-<id>.meta.json (agentType,
+# description).
+#
+# Usage: claude-subagent-models [session-id]
+
+set -eu
+
+usage() {
+  echo "Usage: claude-subagent-models [session-id]" >&2
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ $# -gt 1 ]; then
+  usage
+  exit 1
+fi
+
+project_slug="$(echo "$PWD" | tr '/.' '-')"
+project_dir="$HOME/.claude/projects/$project_slug"
+
+if [ ! -d "$project_dir" ]; then
+  echo "claude-subagent-models: no project directory found at $project_dir" >&2
+  exit 1
+fi
+
+if [ $# -eq 1 ]; then
+  session_id="$1"
+else
+  session_id=""
+  latest_mtime=0
+  for dir in "$project_dir"/*/; do
+    [ -d "${dir}subagents" ] || continue
+    mtime="$(stat -c '%Y' "${dir}subagents")"
+    if [ "$mtime" -gt "$latest_mtime" ]; then
+      latest_mtime="$mtime"
+      session_id="$(basename "$dir")"
+    fi
+  done
+  if [ -z "$session_id" ]; then
+    echo "no sessions with subagents found"
+    exit 0
+  fi
+fi
+
+subagents_dir="$project_dir/$session_id/subagents"
+
+if [ ! -d "$subagents_dir" ]; then
+  echo "claude-subagent-models: no subagents directory found at $subagents_dir" >&2
+  exit 1
+fi
+
+echo "$session_id"
+
+{
+  printf 'AGENT_ID\tTYPE\tMODEL\tOUT_TOKENS\tDESCRIPTION\n'
+  for jsonl in "$subagents_dir"/agent-*.jsonl; do
+    [ -e "$jsonl" ] || continue
+    base="$(basename "$jsonl" .jsonl)"
+    agent_id="${base#agent-}"
+    meta="$subagents_dir/$base.meta.json"
+
+    agent_type="-"
+    description="-"
+    if [ -f "$meta" ]; then
+      agent_type="$(jq -r '.agentType // "-"' "$meta")"
+      description="$(jq -r '.description // "-"' "$meta")"
+    fi
+
+    models="$(jq -rs '[.[] | select(.type=="assistant") | .message.model] | unique | if length == 0 then "-" else join(",") end' "$jsonl")"
+    out_tokens="$(jq -rs '[.[] | select(.type=="assistant") | (.message.usage.output_tokens // 0)] | add // 0' "$jsonl")"
+
+    printf '%s\t%s\t%s\t%s\t%s\n' "$agent_id" "$agent_type" "$models" "$out_tokens" "$description"
+  done
+} | column -t -s "$(printf '\t')"

--- a/bin/claude-subagent-models
+++ b/bin/claude-subagent-models
@@ -25,7 +25,9 @@ if [ $# -gt 1 ]; then
   exit 1
 fi
 
-project_slug="$(echo "$PWD" | tr '/.' '-')"
+# Claude Code names project dirs by replacing every non-alphanumeric
+# character with "-" (verified against the claude binary, v2.1.212).
+project_slug="${PWD//[^a-zA-Z0-9]/-}"
 project_dir="$HOME/.claude/projects/$project_slug"
 
 if [ ! -d "$project_dir" ]; then
@@ -40,11 +42,16 @@ else
   latest_mtime=0
   for dir in "$project_dir"/*/; do
     [ -d "${dir}subagents" ] || continue
-    mtime="$(stat -c '%Y' "${dir}subagents")"
-    if [ "$mtime" -gt "$latest_mtime" ]; then
-      latest_mtime="$mtime"
-      session_id="$(basename "$dir")"
-    fi
+    # Directory mtime only tracks file creation; appends to existing
+    # jsonl files don't bump it, so key on the newest jsonl instead.
+    for jsonl in "${dir}subagents"/agent-*.jsonl; do
+      [ -e "$jsonl" ] || continue
+      mtime="$(stat -c '%Y' "$jsonl")"
+      if [ "$mtime" -gt "$latest_mtime" ]; then
+        latest_mtime="$mtime"
+        session_id="$(basename "$dir")"
+      fi
+    done
   done
   if [ -z "$session_id" ]; then
     echo "no sessions with subagents found"
@@ -76,8 +83,12 @@ echo "$session_id"
       description="$(jq -r '.description // "-"' "$meta")"
     fi
 
-    models="$(jq -rs '[.[] | select(.type=="assistant") | .message.model] | unique | if length == 0 then "-" else join(",") end' "$jsonl")"
-    out_tokens="$(jq -rs '[.[] | select(.type=="assistant") | (.message.usage.output_tokens // 0)] | add // 0' "$jsonl")"
+    models="$(jq -rs '[.[] | select(.type=="assistant") | (.message.model // empty)] | unique | if length == 0 then "-" else join(",") end' "$jsonl")"
+    # One API message spans multiple jsonl lines (one per content block),
+    # each carrying an in-progress usage snapshot that resets per message
+    # — dedupe by message id and take the final (max) snapshot so partial
+    # snapshots aren't double-counted.
+    out_tokens="$(jq -rs '[.[] | select(.type=="assistant")] | group_by(.message.id) | map([.[].message.usage.output_tokens // 0] | max) | add // 0' "$jsonl")"
 
     printf '%s\t%s\t%s\t%s\t%s\n' "$agent_id" "$agent_type" "$models" "$out_tokens" "$description"
   done


### PR DESCRIPTION
## Why

Claude Code does not display which model a subagent (Agent tool task) actually ran on, so there is no quick way to see whether a delegated task consumed sonnet, opus, or the top tier. The ground truth exists in the session transcript directory (`~/.claude/projects/<project>/<session-id>/subagents/`): `agent-*.jsonl` assistant messages carry `.message.model` and `.message.usage.output_tokens`, and `agent-*.meta.json` carries `agentType` and `description`. This complements #302, which tiers subagent model selection — this script is how to audit that the tiering actually holds.

## What

- Add `bin/claude-subagent-models`: prints one aligned row per subagent — agent id, type, distinct model(s), summed output tokens, description — for the given session id, or for the most recently active session with subagents when no argument is given
- Add the script's row to the `bin/README.md` table
- `scripts/deploy.sh` needs no change: it auto-discovers 0755 files under `bin/`

## Verification

- [x] Ran in this repo with an explicit session id and with no argument (after the review-fix commit): both printed the expected table, including known rows `claude-code-guide` on `claude-haiku-4-5-20251001` and `Explore` on `claude-opus-4-8` (values cross-checked by reading the jsonl directly with `jq`)
- [x] Token dedupe verified against a transcript with duplicate message ids: naive per-line sum 7558 vs deduped 7482 on `agent-a7f61d07724c684c3.jsonl`, matching per-message final snapshots summed by hand
- [x] `--help` prints usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxxdLvcFJSCbG4YRUSTsWx
