### PR TITLE
Exclude external mutations from plan-approval scope

### DIFF
--- a/AIRULES.md
+++ b/AIRULES.md
@@ -26,7 +26,7 @@
   - user 側で手動実行が必要な操作 (外部ツール auth、cloud profile 選択、sudo 等の権限昇格、手動 shell コマンド実行)
   - user への回答を待つ確認提示 (A/B 選択の丸投げ、方針レビュー要求)
 - 承認待ちで stop するのは以下の場合のみ
-  - unrecoverable / 外部影響のある副作用 (delete、publish、external mutation、send message 等)。plan 承認や進行指示は、対象と操作がそこに明記されていた場合を除きこれらの個別承認を含まない。上の cat 1 destructive で他に代替パスが無い場合もこの stop に落ちる
+  - unrecoverable / 外部影響のある副作用 (delete、publish、external mutation、send message 等)。上の cat 1 destructive で他に代替パスが無い場合もこの stop に落ちる。plan 承認・進行指示がこれらを個別承認するのは、対象と操作がそこに明記されている場合と、起動済み workflow/skill の手順として pre-authorize されている場合のみ (例: issue body 編集の承認は comment 投稿の承認を含まない)
   - スコープが元の task から広がる
   - 評価／依頼の区別が本質的に曖昧
 - 承認待ちのsafety mechanism（hook拒否、permission denial、classifier拒否等）に一度止められたら、別経路（alias回避、別コマンド、別フラグ等）で同じ行為を再試行しない。denyを最終判断として受け止め、行為だけでなく方針自体も再検討する

--- a/AIRULES.md
+++ b/AIRULES.md
@@ -26,7 +26,7 @@
   - user 側で手動実行が必要な操作 (外部ツール auth、cloud profile 選択、sudo 等の権限昇格、手動 shell コマンド実行)
   - user への回答を待つ確認提示 (A/B 選択の丸投げ、方針レビュー要求)
 - 承認待ちで stop するのは以下の場合のみ
-  - unrecoverable / 外部影響のある副作用 (delete、publish、external mutation、send message 等)。上の cat 1 destructive で他に代替パスが無い場合もこの stop に落ちる
+  - unrecoverable / 外部影響のある副作用 (delete、publish、external mutation、send message 等)。plan 承認や進行指示は、対象と操作がそこに明記されていた場合を除きこれらの個別承認を含まない。上の cat 1 destructive で他に代替パスが無い場合もこの stop に落ちる
   - スコープが元の task から広がる
   - 評価／依頼の区別が本質的に曖昧
 - 承認待ちのsafety mechanism（hook拒否、permission denial、classifier拒否等）に一度止められたら、別経路（alias回避、別コマンド、別フラグ等）で同じ行為を再試行しない。denyを最終判断として受け止め、行為だけでなく方針自体も再検討する


### PR DESCRIPTION
## Summary

Integrates an approval-scope boundary into the wait-for-approval stop condition in AIRULES.md 応答の姿勢と判断: plan approval or a progression instruction covers an individual external mutation (comment posting, issue creation, message sending) only when the operation and its target are named in the plan, or when the operation is a pre-authorized step of an invoked workflow/skill.

Scope: global user rule (AIRULES.md), applies to all projects.

## Background

First feedback action from the 2026-07 retro-note batch analysis (91 findings, 23 sessions, 7 projects). Cluster M9 (approval-scope inflation) contains 3 findings of which 2 are high severity — the highest high-severity density of all 9 clusters:

- Created issues in a repository the plan did not name, based on plan approval alone (high)
- Posted an issue comment mid-task, interpreting it as implicitly covered by an approved issue-body edit (high, recorded as approval-scope in analysis)
- Treated checkbox flips and comment posting as the same authorization category (medium)

The existing stop condition already lists external mutations, but all three findings show the same failure mechanism: the preceding bullet (approved plan → pick a primary path and proceed) was read as overriding the stop condition for actions listed in or adjacent to the plan. Per the rule-editing convention, the boundary is integrated into the affected instruction itself rather than appended as a new bullet.

Code review flagged that the initial wording could be read as requiring a stop before steps a running workflow/skill already pre-authorizes (push, PR creation, review reactions), contradicting the git-workflow skill contract; the second commit rewrites the clause in positive form with the workflow/skill carve-out and a granularity example.

No verification beyond the pre-commit hooks and CI (Checks panel) applies to this one-line rule edit.
