### PR TITLE
Steer pr-selfcheck away from temp branches when reading PR files

### DIFF
--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -17,6 +17,12 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    `gh pr view <number> --json title,body,url,additions,deletions,files`
 1. Retrieve the diff:
    `gh pr diff <number>`
+1. When verifying a body claim needs file contents at the PR head,
+   run `git fetch origin pull/<number>/head` once and read via
+   `git show FETCH_HEAD:<path>`. Do not create local branches and do
+   not run `git branch -D`/`-d` — branch deletion hits a blocking
+   permission prompt in this environment, and skipping the cleanup
+   leaves stray branches behind
 1. Read `~/.claude/skills/git-workflow/pr-guidelines.md` to load the PR Body Checklist
 1. For each URL found in the PR body, verify accessibility with WebFetch
    If a URL is unreachable (network error, 403, etc.), report it as "unverifiable" rather than a must-fix.

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -20,9 +20,8 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 1. When verifying a body claim needs file contents at the PR head,
    run `git fetch origin pull/<number>/head` once and read via
    `git show FETCH_HEAD:<path>`. Do not create local branches and do
-   not run `git branch -D`/`-d` — branch deletion hits a blocking
-   permission prompt in this environment, and skipping the cleanup
-   leaves stray branches behind
+   not run `git branch -D`/`-d` (branch deletion blocks on a
+   permission prompt)
 1. Read `~/.claude/skills/git-workflow/pr-guidelines.md` to load the PR Body Checklist
 1. For each URL found in the PR body, verify accessibility with WebFetch
    If a URL is unreachable (network error, 403, etc.), report it as "unverifiable" rather than a must-fix.
@@ -31,7 +30,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 
 ## Review Criteria
 
-Evaluate the PR against the PR Body Checklist loaded in Step 3 (`~/.claude/skills/git-workflow/pr-guidelines.md`).
+Evaluate the PR against the PR Body Checklist loaded in Step 4 (`~/.claude/skills/git-workflow/pr-guidelines.md`).
 
 In addition to the high-level checklist, apply the following concrete
 signals so detection does not rely on subagent interpretation alone.


### PR DESCRIPTION
## Summary

Adds a step to the pr-selfcheck skill telling the fork agent how to read PR-head file contents without creating local branches: `git fetch origin pull/<number>/head` once, then `git show FETCH_HEAD:<path>`, and never run `git branch -D`/`-d`.

Scope: global Claude Code configuration (claude/skills/pr-selfcheck).

## Background

While verifying PR body claims during the #307 review flow, selfcheck fork agents twice improvised a fetch-into-temp-branch approach (`git fetch origin pull/307/head:pr-307-check` ... `git branch -D pr-307-check` as one compound command). The trailing branch deletion matches the `Bash(git branch -D *)` ask rule, so the whole compound command blocked on a permission prompt mid-check, and denying it left stray local branches behind. The user asked that cleanup deletion simply never be needed; reading through FETCH_HEAD achieves that with no state to clean up.

## Verification

- [x] Reproduced the mechanism twice in the same session (two independent fork agents chose the temp-branch pattern; the second blocked on the ask rule until manually resolved)
- [ ] Next /pr-selfcheck run that needs PR-head file contents uses FETCH_HEAD and completes without a permission prompt
