### PR TITLE
Remind to show diff on gh pr/issue edit; let classifier handle gh issue edit

### DIFF
--- a/claude/hooks/remind_show_edit_diff.py
+++ b/claude/hooks/remind_show_edit_diff.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Remind the agent to show a diff after editing a PR/issue title or body.
+
+Fires on ``PostToolUse`` events for ``Bash`` calls. When the command is a
+``gh pr edit`` or ``gh issue edit`` invocation that includes a flag which
+overwrites the title or body (``--title``/``-t``, ``--body``/``-b``, or
+``--body-file``/``-F``), emits an ``additionalContext`` reminder to present
+the before/after diff to the user, since these flags silently replace the
+existing content and a mistaken value is otherwise easy to lose. No state is
+persisted; the reminder fires on every matching command in every session by
+design.
+
+Registered under ``PostToolUse`` with ``matcher: "Bash"``. Set
+``ENABLE_EDIT_DIFF_REMINDER=0`` to disable.
+
+Spec: https://code.claude.com/docs/en/hooks#posttooluse
+"""
+import json
+import os
+import re
+import shlex
+import sys
+
+_EDIT_FLAGS = {"--title", "-t", "--body", "-b", "--body-file", "-F"}
+
+MESSAGE = (
+    "A `gh pr edit` / `gh issue edit` that changed the title or body just "
+    "ran. If you did not present the before/after diff to the user before "
+    "executing this, present it now: fetch the previous value (from the "
+    "earlier `gh pr view` / `gh issue view` output already in this "
+    "conversation, or by re-fetching if you cannot recover it) and show a "
+    "diff against the new body you just applied. This gives the user a "
+    "chance to catch and recover overwritten content. See the git-workflow "
+    "skill Section 5 for the canonical pre-edit procedure."
+)
+
+
+def _is_edit_diff_command(command: str) -> bool:
+    normalized = re.sub(r"\s+", " ", command).strip()
+    if "gh pr edit " not in normalized and "gh issue edit " not in normalized:
+        return False
+    try:
+        tokens = shlex.split(normalized)
+    except ValueError:
+        # Unbalanced quotes or similar: don't guess, fail open silently.
+        return False
+    return any(token in _EDIT_FLAGS for token in tokens)
+
+
+def main() -> None:
+    if os.environ.get("ENABLE_EDIT_DIFF_REMINDER", "1") == "0":
+        sys.exit(0)
+
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+    if not isinstance(data, dict):
+        sys.exit(0)
+
+    if data.get("tool_name", "") != "Bash":
+        sys.exit(0)
+
+    command = (data.get("tool_input") or {}).get("command", "")
+    if not command:
+        sys.exit(0)
+
+    if not _is_edit_diff_command(command):
+        sys.exit(0)
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": MESSAGE,
+        },
+    }))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/hooks/remind_show_edit_diff.py
+++ b/claude/hooks/remind_show_edit_diff.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
 """Remind the agent to show a diff after editing a PR/issue title or body.
 
-Fires on ``PostToolUse`` events for ``Bash`` calls. When the command is a
-``gh pr edit`` or ``gh issue edit`` invocation that includes a flag which
-overwrites the title or body (``--title``/``-t``, ``--body``/``-b``, or
-``--body-file``/``-F``), emits an ``additionalContext`` reminder to present
-the before/after diff to the user, since these flags silently replace the
-existing content and a mistaken value is otherwise easy to lose. No state is
-persisted; the reminder fires on every matching command in every session by
-design.
+Fires on ``PostToolUse`` events for ``Bash`` calls. When the command begins
+with ``gh pr edit`` or ``gh issue edit`` and includes a flag that overwrites
+the title or body (``--title``/``-t``, ``--body``/``-b``, ``--body-file``/
+``-F``, and the ``=``-joined forms of the long options), emits an
+``additionalContext`` reminder to present the before/after diff to the user.
+The reminder is only actionable when the prior value is still visible in
+the conversation (an earlier ``gh {pr,issue} view`` output, or the body file
+the agent wrote): re-fetching after the edit returns the new value, so a
+lost prior value cannot be reconstructed from the server.
+
+The command must actually start with ``gh (pr|issue) edit`` (first three
+tokens), so short flags like ``-F`` appearing in compound commands
+(``... && grep -F pat``) do not over-fire. No state is persisted; the
+reminder fires on every matching command in every session by design.
 
 Registered under ``PostToolUse`` with ``matcher: "Bash"``. Set
 ``ENABLE_EDIT_DIFF_REMINDER=0`` to disable.
@@ -17,34 +23,74 @@ Spec: https://code.claude.com/docs/en/hooks#posttooluse
 """
 import json
 import os
-import re
 import shlex
 import sys
 
-_EDIT_FLAGS = {"--title", "-t", "--body", "-b", "--body-file", "-F"}
+_EDIT_FLAGS = frozenset({"--title", "-t", "--body", "-b", "--body-file", "-F"})
+_SHELL_OPERATORS = frozenset({"&&", "||", "|", ";", "&", "\n"})
 
 MESSAGE = (
     "A `gh pr edit` / `gh issue edit` that changed the title or body just "
     "ran. If you did not present the before/after diff to the user before "
-    "executing this, present it now: fetch the previous value (from the "
-    "earlier `gh pr view` / `gh issue view` output already in this "
-    "conversation, or by re-fetching if you cannot recover it) and show a "
-    "diff against the new body you just applied. This gives the user a "
-    "chance to catch and recover overwritten content. See the git-workflow "
-    "skill Section 5 for the canonical pre-edit procedure."
+    "executing this, present it now using the prior value from earlier in "
+    "this conversation (an earlier `gh pr view` / `gh issue view` output, "
+    "or the body file you wrote for this edit). Re-fetching now returns "
+    "the new value, so recovery is only possible when the prior value is "
+    "still visible in context. For future edits, follow the `Update a PR "
+    "/ issue` procedure in the git-workflow skill so the diff is shown "
+    "before the edit runs."
 )
 
 
+def _matches_edit_flag(token: str) -> bool:
+    """Match ``--title``, ``-t``, etc. and their ``--flag=value`` forms.
+
+    >>> _matches_edit_flag("--title")
+    True
+    >>> _matches_edit_flag("--title=NEW")
+    True
+    >>> _matches_edit_flag("-t")
+    True
+    >>> _matches_edit_flag("--body-file=/tmp/x")
+    True
+    >>> _matches_edit_flag("--add-label")
+    False
+    >>> _matches_edit_flag("--titles")
+    False
+    """
+    return token.split("=", 1)[0] in _EDIT_FLAGS
+
+
 def _is_edit_diff_command(command: str) -> bool:
-    normalized = re.sub(r"\s+", " ", command).strip()
-    if "gh pr edit " not in normalized and "gh issue edit " not in normalized:
-        return False
+    """Return True when the command runs ``gh (pr|issue) edit`` with an overwrite flag.
+
+    >>> _is_edit_diff_command("gh pr edit 123 --body-file /tmp/x")
+    True
+    >>> _is_edit_diff_command("gh issue edit 5 --title='new title'")
+    True
+    >>> _is_edit_diff_command("gh pr edit 123 --add-label foo")
+    False
+    >>> _is_edit_diff_command("gh pr create --body-file /tmp/x")
+    False
+    >>> _is_edit_diff_command("gh pr edit 123 --add-label foo && grep -F pat log")
+    False
+    >>> _is_edit_diff_command("gh pr edit 123 -t 'new'")
+    True
+    """
     try:
-        tokens = shlex.split(normalized)
+        tokens = shlex.split(command)
     except ValueError:
-        # Unbalanced quotes or similar: don't guess, fail open silently.
         return False
-    return any(token in _EDIT_FLAGS for token in tokens)
+    if len(tokens) < 4:
+        return False
+    if tokens[0] != "gh" or tokens[1] not in ("pr", "issue") or tokens[2] != "edit":
+        return False
+    for tok in tokens[3:]:
+        if tok in _SHELL_OPERATORS:
+            break
+        if _matches_edit_flag(tok):
+            return True
+    return False
 
 
 def main() -> None:
@@ -61,7 +107,10 @@ def main() -> None:
     if data.get("tool_name", "") != "Bash":
         sys.exit(0)
 
-    command = (data.get("tool_input") or {}).get("command", "")
+    tool_input = data.get("tool_input")
+    if not isinstance(tool_input, dict):
+        sys.exit(0)
+    command = tool_input.get("command", "")
     if not command:
         sys.exit(0)
 

--- a/claude/rules/git-essentials.md
+++ b/claude/rules/git-essentials.md
@@ -50,3 +50,11 @@ NOT restate the detailed procedures from the skill.
   --hard` on a published branch, back out to a merge-based path:
   `gh pr update-branch <N>`, merge the default branch into the
   feature branch, or a fresh commit on top.
+
+## PR / issue body edits
+
+- Before running `gh pr edit` / `gh issue edit` with `--body`,
+  `--body-file`, or `--title`, present the diff between the current
+  and the new value in the conversation so the user can review and
+  recover overwritten content. Procedure lives in the git-workflow
+  skill Section 5.

--- a/claude/rules/git-essentials.md
+++ b/claude/rules/git-essentials.md
@@ -55,6 +55,5 @@ NOT restate the detailed procedures from the skill.
 
 - Before running `gh pr edit` / `gh issue edit` with `--body`,
   `--body-file`, or `--title`, present the diff between the current
-  and the new value in the conversation so the user can review and
-  recover overwritten content. Procedure lives in the git-workflow
-  skill Section 5.
+  and the new value in the conversation. Procedure lives in the
+  `Update a PR / issue` section of the git-workflow skill.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -312,7 +312,6 @@
       "Bash(git worktree move *)",
       "Bash(git worktree lock *)",
       "Bash(git worktree unlock *)",
-      "Bash(gh issue edit *)",
       "Bash(gh api * --method*)",
       "Bash(gh api * -X*)",
       "Bash(gh api * --input*)",
@@ -385,6 +384,15 @@
           {
             "type": "command",
             "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"If this plan involves implementation beyond a trivial edit, dispatch the implementer subagent per the implementation-delegation rule.\"}}'"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=~/.claude/hooks/remind_show_edit_diff.py; if [ -f \"$f\" ] && command -v python3 >/dev/null; then python3 \"$f\"; fi"
           }
         ]
       }


### PR DESCRIPTION
## Purpose

Two friction points around `gh pr edit` / `gh issue edit`:

1. `gh issue edit *` was in `permissions.ask`, so every invocation stopped for a dialog even in auto mode.
2. Neither command shows the caller what is being overwritten. `--title` / `--body` / `--body-file` silently replace the existing value, and a mistake was hard to catch until after the fact.

## Key changes

- `claude/settings.json`: drop `"Bash(gh issue edit *)"` from `permissions.ask` so the auto-mode classifier decides (`gh pr edit *` is already in `allow` and stays there); register a new `PostToolUse` hook on the `Bash` matcher that invokes `remind_show_edit_diff.py`
- `claude/hooks/remind_show_edit_diff.py` (new): matched `gh {pr,issue} edit` calls with a title/body-overwrite flag get an `additionalContext` reminder to show the before/after diff. Matches are anchored to `tokens[0:3]` and stop scanning at the first shell operator (so `... && grep -F pat` doesn't over-fire), and split on `=` so `--title=NEW` is caught. Match rules and kill switch in the module docstring.
- `claude/rules/git-essentials.md`: add a slim `## PR / issue body edits` section stating the pre-edit-diff expectation, pointing at the git-workflow skill's `Update a PR / issue` procedure

Design choice: kept the rule short (rule = mandate, skill procedure = how). Kept the hook stateless (fires every edit) since the diff reminder is cheap for the model and the failure mode of missing a diff is user-visible content loss. The reminder honestly notes that recovery only works when the prior value is still in context — re-fetching post-edit returns the new value.

## Verification

- [x] `python3 -m py_compile claude/hooks/remind_show_edit_diff.py` — clean
- [x] `python3 -m doctest claude/hooks/remind_show_edit_diff.py` — 12 tests pass
- [x] Positive: `gh pr edit 123 --body-file /tmp/x` → fires
- [x] Positive: `gh issue edit 5 --title "new title"` → fires
- [x] Positive: `gh pr edit 123 --title=NEW` (`=`-form) → fires
- [x] Positive: `gh pr edit 123 -t new` (short flag) → fires
- [x] Negative: `gh pr edit 123 --add-label foo` (edit without overwrite flag) → no output
- [x] Negative: `gh pr edit 123 --add-label foo && grep -F pat log` (short flag in compound command) → no output
- [x] Negative: `gh pr edit 123 --add-label foo | tee -a out` (pipe) → no output
- [x] Negative: non-`Bash` tool call → no output
- [x] Negative: `gh pr create --body-file /tmp/x` (create, not edit) → no output
- [x] `jq . claude/settings.json` → valid JSON after the ask-list removal and the new `PostToolUse` block
- [x] End-to-end in a fresh session after `./scripts/deploy.sh`: run an actual `gh issue edit` to confirm the classifier path (no ask dialog stall) and see the reminder land as `additionalContext` in the next turn
