### PR TITLE
Allow git merge without prompting

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -20,6 +20,7 @@
       "Bash(mkdir *)",
       "Bash(tree *)",
       "Bash(git *)",
+      "Bash(git merge *)",
       "Bash(git-worktree-create *)",
       "Bash(jq *)",
       "Bash(yq *)",
@@ -295,7 +296,6 @@
       "Read(**/serviceAccount.json)"
     ],
     "ask": [
-      "Bash(git merge *)",
       "Bash(git rebase *)",
       "Bash(git commit --amend)",
       "Bash(git commit --amend *)",


### PR DESCRIPTION
## Summary

Move `Bash(git merge *)` from the ask list to the allow list in claude/settings.json, so git merge runs without a permission prompt.

## Background

Ask rules take precedence over allow rules ("a matching ask rule prompts even when a more specific allow rule also matches the same call" — https://code.claude.com/docs/en/permissions ), so every merge prompted even though the blanket `Bash(git *)` allow matched. This blocked subagents from resolving PR branch conflicts: a permission prompt raised from a background agent gives the user no context about which branch is being merged into, so it cannot be approved meaningfully.

## Why an explicit allow entry (and why removing the ask rule alone is not enough)

- Today the entry is redundant with `Bash(git *)`, but #208 replaces that blanket with an explicit allowlist that deliberately leaves merge out
- Without this entry, post-#208 merges would fall through to the auto-mode classifier (subject to occasional transient-error denials, one observed 2026-07-20) or a manual-mode prompt
- With it, merge resolves at rule-evaluation time in every mode

## Risk assessment

git merge is local-only and recoverable:

- Committed state stays permanently reachable via the merge commit's first parent (and `git reflog`, 90-day default per `man git-gc`)
- A merge that would overwrite uncommitted changes or untracked files refuses to start
- The remote is untouched until a separate `git push`
- After a push, undo is `git revert -m 1 <merge commit>` (force push stays denied)

The genuinely destructive git commands (`reset --hard`, `clean`, `stash drop/clear`, `rebase`, `commit --amend`) stay in ask/deny.

## Interaction with #208

#208's branch (`feature/explicit-git-allowlist-187`) also deletes the `Bash(git merge *)` ask entry, so the ask-side change merges cleanly either way. The new allow entry sits next to `Bash(git *)`, which #208 replaces; the expected resolution is to keep this entry in #208's allowlist.

## Verification

- [x] `jq -e '.permissions.allow | index("Bash(git merge *)")'` returns an index; the same lookup on `.permissions.ask` returns null
- [x] pre-commit ran on the commit: `Check JSON.....Passed` (hook output at commit time)
- [x] After merge + settings reload: a subagent `git merge origin/main` on a feature branch runs without a permission prompt
