### PR TITLE
Route ghostty bold ASCII to Menlo via font-family-bold

### DIFF
--- a/xdg-config/ghostty/config
+++ b/xdg-config/ghostty/config
@@ -19,6 +19,7 @@ quick-terminal-position = center
 quick-terminal-size = 1080px, 50%
 
 font-family = "Monaco"
+font-family-bold = "Menlo"
 font-family = "BIZ UDGothic Bold"
 font-style = Regular
 font-size = 12


### PR DESCRIPTION
## Summary
- Pin ghostty bold ASCII rendering to Menlo with font-family-bold, leaving CJK bold on BIZ UDGothic Bold

## Changes
- xdg-config/ghostty/config: add `font-family-bold = "Menlo"` between the Monaco and BIZ UDGothic Bold entries

## Background
Bold ASCII had no dedicated bold face and fell through the regular font-family cascade. Issue #281 verified at ghostty source level (Collection.zig per-style buckets, CodepointResolver fallback) and on-device (`ghostty +show-face --style=bold`) that this line routes bold ASCII to Menlo while bold CJK still resolves to BIZ UDGothic Bold

Issue: #281

## Verification
- [x] `ghostty +show-face --string="のA" --style=bold --font-family-bold=Menlo` shows A → Menlo, の → BIZ UDGothic (recorded in issue #281 comment, 2026-07-20)
- [x] pre-commit hooks passed on commit
- [ ] Visual check in a live terminal that Menlo Bold next to Monaco Regular looks acceptable (subjective, user-side after deploy)
