### PR TITLE
Disable copy-on-select in fullscreen TUI

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -516,6 +516,7 @@
   "model": "claude-opus-4-7[1m]",
   "autoUpdatesChannel": "stable",
   "tui": "fullscreen",
+  "copyOnSelect": false,
   "autoMemoryEnabled": false,
   "theme": "auto",
   "remoteControlAtStartup": true,


### PR DESCRIPTION
## Summary

Disable auto copy-on-select in Claude Code's fullscreen TUI.

Since switching `tui` to `fullscreen` (d0fabd4), Claude Code captures mouse events and auto-copies any selected text to the system clipboard on mouse release. Even a small accidental drag clobbers the clipboard, which is annoying while pasting between apps. Set `copyOnSelect: false` in `claude/settings.json` to turn that off. Manual copy (`Ctrl+Shift+c`, or `Cmd+c` on kitty-protocol terminals like Ghostty) still works.

Confirmed the key name and default (`true`) against the Claude Code binary at `/opt/homebrew/Caskroom/claude-code@latest/2.1.215/claude` — the `/config` "Copy on select" toggle persists the boolean `copyOnSelect` in `settings.json`, and the runtime reads `bt().copyOnSelect ?? !0`.

## Verification

- [x] `settings.json` remains valid JSON (pre-commit `Check JSON` passed)
- [ ] After deploy + relaunch, drag-select in fullscreen TUI does not overwrite the clipboard (manual check by user)

## References

- Fullscreen rendering docs: https://code.claude.com/docs/en/fullscreen
- Feature request thread: https://github.com/anthropics/claude-code/issues/60755
