### PR TITLE
Require PR/issue edit diff to be in assistant message body

### DIFF
--- a/claude/rules/git-essentials.md
+++ b/claude/rules/git-essentials.md
@@ -55,7 +55,6 @@ NOT restate the detailed procedures from the skill.
 
 - Before running `gh pr edit` / `gh issue edit` with `--body`,
   `--body-file`, or `--title`, emit the diff between the current
-  and the new value as text in the assistant message body (a
-  fenced ```diff block). Do not substitute a Bash / tool-call
-  diff. Procedure lives in the `Update a PR / issue` section of
-  the git-workflow skill.
+  and new value as text in the assistant message body — a fenced
+  ```diff block, not a Bash / tool-call output (procedure: the
+  `Update a PR / issue` section of the git-workflow skill)

--- a/claude/rules/git-essentials.md
+++ b/claude/rules/git-essentials.md
@@ -54,6 +54,9 @@ NOT restate the detailed procedures from the skill.
 ## PR / issue body edits
 
 - Before running `gh pr edit` / `gh issue edit` with `--body`,
-  `--body-file`, or `--title`, present the diff between the current
-  and the new value in the conversation. Procedure lives in the
-  `Update a PR / issue` section of the git-workflow skill.
+  `--body-file`, or `--title`, emit the diff between the current and
+  the new value as text in the assistant message body (a fenced
+  ```diff block), not as a Bash / tool-call output. Tool-call output
+  is not reliably visible to the user, so a tool-call-only diff does
+  not satisfy this rule. Procedure lives in the `Update a PR /
+  issue` section of the git-workflow skill.

--- a/claude/rules/git-essentials.md
+++ b/claude/rules/git-essentials.md
@@ -54,9 +54,8 @@ NOT restate the detailed procedures from the skill.
 ## PR / issue body edits
 
 - Before running `gh pr edit` / `gh issue edit` with `--body`,
-  `--body-file`, or `--title`, emit the diff between the current and
-  the new value as text in the assistant message body (a fenced
-  ```diff block), not as a Bash / tool-call output. Tool-call output
-  is not reliably visible to the user, so a tool-call-only diff does
-  not satisfy this rule. Procedure lives in the `Update a PR /
-  issue` section of the git-workflow skill.
+  `--body-file`, or `--title`, emit the diff between the current
+  and the new value as text in the assistant message body (a
+  fenced ```diff block). Do not substitute a Bash / tool-call
+  diff. Procedure lives in the `Update a PR / issue` section of
+  the git-workflow skill.

--- a/claude/rules/git-essentials.md
+++ b/claude/rules/git-essentials.md
@@ -56,5 +56,5 @@ NOT restate the detailed procedures from the skill.
 - Before running `gh pr edit` / `gh issue edit` with `--body`,
   `--body-file`, or `--title`, emit the diff between the current
   and new value as text in the assistant message body — a fenced
-  ```diff block, not a Bash / tool-call output (procedure: the
-  `Update a PR / issue` section of the git-workflow skill)
+  `diff` code block, not a Bash / tool-call output (procedure:
+  the `Update a PR / issue` section of the git-workflow skill)

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -223,8 +223,8 @@ routine CI / comment events.
      `gh pr view <number> --json body --jq .body`
      (or `gh issue view <number> --json body --jq .body` for issues)
   1. Emit a diff between the current body and the new body as
-     text in the assistant message body (a fenced ```diff block).
-     Do not substitute a Bash / tool-call diff.
+     text in the assistant message body — a fenced ```diff block,
+     not a Bash / tool-call output
   1. Write the new body to a fresh file under the session scratchpad
      directory using the Write tool (new filename per revision — no
      temp-file generation, no Read of an empty file)

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -223,8 +223,8 @@ routine CI / comment events.
      `gh pr view <number> --json body --jq .body`
      (or `gh issue view <number> --json body --jq .body` for issues)
   1. Emit a diff between the current body and the new body as
-     text in the assistant message body — a fenced ```diff block,
-     not a Bash / tool-call output
+     text in the assistant message body — a fenced `diff` code
+     block, not a Bash / tool-call output
   1. Write the new body to a fresh file under the session scratchpad
      directory using the Write tool (new filename per revision — no
      temp-file generation, no Read of an empty file)

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -222,20 +222,15 @@ routine CI / comment events.
   1. Fetch the current body:
      `gh pr view <number> --json body --jq .body`
      (or `gh issue view <number> --json body --jq .body` for issues)
-  1. Emit a diff between the current body and the new body as text
-     in the assistant message body (a fenced ```diff block), not as
-     a Bash / tool-call output. Tool-call output is not reliably
-     visible to the user; the diff must appear in the assistant's
-     own message so it is visible and recoverable.
+  1. Emit a diff between the current body and the new body as
+     text in the assistant message body (a fenced ```diff block).
+     Do not substitute a Bash / tool-call diff.
   1. Write the new body to a fresh file under the session scratchpad
      directory using the Write tool (new filename per revision — no
      temp-file generation, no Read of an empty file)
   1. Execute the edit:
      `gh pr edit <number> --body-file <body file path>`
      (or `gh issue edit <number> --body-file <body file path>`)
-  The goal is observability — always show the diff so the user can see
-  what changed and recover manually-written content if accidentally
-  overwritten.
 
 Note: Always use `--body-file` for any body update. The `#`-prefixed lines
 in PR/issue bodies trigger Claude Code's security pre-check when passed

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -222,8 +222,11 @@ routine CI / comment events.
   1. Fetch the current body:
      `gh pr view <number> --json body --jq .body`
      (or `gh issue view <number> --json body --jq .body` for issues)
-  1. Output a diff between the current body and the new body in the
-     conversation (so what changed is visible and recoverable).
+  1. Emit a diff between the current body and the new body as text
+     in the assistant message body (a fenced ```diff block), not as
+     a Bash / tool-call output. Tool-call output is not reliably
+     visible to the user; the diff must appear in the assistant's
+     own message so it is visible and recoverable.
   1. Write the new body to a fresh file under the session scratchpad
      directory using the Write tool (new filename per revision — no
      temp-file generation, no Read of an empty file)


### PR DESCRIPTION
## Summary

旧ルール文言「present the diff in the conversation」だと Claude Code が Bash の diff コマンド出力 (ユーザーには見えない tool-call output) で済ませて「conversation に出した」と主張することが多発していたので、assistant message body 内に diff を出すことを明示する

## Test plan

- [x] 次に `gh pr edit --body-file` を実行するタスクで、Claude が実際に assistant message 内に diff を出しているか確認
