### PR TITLE
Work around fullscreen TUI ignoring copyOnSelect

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -82,6 +82,10 @@ export SHELLCHECK_OPTS='--exclude=SC1090,SC1091,SC2039,SC3010,SC3060,SC3028'
 export TF_PLUGIN_CACHE_DIR="$HOME/.terraform.d/plugin-cache"
 export CHECKPOINT_DISABLE=1
 
+# Claude Code: fullscreen renderer ignores copyOnSelect (anthropics/claude-code#77259).
+# Disable mouse click capture so terminal-native select+copy works while wheel scroll stays.
+export CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1
+
 # AWS Profile Switcher
 if [ -f ~/.aws/current_profile ]; then
   AWS_PROFILE="$(cat ~/.aws/current_profile)"

--- a/.bash_profile
+++ b/.bash_profile
@@ -83,8 +83,9 @@ export TF_PLUGIN_CACHE_DIR="$HOME/.terraform.d/plugin-cache"
 export CHECKPOINT_DISABLE=1
 
 # Claude Code: fullscreen renderer ignores copyOnSelect (anthropics/claude-code#77259).
-# Disable mouse click capture so terminal-native select+copy works while wheel scroll stays.
-export CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1
+# Fully opt out of mouse capture so click-drag select + Cmd+c work like a normal terminal.
+# Trade-off: wheel scroll inside Claude Code is lost; use PgUp/PgDn or Fn+↑/↓.
+export CLAUDE_CODE_DISABLE_MOUSE=1
 
 # AWS Profile Switcher
 if [ -f ~/.aws/current_profile ]; then


### PR DESCRIPTION
## Summary

Claude Code's fullscreen renderer bypasses the `copyOnSelect` gate. Even with `"copyOnSelect": false` in `settings.json` (added in #319), any drag-select in the TUI still fires OSC 52 and overwrites the system clipboard. Upstream tracker: [anthropics/claude-code#77259](https://github.com/anthropics/claude-code/issues/77259) — OPEN, updated 2026-07-13, and still repro on v2.1.215.

Set `CLAUDE_CODE_DISABLE_MOUSE=1` in `.bash_profile` as a workaround:

- Click-drag inside Claude Code no longer captures — plain click-drag selects natively and `Cmd+c` copies via the terminal, like any other TUI.
- Wheel scroll inside Claude Code is lost. Keyboard scrolling (`PgUp`/`PgDn`, `Ctrl+Home`/`End`, `Fn+↑`/`↓` on Mac) still works.
- Click-to-expand tool output, in-app cursor positioning, and URL clicking are lost. Acceptable trade for normal terminal copy/paste behavior.
- Flicker-free rendering and flat memory usage of fullscreen stay (they're independent of mouse capture).

Keep `"copyOnSelect": false` in `claude/settings.json` so the fix applies once upstream lands and this env var can be removed.

## Test plan

- [x] `shellcheck .bash_profile` passes (clean exit, no warnings).
- [x] Sourcing the PR's `.bash_profile` directly in a subshell exports `CLAUDE_CODE_DISABLE_MOUSE=1` (verified pre-merge). Full flow — post-merge `./scripts/deploy.sh` + new shell picks it up — deferred to post-merge.
- [ ] In a fresh `claude` session (fullscreen), a click-drag selects natively and `Cmd+c` copies via the terminal.
