### PR TITLE
Work around fullscreen TUI ignoring copyOnSelect

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -82,6 +82,10 @@ export SHELLCHECK_OPTS='--exclude=SC1090,SC1091,SC2039,SC3010,SC3060,SC3028'
 export TF_PLUGIN_CACHE_DIR="$HOME/.terraform.d/plugin-cache"
 export CHECKPOINT_DISABLE=1
 
+# Claude Code: fullscreen renderer ignores copyOnSelect (anthropics/claude-code#77259).
+# Disable mouse click capture so terminal-native select+copy works while wheel scroll stays.
+export CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1
+
 # AWS Profile Switcher
 if [ -f ~/.aws/current_profile ]; then
   AWS_PROFILE="$(cat ~/.aws/current_profile)"

--- a/.bash_profile
+++ b/.bash_profile
@@ -83,7 +83,7 @@ export TF_PLUGIN_CACHE_DIR="$HOME/.terraform.d/plugin-cache"
 export CHECKPOINT_DISABLE=1
 
 # Claude Code: fullscreen renderer ignores copyOnSelect (anthropics/claude-code#77259).
-# Disable mouse click capture so terminal-native select+copy works while wheel scroll stays.
+# Disable in-app click handling so Shift/Option-drag selects natively (no auto-copy); wheel scroll stays.
 export CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1
 
 # AWS Profile Switcher


### PR DESCRIPTION
## Summary

Claude Code's fullscreen renderer bypasses the `copyOnSelect` gate. Even with `"copyOnSelect": false` in `settings.json` (added in #319), any drag-select in the TUI still fires the clipboard write and overwrites the system clipboard. Upstream tracker: [anthropics/claude-code#77259](https://github.com/anthropics/claude-code/issues/77259) — OPEN, updated 2026-07-13, still repro on v2.1.215.

The classic renderer honors `copyOnSelect: false`, but switching back to it reintroduces the scroll-to-top stroboscope in long conversations ([anthropics/claude-code#826](https://github.com/anthropics/claude-code/issues/826), OPEN, 353 comments) — which is why `d0fabd4` moved to fullscreen in the first place.

Set `CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1` in `.bash_profile` as a middle-ground workaround:

- Plain click-drag inside Claude Code no longer captures — so no auto-copy fires on release.
- Selection: hold Shift (or Option in iTerm2) while dragging → the terminal handles the selection natively → `Cmd+c` copies via the terminal. This is the terminal's normal application-bypass gesture.
- Wheel scroll inside Claude Code still works.
- Click-to-expand tool output, in-app cursor positioning, and URL clicking are lost.
- Fullscreen's flicker-free rendering and flat memory usage stay.

Supersedes the closed #322, which switched to `CLAUDE_CODE_DISABLE_MOUSE=1` and lost wheel scroll — heavier trade than needed.

Keep `"copyOnSelect": false` in `claude/settings.json` so the fix applies once upstream lands and this env var can be removed.

## Test plan

- [x] Sourcing the PR's `.bash_profile` in a subshell exports `CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1` (verified pre-merge).
- [ ] After merge + `./scripts/deploy.sh` + fresh shell + fresh `claude` session (fullscreen): plain click-drag no longer overwrites the clipboard; Shift/Option-drag selects natively and `Cmd+c` copies; wheel scroll still works.
