### PR TITLE
Deny aws logs start-query via PreToolUse hook

### DIFF
--- a/claude/hooks/block_aws_logs_start_query.py
+++ b/claude/hooks/block_aws_logs_start_query.py
@@ -7,11 +7,14 @@ data. Block it at the permission layer so no allow rule (e.g. the
 it, and so the block is not bypassed by option-position tricks that a
 glob-based ``permissions.deny`` entry would miss.
 
-The hook splits the command into shell segments (respecting quotes),
-strips leading environment-variable assignments and an optional
-``env ...`` wrapper from each segment, and denies the segment when the
-resolved command is ``aws`` (or a path ending in ``/aws``) with
-service ``logs`` and subcommand ``start-query``.
+The hook splits the command into shell segments (respecting quotes and
+collapsing ``\\`` + newline line continuations), strips leading
+environment-variable assignments and an optional ``env ...`` wrapper
+from each segment, walks past aws global options — including known
+value-taking flags like ``--profile`` in either ``--profile stg-ro`` or
+``--profile=stg-ro`` form — and denies the segment when the resolved
+command is ``aws`` (or a path ending in ``/aws``) with service ``logs``
+and subcommand ``start-query``.
 
 Spec: https://code.claude.com/docs/en/hooks
 """
@@ -50,12 +53,18 @@ REASON = (
 def _split_outside_quotes(command: str) -> list[str]:
     """Split by shell separators, ignoring separators inside quotes.
 
+    Bash line continuation ``\\`` + newline outside quotes is collapsed
+    before splitting so a multi-line ``aws logs start-query \\<NL> ...``
+    still lands in one segment.
+
     >>> _split_outside_quotes("aws logs start-query | jq .")
     ['aws logs start-query ', ' jq .']
     >>> _split_outside_quotes("echo 'aws logs start-query | jq .'")
     ["echo 'aws logs start-query | jq .'"]
     >>> _split_outside_quotes("foo && aws logs start-query")
     ['foo ', ' aws logs start-query']
+    >>> _split_outside_quotes("aws logs start-query \\\\\\n  --foo bar")
+    ['aws logs start-query   --foo bar']
     """
     segments: list[str] = []
     current: list[str] = []
@@ -63,6 +72,9 @@ def _split_outside_quotes(command: str) -> list[str]:
     i = 0
     while i < len(command):
         ch = command[i]
+        if ch == "\\" and not in_single and i + 1 < len(command) and command[i + 1] == "\n":
+            i += 2
+            continue
         if ch == "\\" and in_double and i + 1 < len(command):
             current.append(ch)
             current.append(command[i + 1])
@@ -166,6 +178,16 @@ def blocks(command: str) -> bool:
     True
     >>> blocks("aws --profile stg-ro --region us-east-1 logs start-query")
     True
+    >>> blocks("aws --debug logs start-query")
+    True
+    >>> blocks("aws --output text logs start-query")
+    True
+
+    Blocked (backslash + newline line continuation):
+    >>> blocks("aws logs start-query \\\\\\n  --log-group-name /aws/lambda/foo")
+    True
+    >>> blocks("AWS_PROFILE=stg-ro aws logs start-query \\\\\\n  --query-string 'fields @timestamp'")
+    True
 
     Blocked (absolute path):
     >>> blocks("/opt/homebrew/bin/aws logs start-query")
@@ -197,6 +219,8 @@ def blocks(command: str) -> bool:
 
     Not blocked (option value happens to be ``logs`` / ``start-query``):
     >>> blocks("aws --profile logs s3 ls")
+    False
+    >>> blocks("aws --output start-query logs describe-log-groups")
     False
 
     Not blocked (help lookup with ``help`` before subcommand):

--- a/claude/hooks/block_aws_logs_start_query.py
+++ b/claude/hooks/block_aws_logs_start_query.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Deny ``aws logs start-query`` invocations regardless of profile or option shape.
+
+CloudWatch Logs Insights ``start-query`` can scan large volumes of log
+data. Block it at the permission layer so no allow rule (e.g. the
+``AWS_PROFILE=*-ro aws *`` read-only bundles) can implicitly authorize
+it, and so the block is not bypassed by option-position tricks that a
+glob-based ``permissions.deny`` entry would miss.
+
+The hook splits the command into shell segments (respecting quotes),
+strips leading environment-variable assignments and an optional
+``env ...`` wrapper from each segment, and denies the segment when the
+resolved command is ``aws`` (or a path ending in ``/aws``) with
+service ``logs`` and subcommand ``start-query``.
+
+Spec: https://code.claude.com/docs/en/hooks
+"""
+import json
+import re
+import shlex
+import sys
+
+_SEPARATOR_RE = re.compile(r"&&|\|\||;|\||&|\n")
+_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+_AWS_GLOBAL_VALUE_FLAGS = {
+    "--profile",
+    "--region",
+    "--output",
+    "--endpoint-url",
+    "--ca-bundle",
+    "--cli-connect-timeout",
+    "--cli-read-timeout",
+    "--query",
+    "--color",
+    "--cli-input-yaml",
+    "--cli-input-json",
+    "--cli-binary-format",
+    "--cli-pager",
+    "--cli-auto-prompt",
+}
+
+REASON = (
+    "aws logs start-query is denied. CloudWatch Logs Insights queries "
+    "can scan large volumes of log data and are billed by scanned "
+    "bytes. If genuinely needed, ask the user to run it directly."
+)
+
+
+def _split_outside_quotes(command: str) -> list[str]:
+    """Split by shell separators, ignoring separators inside quotes.
+
+    >>> _split_outside_quotes("aws logs start-query | jq .")
+    ['aws logs start-query ', ' jq .']
+    >>> _split_outside_quotes("echo 'aws logs start-query | jq .'")
+    ["echo 'aws logs start-query | jq .'"]
+    >>> _split_outside_quotes("foo && aws logs start-query")
+    ['foo ', ' aws logs start-query']
+    """
+    segments: list[str] = []
+    current: list[str] = []
+    in_single = in_double = False
+    i = 0
+    while i < len(command):
+        ch = command[i]
+        if ch == "\\" and in_double and i + 1 < len(command):
+            current.append(ch)
+            current.append(command[i + 1])
+            i += 2
+            continue
+        if ch == "'" and not in_double:
+            in_single = not in_single
+            current.append(ch)
+            i += 1
+            continue
+        if ch == '"' and not in_single:
+            in_double = not in_double
+            current.append(ch)
+            i += 1
+            continue
+        if not in_single and not in_double:
+            m = _SEPARATOR_RE.match(command, i)
+            if m:
+                segments.append("".join(current))
+                current = []
+                i = m.end()
+                continue
+        current.append(ch)
+        i += 1
+    segments.append("".join(current))
+    return segments
+
+
+def _drop_env_prefix(tokens: list[str]) -> list[str]:
+    """Strip leading ``KEY=VALUE`` assignments and an optional ``env`` wrapper."""
+    i = 0
+    while i < len(tokens) and _ENV_ASSIGN_RE.match(tokens[i]):
+        i += 1
+    if i < len(tokens) and tokens[i] == "env":
+        i += 1
+        while i < len(tokens) and _ENV_ASSIGN_RE.match(tokens[i]):
+            i += 1
+    return tokens[i:]
+
+
+def _is_aws(tok: str) -> bool:
+    return tok == "aws" or tok.endswith("/aws")
+
+
+def _next_positional(tokens: list[str], start: int) -> int:
+    """Return index of next positional (non-option) token, treating known
+    aws global flags with values in space form as consuming the next token."""
+    i = start
+    while i < len(tokens):
+        t = tokens[i]
+        if not t.startswith("-"):
+            return i
+        if "=" in t:
+            i += 1
+            continue
+        if t in _AWS_GLOBAL_VALUE_FLAGS:
+            i += 2
+        else:
+            i += 1
+    return -1
+
+
+def _segment_blocks(segment: str) -> bool:
+    try:
+        tokens = shlex.split(segment, comments=False, posix=True)
+    except ValueError:
+        return False
+    tokens = _drop_env_prefix(tokens)
+    if not tokens or not _is_aws(tokens[0]):
+        return False
+    i = _next_positional(tokens, 1)
+    if i < 0 or tokens[i] != "logs":
+        return False
+    j = _next_positional(tokens, i + 1)
+    return j > 0 and tokens[j] == "start-query"
+
+
+def blocks(command: str) -> bool:
+    """Return True if any segment invokes ``aws logs start-query``.
+
+    Blocked (direct):
+    >>> blocks("aws logs start-query --log-group-name /aws/lambda/foo --query-string 'fields @timestamp'")
+    True
+    >>> blocks("aws logs start-query")
+    True
+
+    Blocked (env-var prefix, single and multiple):
+    >>> blocks("AWS_PROFILE=stg-ro aws logs start-query --log-group-name x")
+    True
+    >>> blocks("AWS_PROFILE=stg-ro AWS_REGION=us-east-1 aws logs start-query")
+    True
+
+    Blocked (``env`` wrapper):
+    >>> blocks("env AWS_PROFILE=stg-ro aws logs start-query")
+    True
+
+    Blocked (global option before service):
+    >>> blocks("aws --profile stg-ro logs start-query")
+    True
+    >>> blocks("aws --profile=stg-ro logs start-query")
+    True
+    >>> blocks("aws --profile stg-ro --region us-east-1 logs start-query")
+    True
+
+    Blocked (absolute path):
+    >>> blocks("/opt/homebrew/bin/aws logs start-query")
+    True
+
+    Blocked (piped, chained, backgrounded):
+    >>> blocks("aws logs start-query | jq .")
+    True
+    >>> blocks("foo && aws logs start-query")
+    True
+    >>> blocks("aws logs start-query &")
+    True
+
+    Not blocked (different subcommand):
+    >>> blocks("aws logs describe-log-groups")
+    False
+    >>> blocks("aws logs filter-log-events --log-group-name /aws/lambda/foo")
+    False
+    >>> blocks("aws logs get-query-results --query-id abc")
+    False
+
+    Not blocked (string only appears inside quotes — commit message, PR body):
+    >>> blocks("git commit -m 'block aws logs start-query'")
+    False
+    >>> blocks("gh pr create --title 'Deny aws logs start-query'")
+    False
+    >>> blocks("echo \\"aws logs start-query\\"")
+    False
+
+    Not blocked (option value happens to be ``logs`` / ``start-query``):
+    >>> blocks("aws --profile logs s3 ls")
+    False
+
+    Not blocked (help lookup with ``help`` before subcommand):
+    >>> blocks("aws logs help")
+    False
+    """
+    for segment in _split_outside_quotes(command):
+        if _segment_blocks(segment):
+            return True
+    return False
+
+
+if __name__ == "__main__":
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    command = data.get("tool_input", {}).get("command", "")
+
+    if tool_name == "Bash" and blocks(command):
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": REASON,
+            },
+        }))
+
+    sys.exit(0)

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -275,6 +275,8 @@
       "Bash(git restore .)",
       "Bash(gcloud * get-credentials *)",
       "Bash(gcloud * get-mount-command *)",
+      "Bash(aws logs start-query *)",
+      "Bash(* aws logs start-query *)",
       "WebFetch(domain:localhost)",
       "WebFetch(domain:127.0.0.1)",
       "WebFetch(domain:0.0.0.0)",

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -275,8 +275,6 @@
       "Bash(git restore .)",
       "Bash(gcloud * get-credentials *)",
       "Bash(gcloud * get-mount-command *)",
-      "Bash(aws logs start-query *)",
-      "Bash(* aws logs start-query *)",
       "WebFetch(domain:localhost)",
       "WebFetch(domain:127.0.0.1)",
       "WebFetch(domain:0.0.0.0)",
@@ -375,6 +373,10 @@
           {
             "type": "command",
             "command": "f=~/.claude/hooks/block_raw_github_fetch.py; if [ -f \"$f\" ] && command -v python3 >/dev/null; then python3 \"$f\"; fi"
+          },
+          {
+            "type": "command",
+            "command": "f=~/.claude/hooks/block_aws_logs_start_query.py; if [ -f \"$f\" ] && command -v python3 >/dev/null; then python3 \"$f\"; fi"
           }
         ]
       },


### PR DESCRIPTION
## Summary

Deny CloudWatch Logs Insights `start-query` at the Claude Code permission layer via a new PreToolUse hook (`claude/hooks/block_aws_logs_start_query.py`), wired into the existing `Bash` PreToolUse chain.

`start-query` is billed by scanned bytes and the existing `AWS_PROFILE=*-ro aws *` allow rules would otherwise implicitly authorize it. `permissions.deny` glob patterns are not enough — they miss aws global options before the service (`aws --profile stg-ro logs start-query`), `env`-wrapped and multi-var env prefixes, absolute paths and pipes, and they self-trigger when the string appears inside a quoted argument (e.g. a `gh pr create --title`). See the hook's docstring for the segment-split + token-walk algorithm.

## Verification

- 29 doctests in `blocks()` and `_split_outside_quotes()` pass (`python3 -m doctest`, also enforced by the `python-doctest` CI job).
- Simulated hook input JSON: deny for `aws logs start-query`, `AWS_PROFILE=stg-ro aws --region us-east-1 logs start-query`, `aws --profile=stg-ro logs start-query`; allow for `aws logs filter-log-events` and `gh pr create --title '…aws logs start-query…'`.
