### PR TITLE
Set Spotlight clipboard history retention to 7 days

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -30,7 +30,7 @@ defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
 defaults write com.apple.menuextra.battery ShowPercent -string "YES"
 defaults write com.apple.Siri HotkeyTag -int 3 # Hold Option Space
 defaults -currentHost write com.apple.Spotlight MenuItemHidden -int 1
-defaults write com.apple.Spotlight PasteboardHistoryTimeout -int 604800  # Clipboard history retention: 7 days (default 8h = 28800)
+defaults write com.apple.Spotlight PasteboardHistoryTimeout -int 604800  # 7 days
 
 echo "Configuring with sudo..."
 sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -30,6 +30,7 @@ defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
 defaults write com.apple.menuextra.battery ShowPercent -string "YES"
 defaults write com.apple.Siri HotkeyTag -int 3 # Hold Option Space
 defaults -currentHost write com.apple.Spotlight MenuItemHidden -int 1
+defaults write com.apple.Spotlight PasteboardHistoryTimeout -int 604800  # Clipboard history retention: 7 days (default 8h = 28800)
 
 echo "Configuring with sudo..."
 sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on


### PR DESCRIPTION
## Summary

Provision Spotlight's clipboard history retention alongside the other macOS defaults in `configure.sh`. 7 days matches how long I actually want to look back; the platform default is 8 hours, which is too short now that Spotlight replaces Pastebot (removed in 1868285) as the clipboard history tool.

## Notes

- `com.apple.Spotlight PasteboardHistoryTimeout` is an undocumented private default (not covered by Apple's public docs). Confirmed on the local host that `defaults read com.apple.Spotlight PasteboardHistoryTimeout` returns `604800` after applying, and that Spotlight's clipboard history observes the new window. Treated as community-sourced knowledge, not an officially documented API.
- The existing "Configuring Pastebot..." block at the end of `configure.sh` is left as-is (out of scope for this PR).
