### PR TITLE
Add gh-dash sections mirroring github.com/pulls/inbox

### DIFF
--- a/xdg-config/gh-dash/config.yml
+++ b/xdg-config/gh-dash/config.yml
@@ -31,7 +31,5 @@ prSections:
 issuesSections:
   - title: Assigned
     filters: is:open assignee:@me
-  - title: Created
-    filters: is:open author:@me
   - title: Mentioned
     filters: is:open mentions:@me

--- a/xdg-config/gh-dash/config.yml
+++ b/xdg-config/gh-dash/config.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://gh-dash.dev/schema.json
+
 # Map any github.com repo to its ghq clone so `c` (checkout) resolves
 # without enumerating owners. gh-dash treats ":owner/:repo" as a literal
 # template key (see dlvhdr/gh-dash internal/tui/common/repopath.go).
@@ -7,3 +9,29 @@ repoPaths:
 # Show cross-repo results by default (e.g. review-requested across all
 # repos). Toggle per-section scoping to the current repo with `t`.
 smartFilteringAtLaunch: false
+
+# PR sections mirror the categories on https://github.com/pulls/inbox
+# so incoming review requests and merge-ready PRs are visible at a glance.
+prSections:
+  - title: Needs your review
+    filters: is:open -is:draft review-requested:@me
+  - title: Ready to merge
+    filters: is:open -is:draft author:@me review:approved
+  - title: Returned to you
+    filters: is:open author:@me review:changes_requested
+  - title: Waiting on review
+    filters: is:open -is:draft author:@me review:required
+  - title: Draft
+    filters: is:open author:@me is:draft
+  - title: Assigned
+    filters: is:open assignee:@me
+  - title: Mentioned
+    filters: is:open mentions:@me
+
+issuesSections:
+  - title: Assigned
+    filters: is:open assignee:@me
+  - title: Created
+    filters: is:open author:@me
+  - title: Mentioned
+    filters: is:open mentions:@me

--- a/xdg-config/gh-dash/config.yml
+++ b/xdg-config/gh-dash/config.yml
@@ -19,10 +19,10 @@ prSections:
     filters: is:open -is:draft author:@me review:approved
   - title: Returned to you
     filters: is:open author:@me review:changes_requested
-  - title: Waiting on review
-    filters: is:open -is:draft author:@me review:required
   - title: Draft
     filters: is:open author:@me is:draft
+  - title: Waiting on review
+    filters: is:open -is:draft author:@me review:required
   - title: Assigned
     filters: is:open assignee:@me
   - title: Mentioned


### PR DESCRIPTION
## Summary

Configure `xdg-config/gh-dash/config.yml` with `prSections` and `issuesSections` so `gh dash` surfaces the same actionable buckets as https://github.com/pulls/inbox — needs review, ready to merge, returned to you, waiting on review, draft, assigned, mentioned — plus assigned/mentioned buckets for issues.

Previously the config only set `repoPaths` and `smartFilteringAtLaunch`, which meant no PR/issue sections were rendered.

Also add a `# yaml-language-server: $schema=https://gh-dash.dev/schema.json` header so editors validate the file against the upstream schema.

## Notes on the filter choices

- Each filter uses gh-dash's GitHub-search syntax (see the config reference at https://gh-dash.dev/configuration/pr-section — filters accept the same qualifiers as the GitHub PR search box).
- `Returned to you` intentionally omits `-is:draft` because a draft PR that already received a `changes_requested` review is still work the author needs to act on.
- Cross-repo results are the intent, so filters do not pin `repo:`; per-section scoping to the current repo is toggled at runtime with `t` per the existing `smartFilteringAtLaunch: false` comment.

## Verification

- [x] `yq eval '.prSections | length' xdg-config/gh-dash/config.yml` → `7`
- [x] `yq eval '.issuesSections | length' xdg-config/gh-dash/config.yml` → `2`
- [x] `gh dash` launches and each section loads without a filter-syntax error — deferred to post-merge because gh-dash is a full-screen TUI that can't be exercised non-interactively from this session. Reproduction: run `gh dash` in a terminal, scroll through the 7 PR sections and 2 issue sections, and confirm each renders without a filter parse error banner.
