### PR TITLE
Enable Spotlight "Results from Clipboard" in configure.sh

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -30,6 +30,7 @@ defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
 defaults write com.apple.menuextra.battery ShowPercent -string "YES"
 defaults write com.apple.Siri HotkeyTag -int 3 # Hold Option Space
 defaults -currentHost write com.apple.Spotlight MenuItemHidden -int 1
+defaults write com.apple.Spotlight PasteboardHistoryEnabled -bool true  # Enable "Results from Clipboard" in Spotlight
 defaults write com.apple.Spotlight PasteboardHistoryTimeout -int 604800  # 7 days
 
 echo "Configuring with sudo..."


### PR DESCRIPTION
## Summary

`scripts/configure.sh` sets `PasteboardHistoryTimeout=604800` (7 days) but never enables the feature, so Spotlight's "Results from Clipboard" stays off on a fresh machine and the timeout has nothing to act on. macOS Tahoe ships this feature disabled by default.

Add `PasteboardHistoryEnabled=true` alongside the timeout so `configure.sh` produces a machine where clipboard history actually shows up in Spotlight.

## Verification

- Key name derived from `_isPasteboardHistoryEnabled` in `/System/Library/ExtensionKit/Extensions/SpotlightPreferenceExtension.appex/Contents/MacOS/SpotlightPreferenceExtension` (matches the naming pattern of the already-working `PasteboardHistoryTimeout`); runtime confirmation on a real Tahoe box still pending — toggle in System Settings > Spotlight after running the script to confirm the checkbox reflects the written value
