### PR TITLE
Trust anthropics/tap for the ant cask in brew bundle

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -11,6 +11,7 @@ tap "configcat/tap", trusted: true
 tap "pipe-cd/tap", trusted: true
 tap "datadog-labs/pack", trusted: true
 tap "jetbrains/junie", trusted: true
+tap "anthropics/tap", trusted: true
 
 brew "mas"
 


### PR DESCRIPTION
## Summary

- `brew bundle` failed with `Refusing to load cask anthropics/tap/ant from untrusted tap anthropics/tap` because 7830a08 added the `anthropics/tap/ant` cask without a matching `tap "anthropics/tap", trusted: true` entry — every other third-party tap in this Brewfile already has one
- Added the missing `trusted: true` tap declaration so `brew bundle install` trusts the tap during its pre-fetch trust-application step (`Homebrew::Bundle::Trust`, applied in `Bundle::Installer#install` before the fetch phase), matching the existing pattern for the other third-party taps

## Verification

- [x] `brew bundle check --verbose` no longer reports the "Refusing to load cask ... from untrusted tap" error (only the expected "needs to be installed or updated" lines remain)
- [x] Read Homebrew's `bundle/installer.rb`, `bundle/trust.rb`, and `bundle/cask.rb` source (Homebrew 6.0.12) confirming `tap "...", trusted: true` is applied via `Homebrew::Bundle::Trust.entries` before the fetch phase that previously errored
- Not run: full `brew bundle install` (would install/upgrade every package in the Brewfile, out of scope for this config fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
