### PR TITLE
Switch the Notification hook sound to Submarine

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -464,17 +464,6 @@
           }
         ]
       }
-    ],
-    "SubagentStop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "if command -v noti >/dev/null; then NOTI_NSUSER_SOUNDNAME=Pop noti --title 'Claude Code' --message 'Subagent done.'; fi"
-          }
-        ]
-      }
     ]
   },
   "statusLine": {

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -445,7 +445,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if command -v noti >/dev/null; then NOTI_NSUSER_SOUNDNAME=Blow noti --title 'Claude Code' --message 'Requires response.'; fi"
+            "command": "if command -v noti >/dev/null; then NOTI_NSUSER_SOUNDNAME=Submarine noti --title 'Claude Code' --message 'Requires response.'; fi"
           }
         ]
       }
@@ -461,6 +461,17 @@
           {
             "type": "command",
             "command": "if command -v noti >/dev/null; then NOTI_NSUSER_SOUNDNAME=Glass noti --title 'Claude Code' --message 'Done! Yay!'; fi"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v noti >/dev/null; then NOTI_NSUSER_SOUNDNAME=Pop noti --title 'Claude Code' --message 'Subagent done.'; fi"
           }
         ]
       }


### PR DESCRIPTION
Refs #148. Successor to #210 (closed), landing what survives of Phase 1 idea A within noti.

## Why

#210 replaced noti with a native notify.sh, partly on the assumption that noti was worth dropping as a dependency. That assumption was re-checked when reviewing the PR queue: noti migrated from GitHub to Codeberg (https://codeberg.org/roble/noti — the brew formula homepage points there) and is actively maintained (commits in 2026-04, latest release 3.8.0). With the dependency argument gone, the audible-distinction goal fits in a settings-only change.

## What

claude/settings.json hooks only. Sound mapping after this PR: Stop = Glass (unchanged), Notification = Submarine (changed, so a waiting permission prompt is audibly distinct from the Stop chime).

## Out of scope (stays in #148)

- SubagentStop hook (idea E): an earlier revision of this branch added it, and because the settings.json symlink makes the checked-out branch live immediately, it got an unplanned live trial in a subagent-heavy session — "Subagent done." fired constantly and carried no actionable information. Dropped; the finding is recorded on #148
- Repo/branch in the notification title (parallel-session disambiguation) — needs a wrapper reading the hook stdin JSON; can be a thin script that ends in a noti call
- Permission/idle content branching within Notification — same wrapper

## Verification

- [x] `jq . claude/settings.json` validates
- [x] `NOTI_NSUSER_SOUNDNAME` is the same mechanism already in use on main; the Submarine variant fired via noti with exit 0 and posted a notification during PR prep (the user heard the test sounds live)
- [x] Live session after merge + deploy: Notification plays Submarine on a permission prompt, audibly distinct from Stop's Glass
