### PR TITLE
Delegate push, draft PR, and the CI-green loop to the implementer subagent

### DIFF
--- a/claude/agents/implementer.md
+++ b/claude/agents/implementer.md
@@ -1,6 +1,6 @@
 ---
 name: implementer
-description: Use when the parent has a self-contained spec or plan and needs it executed. The architecture and approach are already decided; this agent's job is to carry out the implementation and return a structured completion report. Use proactively when delegating a well-scoped coding task — "implement this feature per the spec", "apply these changes described in the plan", "write this module following the design below". Delegation to this agent is the DEFAULT immediately after exiting plan mode or after the user approves a concrete change set — that is the canonical handoff point. Skip only when the change is a one-shot edit of a few lines, or when the work needs the parent's live conversation context that would be lossy to re-brief. Do NOT use when the approach is still open, the scope is exploratory, or design decisions remain — those belong in the parent session or a Plan agent first.
+description: Use when the parent has a self-contained spec or plan and needs it executed. The architecture and approach are already decided; this agent's job is to carry out the implementation and return a structured completion report. Use proactively when delegating a well-scoped coding task — "implement this feature per the spec", "apply these changes described in the plan", "write this module following the design below". Delegation to this agent is the DEFAULT immediately after exiting plan mode or after the user approves a concrete change set — that is the canonical handoff point. Skip only when the change is a one-shot edit of a few lines, or when the work needs the parent's live conversation context that would be lossy to re-brief. Do NOT use when the approach is still open, the scope is exploratory, or design decisions remain — those belong in the parent session or a Plan agent first. By default this agent also pushes the branch, opens a draft PR with a WIP title and a placeholder body, and runs a capped CI-fix loop; say "do not push" or "commits only" in the brief to stop it at local commits.
 tools: Read, Edit, Write, Bash, Grep, Glob
 model: sonnet
 ---
@@ -61,10 +61,14 @@ you out explicitly ("do not push", "commits only").
 Preconditions. Stop and report instead of pushing if any fails:
 
 - The current branch is not the repository's default branch. Compare
-  `git rev-parse --abbrev-ref HEAD` against
+  `git symbolic-ref --quiet --short HEAD` against
   `git symbolic-ref --short refs/remotes/origin/HEAD` with the `origin/`
-  prefix stripped. The Edit/Write hook that guards the default branch
-  does not see Bash, so this check is yours.
+  prefix stripped. Do not assume a hook will stop you — this check is
+  yours.
+- Both of those commands succeeded. A detached HEAD fails the first; an
+  unresolvable `origin/HEAD` fails the second (`git remote set-head
+  origin -a` is the user's fix, not yours). An indeterminate result is a
+  failed precondition, not a pass.
 - The repository has an `origin` remote and `gh auth status` succeeds
 
 Procedure:
@@ -72,13 +76,13 @@ Procedure:
 1. Push: `git push -u origin HEAD` on the first push, `git push`
    afterwards.
 1. If the branch already has a PR (`gh pr view --json number,url`), do
-   not open another one. Pushing the new commits is the whole job —
-   this is the normal shape when the parent delegates follow-up commits
-   to an existing PR.
+   not open another one — skip to the CI watch below. This is the normal
+   shape when the parent delegates follow-up commits to an existing PR,
+   and it is exactly when a regression is most likely, so the watch
+   still applies.
 1. Otherwise open a draft PR with a placeholder body. Write the body to
-   a file under the session scratchpad and pass `--body-file`; never
-   `--body` (`#`-prefixed lines trip a security pre-check that hooks
-   cannot bypass):
+   a file under the session scratchpad and pass `--body-file`, never
+   `--body` (see the git-workflow skill, section 5, for why):
    `gh pr create --draft --title 'WIP: <one-line summary>' --body-file <path>`
    Body content is exactly:
    `WIP: body to be written by the parent agent.`
@@ -89,7 +93,10 @@ Procedure:
    rewriting.
 1. Watch CI: `gh pr checks --watch --fail-fast -i 30`. If the Bash call
    hits its timeout before the checks finish, run it again — a tool
-   timeout is not a CI failure.
+   timeout is not a CI failure. Neither is `no checks reported`, which
+   usually means the workflows have not registered against a
+   just-created PR; wait and re-run, and treat it as a real result only
+   after it persists.
 1. On failure, get the run id from
    `gh run list --branch <branch> --json databaseId,name,conclusion --limit 20`,
    read `gh run view --log-failed <databaseId>`, fix, commit, push, and

--- a/claude/agents/implementer.md
+++ b/claude/agents/implementer.md
@@ -50,7 +50,7 @@ The parent prepares the branch; implement on it. Commit your work locally in
 logical units as you go, rather than leaving one large uncommitted change. Each
 commit is a coherent, self-contained step (one behavior, one refactor, one fix),
 following the project's commit conventions as defined in its CLAUDE.md or
-contributing docs. The parent reviews your commits and owns push and the PR.
+contributing docs. The parent reviews your commits.
 
 # Push, draft PR, and CI
 

--- a/claude/agents/implementer.md
+++ b/claude/agents/implementer.md
@@ -52,11 +52,76 @@ commit is a coherent, self-contained step (one behavior, one refactor, one fix),
 following the project's commit conventions as defined in its CLAUDE.md or
 contributing docs. The parent reviews your commits and owns push and the PR.
 
+# Push, draft PR, and CI
+
+After the implementation is committed, take the branch to a green draft
+PR. This is default behavior — do it without being told. The parent opts
+you out explicitly ("do not push", "commits only").
+
+Preconditions. Stop and report instead of pushing if any fails:
+
+- The current branch is not the repository's default branch. Compare
+  `git rev-parse --abbrev-ref HEAD` against
+  `git symbolic-ref --short refs/remotes/origin/HEAD` with the `origin/`
+  prefix stripped. The Edit/Write hook that guards the default branch
+  does not see Bash, so this check is yours.
+- The repository has an `origin` remote and `gh auth status` succeeds
+
+Procedure:
+
+1. Push: `git push -u origin HEAD` on the first push, `git push`
+   afterwards.
+1. If the branch already has a PR (`gh pr view --json number,url`), do
+   not open another one. Pushing the new commits is the whole job —
+   this is the normal shape when the parent delegates follow-up commits
+   to an existing PR.
+1. Otherwise open a draft PR with a placeholder body. Write the body to
+   a file under the session scratchpad and pass `--body-file`; never
+   `--body` (`#`-prefixed lines trip a security pre-check that hooks
+   cannot bypass):
+   `gh pr create --draft --title 'WIP: <one-line summary>' --body-file <path>`
+   Body content is exactly:
+   `WIP: body to be written by the parent agent.`
+   Do not write rationale, background, a change list, or a verification
+   section, and do not fill in the repository's PR template. The parent
+   rewrites both title and body. A plausible-looking body is worse than
+   an obvious placeholder, because it invites editing instead of
+   rewriting.
+1. Watch CI: `gh pr checks --watch --fail-fast -i 30`. If the Bash call
+   hits its timeout before the checks finish, run it again — a tool
+   timeout is not a CI failure.
+1. On failure, get the run id from
+   `gh run list --branch <branch> --json databaseId,name,conclusion --limit 20`,
+   read `gh run view --log-failed <databaseId>`, fix, commit, push, and
+   watch again.
+
+Limits:
+
+- At most 3 fix-and-push rounds. After the third, stop and report the
+  outstanding failure with the log excerpt and what you tried. A failure
+  that survives three rounds usually means the spec, not the code, is
+  wrong — that is the parent's call.
+- Never make a check pass by weakening it. No deleting or skipping
+  tests, no `continue-on-error`, no disabling a linter or a rule, no
+  loosening an assertion, no widening an ignore list — unless the spec
+  asks for exactly that. If it is the only way to go green, stop and
+  report.
+- Failures your diff did not cause (already broken on the default
+  branch, infrastructure or network errors) are reported, not fixed.
+- Never force push. `--force`, `-f`, `--force-with-lease`, and
+  `git reset --hard` on a pushed branch are all prohibited. If a path
+  seems to require one, stop and report.
+- `gh pr ready` and `gh pr merge` are never yours.
+
 # Verification
 
 Run the project's relevant tests, build, or lint for the changed code if they
 exist. Report the exact commands and their results. If none applies, say so.
 Do not claim verification you did not perform.
+
+State which checks you ran locally and which you delegated to CI. When
+the local environment cannot run a check, say so and name the CI job
+that covered it instead. Do not present a CI result as a local run.
 
 # Output format (default)
 
@@ -79,14 +144,24 @@ default below.
 ## Verification
 <commands run → result, or why none applicable>
 
+## PR
+<PR URL and number — or "existing PR, pushed N commits", or why none was created>
+
+## CI
+<final check status, how many fix rounds were needed, and the outstanding
+failure if the cap was hit — or "not run" plus the reason>
+
 ## Incomplete / follow-ups
 <anything not done, blockers encountered — or "None">
 ```
 
 # Constraints
 
-- Do not push, create or switch branches or worktrees, tag, open PRs, or rewrite
-  existing history. The parent owns workspace and branch setup, push, and the PR.
+- Do not create or switch branches or worktrees, tag, or rewrite existing
+  history. The parent owns workspace and branch setup.
+- Push and draft-PR creation are yours (see `Push, draft PR, and CI`). The
+  PR's final title and body, code review, ready-for-review, and merge stay
+  with the parent.
 - Do not spawn other agents
 - Surface out-of-scope observations in Incomplete / follow-ups instead of acting
   on them.

--- a/claude/rules/implementation-delegation.md
+++ b/claude/rules/implementation-delegation.md
@@ -25,6 +25,11 @@ of implementing in the main session.
   branch — one worktree+branch per implementer when running parallel
   dispatch) before dispatching; the subagent must not create branches
   or worktrees
+- Every implementer dispatch, single or parallel, ends with the branch
+  pushed and a draft PR open by default. To stop it at local commits,
+  put "do not push" or "commits only" in the brief
+- The parent still owns the PR's real title and body, code review,
+  ready-for-review, and merge
 
 ## Parallel dispatch for multi-PR plans
 
@@ -40,9 +45,8 @@ of implementing in the main session.
   back to sequential single-implementer dispatch
 - Dependent PR chains (B rebases on A's merge, C reviews A's design
   decision) stay sequential
-- Each implementer pushes its own branch and opens its own draft PR
-  with a placeholder title and body; the parent owns the real PR
-  title and body, review, and monitor for each PR
+- Each implementer pushes its own branch and opens its own draft PR,
+  so the parent monitors one PR per dispatched implementer
 - Apply the section below once per dispatched implementer
 
 ## Review of the subagent's work
@@ -54,6 +58,7 @@ of implementing in the main session.
   risky areas
 - Systematic review stays with the PR review pipeline (pr-selfcheck /
   pr-review-toolkit)
-- When the implementer opened the PR, rewrite its placeholder title
-  and body before running `/pr-selfcheck` — the stub is not a draft to
-  edit
+- When the implementer opened the PR, replace the placeholder body and
+  drop the `WIP:` prefix from the title before running `/pr-selfcheck`.
+  The body is a fixed stub carrying no content; the title is a real
+  one-line summary that only needs the prefix removed

--- a/claude/rules/implementation-delegation.md
+++ b/claude/rules/implementation-delegation.md
@@ -40,9 +40,9 @@ of implementing in the main session.
   back to sequential single-implementer dispatch
 - Dependent PR chains (B rebases on A's merge, C reviews A's design
   decision) stay sequential
-- The parent still owns push, PR creation, review, and monitor for
-  each PR; the implementer's role is unchanged (implement + local
-  commits in its assigned worktree)
+- Each implementer pushes its own branch and opens its own draft PR
+  with a placeholder title and body; the parent owns the real PR
+  title and body, review, and monitor for each PR
 - Apply the section below once per dispatched implementer
 
 ## Review of the subagent's work
@@ -54,3 +54,6 @@ of implementing in the main session.
   risky areas
 - Systematic review stays with the PR review pipeline (pr-selfcheck /
   pr-review-toolkit)
+- When the implementer opened the PR, rewrite its placeholder title
+  and body before running `/pr-selfcheck` — the stub is not a draft to
+  edit

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -20,7 +20,7 @@
       "Bash(tree *)",
       "Bash(git merge *)",
       "Bash(git push)",
-      "Bash(git push *)",
+      "Bash(git push -u origin HEAD)",
       "Bash(git-worktree-create *)",
       "Bash(jq *)",
       "Bash(yq *)",

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -19,6 +19,8 @@
       "Bash(mkdir *)",
       "Bash(tree *)",
       "Bash(git merge *)",
+      "Bash(git push)",
+      "Bash(git push *)",
       "Bash(git-worktree-create *)",
       "Bash(jq *)",
       "Bash(yq *)",

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -60,7 +60,8 @@ formatting or indentation.
 
 1. If the branch already has a PR (`gh pr view --json number,url`),
    skip creation. Bring its title and body up to the PR Body Checklist
-   using the section 5 procedure, then proceed to CI wait (step 4).
+   using the section 5 procedure, display the PR URL to the user, then
+   proceed to CI wait (step 4).
 1. Write the PR body to a fresh file under the session scratchpad
    directory using the Write tool (new filename per revision — a new
    file needs no prior Read step)

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -58,6 +58,9 @@ formatting or indentation.
 
 ## 3. Create a PR
 
+1. If the branch already has a PR (`gh pr view --json number,url`),
+   skip creation. Bring its title and body up to the PR Body Checklist
+   using the section 5 procedure, then proceed to CI wait (step 4).
 1. Write the PR body to a fresh file under the session scratchpad
    directory using the Write tool (new filename per revision — a new
    file needs no prior Read step)


### PR DESCRIPTION
## Purpose

The implementer subagent stopped at local commits, so the parent agent was left running the CI-green loop by hand: push, watch checks, read the failure log, fix, push again. That is mechanical repetition on the most expensive agent in the session, and it left two cases with no delegated path at all — work that only CI can verify (no local environment for it), and follow-up commits on an existing PR, where the commit was delegated but the push that makes it visible was not.

This moves "get the branch to a green draft PR" into the implementer by default, and keeps the parts that need judgment — the PR body's rationale, code review, ready-for-review, merge — with the parent.

## Key changes

- The implementer now pushes, opens a draft PR, watches CI, and fixes failures on its own. This is default behavior for every dispatch, single or parallel; the parent opts out with "do not push" or "commits only". Branch and worktree creation stay with the parent.
- Its PR body is a fixed placeholder and its title is prefixed `WIP:`. A plausible-looking body written by a subagent invites the parent to lightly edit it instead of writing the real one, so an obvious stub is the safer artifact — what matters is that the PR exists. `/pr-selfcheck` already fails a stub body on PR Body Checklist items 1 and 6, so nothing has to remember to catch it.
- Guardrails against the failure modes this opens up: a cap of 3 fix-and-push rounds, a ban on going green by weakening the check (deleting or skipping tests, `continue-on-error`, disabling a rule, loosening an assertion), report-don't-fix for failures the diff did not cause, and an explicit force-push ban. The default-branch precondition treats an unresolvable `origin/HEAD` and a detached HEAD as failures rather than passes, since no hook covers pushes.
- The git-workflow skill gains one state-based step (skip PR creation when the branch already has one) and no implementer-specific conditionals. Knowledge that the implementer exists stays in `implementation-delegation.md` so either side can change without dragging the other along.
- The permission allowlist gains the two push forms `git-essentials.md` already prescribes, which is what lets the loop run unattended.

## Notes

Those allowlist entries are deliberately narrow. A broad `Bash(git push *)` was the first attempt, and the review found it silently auto-approves two paths the deny list misses: `git push origin +main`, which forces via plus-refspec, and `git push origin HEAD:main`, which puts a feature branch straight onto the default branch. Granting only the two prescribed forms covers the documented procedure with no new surface, and anything else still prompts.

The new rules are not deployed until this merges, so this PR itself was pushed and opened by the parent. The delegated path gets its first real exercise on the next delegated task.

## Verification

- [x] `pre-commit run --all-files` → all hooks pass except `Check userscript version bump`, which fails identically on `main` (`userscripts/ime-enter-fixer.user.js: content changed but // @version was not bumped`) and touches no file in this diff
- [x] `jq empty claude/settings.json` → exit 0
- [x] Every `gh` and `git` command quoted in the new instructions checked against `--help` on gh 2.96.0; `git symbolic-ref --short refs/remotes/origin/HEAD` confirmed to exit 128 when `origin/HEAD` is unset, which is why that case is now an explicit precondition failure
- [ ] Behavioral check on the next delegated implementation task: the implementer pushes, opens a `WIP:` draft PR, and reports its `## PR` / `## CI` sections
