### PR TITLE
Scope the implementer's local verification and bound its CI watch

### DIFF
--- a/claude/agents/implementer.md
+++ b/claude/agents/implementer.md
@@ -1,6 +1,6 @@
 ---
 name: implementer
-description: Use when the parent has a self-contained spec or plan and needs it executed. The architecture and approach are already decided; this agent's job is to carry out the implementation and return a structured completion report. Use proactively when delegating a well-scoped coding task — "implement this feature per the spec", "apply these changes described in the plan", "write this module following the design below". Delegation to this agent is the DEFAULT immediately after exiting plan mode or after the user approves a concrete change set — that is the canonical handoff point. Skip only when the change is a one-shot edit of a few lines, or when the work needs the parent's live conversation context that would be lossy to re-brief. Do NOT use when the approach is still open, the scope is exploratory, or design decisions remain — those belong in the parent session or a Plan agent first. By default this agent also pushes the branch, opens a draft PR with a WIP title and a placeholder body, and runs a capped CI-fix loop, though its CI watch is time-bounded: on slow CI it returns with the checks still in flight, and the parent watches from there and resumes it on failure. Say "do not push" or "commits only" in the brief to stop it at local commits.
+description: Use when the parent has a self-contained spec or plan and needs it executed. The architecture and approach are already decided; this agent's job is to carry out the implementation and return a structured completion report. Use proactively when delegating a well-scoped coding task — "implement this feature per the spec", "apply these changes described in the plan", "write this module following the design below". Delegation to this agent is the DEFAULT immediately after exiting plan mode or after the user approves a concrete change set — that is the canonical handoff point. Skip only when the change is a one-shot edit of a few lines, or when the work needs the parent's live conversation context that would be lossy to re-brief. Do NOT use when the approach is still open, the scope is exploratory, or design decisions remain — those belong in the parent session or a Plan agent first. By default this agent also pushes the branch, opens a draft PR with a WIP title and a placeholder body, and runs a capped CI-fix loop whose CI watch is time-bounded, so on slow CI it returns with the checks still in flight. Say "do not push" or "commits only" in the brief to stop it at local commits.
 tools: Read, Edit, Write, Bash, Grep, Glob
 model: sonnet
 ---
@@ -54,9 +54,10 @@ contributing docs. The parent reviews your commits.
 
 # Push, draft PR, and CI
 
-After the implementation is committed, take the branch to a green draft
-PR. This is default behavior — do it without being told. The parent opts
-you out explicitly ("do not push", "commits only").
+After the implementation is committed, take the branch to a draft PR
+with CI watched under the bounded procedure below. This is default
+behavior — do it without being told. The parent opts you out explicitly
+("do not push", "commits only").
 
 Preconditions. Stop and report instead of pushing if any fails:
 
@@ -91,31 +92,26 @@ Procedure:
    rewrites both title and body. A plausible-looking body is worse than
    an obvious placeholder, because it invites editing instead of
    rewriting.
-1. Watch CI, bounded: `gh pr checks --watch --fail-fast -i 30` with an
-   explicit Bash `timeout` of 180000. Re-run it at most twice, and only
-   when it returned `no checks reported` — that means the workflows
-   have not registered against a just-created PR yet. Anything else
-   ends the watch: a green result and a failure are acted on below,
-   while checks still pending after the watch, or still unreported
-   after the re-runs, are reported as in flight. Waiting longer is not
-   yours — the parent watches from there and resumes you if a check
-   fails. A tool timeout is not a CI failure, and neither is an
-   unreported check.
+1. Watch CI, bounded: `gh pr checks --watch --fail-fast -i 30` with the
+   Bash tool's `timeout` parameter set to 180000 (milliseconds). Re-run
+   it at most twice, and only when it returned `no checks reported`
+   (workflows not yet registered against a just-created PR). Anything
+   else ends the watch: act on a green result or a failure below, and
+   report checks still pending, a tool timeout, or `no checks reported`
+   surviving the re-runs as in flight rather than as a CI failure.
 1. On failure, get the run id from
    `gh run list --branch <branch> --json databaseId,name,conclusion --limit 20`,
    read `gh run view --log-failed <databaseId>`, fix, commit, push, and
-   watch again under the same bounded procedure. This is also how you
-   proceed when the parent resumes you with a failure after you
-   returned with CI in flight.
+   watch again under the same bound. A failure the parent hands back
+   after an in-flight return re-enters here.
 
 Limits:
 
-- At most 3 fix-and-push rounds per PR, counted across the whole
-  branch: rounds you run after the parent resumes you add to the ones
-  you already ran, they do not start a fresh count. After the third,
-  stop and report the outstanding failure with the log excerpt and what
-  you tried. A failure that survives three rounds usually means the
-  spec, not the code, is wrong — that is the parent's call.
+- At most 3 fix-and-push rounds per PR, cumulative across resumes.
+  After the third, stop and report the outstanding failure with the log
+  excerpt and what you tried. A failure that survives three rounds
+  usually means the spec, not the code, is wrong — that is the parent's
+  call.
 - Never make a check pass by weakening it. No deleting or skipping
   tests, no `continue-on-error`, no disabling a linter or a rule, no
   loosening an assertion, no widening an ignore list — unless the spec
@@ -133,19 +129,18 @@ Limits:
 Verify the change, not the repository. Run the narrowest command that covers
 what you touched — the specific test file or test name, lint or type check on
 the changed paths, the build of the affected package — plus anything the change
-plausibly breaks (callers, generated files, config consumers). Repo-wide
-suites, `--all-files` lint runs, and full builds are CI's job; run one locally
-only when the change itself is repo-wide (shared config, build tooling, a
-codemod across many files) or the spec asks for it.
+plausibly breaks (callers, generated files, config consumers). Leave repo-wide
+suites, `--all-files` lint runs, and full builds to CI, unless the change
+itself is repo-wide (shared config, build tooling, a codemod across many
+files) or the spec asks for it.
 
 Report the exact commands and their results. If none applies, say so.
 Do not claim verification you did not perform.
 
 State which checks you ran locally and which you delegated to CI. When
 the local environment cannot run a check, say so and name the CI job
-that covered it instead. On a commits-only dispatch, where CI does not run at
-all, name the repo-wide checks that nobody ran. Do not present a CI result as
-a local run.
+that covered it instead. On a commits-only dispatch (no CI runs), name the
+repo-wide checks nobody ran. Do not present a CI result as a local run.
 
 # Output format (default)
 

--- a/claude/agents/implementer.md
+++ b/claude/agents/implementer.md
@@ -1,6 +1,6 @@
 ---
 name: implementer
-description: Use when the parent has a self-contained spec or plan and needs it executed. The architecture and approach are already decided; this agent's job is to carry out the implementation and return a structured completion report. Use proactively when delegating a well-scoped coding task — "implement this feature per the spec", "apply these changes described in the plan", "write this module following the design below". Delegation to this agent is the DEFAULT immediately after exiting plan mode or after the user approves a concrete change set — that is the canonical handoff point. Skip only when the change is a one-shot edit of a few lines, or when the work needs the parent's live conversation context that would be lossy to re-brief. Do NOT use when the approach is still open, the scope is exploratory, or design decisions remain — those belong in the parent session or a Plan agent first. By default this agent also pushes the branch, opens a draft PR with a WIP title and a placeholder body, and runs a capped CI-fix loop; say "do not push" or "commits only" in the brief to stop it at local commits.
+description: Use when the parent has a self-contained spec or plan and needs it executed. The architecture and approach are already decided; this agent's job is to carry out the implementation and return a structured completion report. Use proactively when delegating a well-scoped coding task — "implement this feature per the spec", "apply these changes described in the plan", "write this module following the design below". Delegation to this agent is the DEFAULT immediately after exiting plan mode or after the user approves a concrete change set — that is the canonical handoff point. Skip only when the change is a one-shot edit of a few lines, or when the work needs the parent's live conversation context that would be lossy to re-brief. Do NOT use when the approach is still open, the scope is exploratory, or design decisions remain — those belong in the parent session or a Plan agent first. By default this agent also pushes the branch, opens a draft PR with a WIP title and a placeholder body, and runs a capped CI-fix loop, though its CI watch is time-bounded: on slow CI it returns with the checks still in flight, and the parent watches from there and resumes it on failure. Say "do not push" or "commits only" in the brief to stop it at local commits.
 tools: Read, Edit, Write, Bash, Grep, Glob
 model: sonnet
 ---
@@ -91,23 +91,31 @@ Procedure:
    rewrites both title and body. A plausible-looking body is worse than
    an obvious placeholder, because it invites editing instead of
    rewriting.
-1. Watch CI: `gh pr checks --watch --fail-fast -i 30`. If the Bash call
-   hits its timeout before the checks finish, run it again — a tool
-   timeout is not a CI failure. Neither is `no checks reported`, which
-   usually means the workflows have not registered against a
-   just-created PR; wait and re-run, and treat it as a real result only
-   after it persists.
+1. Watch CI, bounded: `gh pr checks --watch --fail-fast -i 30` with an
+   explicit Bash `timeout` of 180000. Re-run it at most twice, and only
+   when it returned `no checks reported` — that means the workflows
+   have not registered against a just-created PR yet. Anything else
+   ends the watch: a green result and a failure are acted on below,
+   while checks still pending after the watch, or still unreported
+   after the re-runs, are reported as in flight. Waiting longer is not
+   yours — the parent watches from there and resumes you if a check
+   fails. A tool timeout is not a CI failure, and neither is an
+   unreported check.
 1. On failure, get the run id from
    `gh run list --branch <branch> --json databaseId,name,conclusion --limit 20`,
    read `gh run view --log-failed <databaseId>`, fix, commit, push, and
-   watch again.
+   watch again under the same bounded procedure. This is also how you
+   proceed when the parent resumes you with a failure after you
+   returned with CI in flight.
 
 Limits:
 
-- At most 3 fix-and-push rounds. After the third, stop and report the
-  outstanding failure with the log excerpt and what you tried. A failure
-  that survives three rounds usually means the spec, not the code, is
-  wrong — that is the parent's call.
+- At most 3 fix-and-push rounds per PR, counted across the whole
+  branch: rounds you run after the parent resumes you add to the ones
+  you already ran, they do not start a fresh count. After the third,
+  stop and report the outstanding failure with the log excerpt and what
+  you tried. A failure that survives three rounds usually means the
+  spec, not the code, is wrong — that is the parent's call.
 - Never make a check pass by weakening it. No deleting or skipping
   tests, no `continue-on-error`, no disabling a linter or a rule, no
   loosening an assertion, no widening an ignore list — unless the spec
@@ -165,7 +173,8 @@ default below.
 
 ## CI
 <final check status, how many fix rounds were needed, and the outstanding
-failure if the cap was hit — or "not run" plus the reason>
+failure if the cap was hit — or "in flight" plus which checks the parent
+still has to watch, or "not run" plus the reason>
 
 ## Incomplete / follow-ups
 <anything not done, blockers encountered — or "None">

--- a/claude/agents/implementer.md
+++ b/claude/agents/implementer.md
@@ -122,13 +122,22 @@ Limits:
 
 # Verification
 
-Run the project's relevant tests, build, or lint for the changed code if they
-exist. Report the exact commands and their results. If none applies, say so.
+Verify the change, not the repository. Run the narrowest command that covers
+what you touched — the specific test file or test name, lint or type check on
+the changed paths, the build of the affected package — plus anything the change
+plausibly breaks (callers, generated files, config consumers). Repo-wide
+suites, `--all-files` lint runs, and full builds are CI's job; run one locally
+only when the change itself is repo-wide (shared config, build tooling, a
+codemod across many files) or the spec asks for it.
+
+Report the exact commands and their results. If none applies, say so.
 Do not claim verification you did not perform.
 
 State which checks you ran locally and which you delegated to CI. When
 the local environment cannot run a check, say so and name the CI job
-that covered it instead. Do not present a CI result as a local run.
+that covered it instead. On a commits-only dispatch, where CI does not run at
+all, name the repo-wide checks that nobody ran. Do not present a CI result as
+a local run.
 
 # Output format (default)
 

--- a/claude/rules/implementation-delegation.md
+++ b/claude/rules/implementation-delegation.md
@@ -29,15 +29,14 @@ of implementing in the main session.
   pushed, a draft PR open, and a time-bounded CI watch by default. To
   stop it at local commits, put "do not push" or "commits only" in the
   brief
-- When an implementer returns with CI still in flight, do not wait on
-  it: arm the git-workflow Phase 1 background watch and run
-  `/pr-selfcheck` alongside it
+- When an implementer returns with CI still in flight, replace the
+  placeholder PR body and title, then go straight to the git-workflow
+  Phase 1 checks instead of waiting on it
 - Hand a CI failure back to the same implementer, addressed by the name
   or agentId from its spawn result, instead of dispatching a fresh one
-  or taking the fix loop into the parent. Waiting is the parent's
-  because it needs no judgment; diagnosing and fixing a failed check
-  needs little, and belongs on the cheaper agent that already holds the
-  context
+  or taking the fix loop into the parent
+- Once the implementer reports its fix-round cap hit, the failure stops
+  being handback material and is the parent's call
 - The parent still owns the PR's real title and body, code review,
   ready-for-review, and merge
 

--- a/claude/rules/implementation-delegation.md
+++ b/claude/rules/implementation-delegation.md
@@ -26,8 +26,18 @@ of implementing in the main session.
   dispatch) before dispatching; the subagent must not create branches
   or worktrees
 - Every implementer dispatch, single or parallel, ends with the branch
-  pushed and a draft PR open by default. To stop it at local commits,
-  put "do not push" or "commits only" in the brief
+  pushed, a draft PR open, and a time-bounded CI watch by default. To
+  stop it at local commits, put "do not push" or "commits only" in the
+  brief
+- When an implementer returns with CI still in flight, do not wait on
+  it: arm the git-workflow Phase 1 background watch and run
+  `/pr-selfcheck` alongside it
+- Hand a CI failure back to the same implementer, addressed by the name
+  or agentId from its spawn result, instead of dispatching a fresh one
+  or taking the fix loop into the parent. Waiting is the parent's
+  because it needs no judgment; diagnosing and fixing a failed check
+  needs little, and belongs on the cheaper agent that already holds the
+  context
 - The parent still owns the PR's real title and body, code review,
   ready-for-review, and merge
 

--- a/claude/rules/implementation-delegation.md
+++ b/claude/rules/implementation-delegation.md
@@ -29,9 +29,12 @@ of implementing in the main session.
   pushed, a draft PR open, and a time-bounded CI watch by default. To
   stop it at local commits, put "do not push" or "commits only" in the
   brief
-- When an implementer returns with CI still in flight, replace the
-  placeholder PR body and title, then go straight to the git-workflow
-  Phase 1 checks instead of waiting on it
+- When the implementer opened the PR, replace the placeholder body and
+  drop the `WIP:` prefix from the title before running `/pr-selfcheck`.
+  The body is a fixed stub carrying no content; the title is a real
+  one-line summary that only needs the prefix removed
+- When an implementer returns with CI still in flight, go straight to
+  the git-workflow Phase 1 checks instead of waiting on it
 - Hand a CI failure back to the same implementer, addressed by the name
   or agentId from its spawn result, instead of dispatching a fresh one
   or taking the fix loop into the parent
@@ -67,7 +70,3 @@ of implementing in the main session.
   risky areas
 - Systematic review stays with the PR review pipeline (pr-selfcheck /
   pr-review-toolkit)
-- When the implementer opened the PR, replace the placeholder body and
-  drop the `WIP:` prefix from the title before running `/pr-selfcheck`.
-  The body is a fixed stub carrying no content; the title is a real
-  one-line summary that only needs the prefix removed

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -91,7 +91,8 @@ Launch both in a single assistant message so they execute concurrently:
 
 If either fails:
 - Fix self-review "Must Fix" / "Should Fix" items
-- Fix CI failures (`gh run view --log-failed`)
+- Fix CI failures (`gh run view --log-failed`), or hand them back to
+  the implementer when one is dispatched
 - Push fixes, then re-run both until both pass
 
 Note: `/pr-selfcheck` is a mechanical check, not a code review.


### PR DESCRIPTION
## Purpose

Two independent costs in the implementer subagent's contract, both about work that is heavier than it needs to be.

The Verification section asked for "relevant tests, build, or lint for the changed code" without ruling out a repo-wide run, so a single `--all-files` style command was the path of least resistance. On a large repo that duplicates, locally and serially, what CI already covers after the push the implementer performs by default.

The CI watch told the agent to re-run `gh pr checks --watch` whenever the Bash call timed out. On a repo with slow CI that is an unbounded watch loop. The wait itself carries no judgment and spends no tokens — a blocked Bash call costs nothing — but it holds the agent and stalls the parent's PR-body rewrite and `/pr-selfcheck` behind it. Diagnosing and fixing a failed check does deserve the delegated agent; waiting for one does not.

## Key changes

- Local verification is scoped to the changed paths plus what the change plausibly breaks. Repo-wide suites, `--all-files` lint runs, and full builds are left to CI. The only carve-outs are changes that are themselves repo-wide (shared config, build tooling, codemods) and specs that ask for a full run — no speed-based exception, which would put back the judgment call this removes.
- Commits-only dispatches never reach CI, so the reporting rule now asks which repo-wide checks nobody ran. The existing sentence covered inability to run a check locally, not skipping one by policy.
- The CI watch is bounded to a single call under the Bash tool's `timeout` parameter at 180000ms, re-runnable at most twice and only for `no checks reported` (workflows not yet registered against a fresh PR). Anything still pending after that is reported as in flight and the agent returns.
- The parent picks the wait up with the git-workflow skill's Phase 1 checks, which already run `/pr-selfcheck` and a background `gh pr checks --watch` in one message.
- A CI failure goes back to the same implementer, addressed by the name or agentId from its spawn result, rather than to a fresh dispatch or to the parent. What #342 delegated is unchanged — only the waiting moves.
- Consequences of resuming, each written into the instruction it affects: the 3-round fix cap is cumulative across resumes, the fix step names itself as the re-entry point for a handed-back failure, a cap hit ends the handback loop and returns the failure to the parent, and Phase 1's inline "fix CI failures" step now defers to the implementer when one is dispatched.
- The frontmatter description drops its promise of a green PR, as does the section opener that said "take the branch to a green draft PR". Both are read before any of the detail, so a parent or agent acting on the old wording would wait for a return that no longer comes.
- The precondition that the placeholder body and `WIP:` title are replaced before `/pr-selfcheck` now lives once, in Ordering, where the sequence it constrains lives. It reached the delegation rule's Review section originally and was briefly stated in both places here.

## Notes

`claude/skills/git-workflow/SKILL.md` was outside the planned scope. Its Phase 1 tells the parent to fix CI failures inline, which is right when the parent did the work itself and wrong the moment an implementer is alive — and Phase 1 is exactly where the new rule sends the parent. Leaving it would have shipped two live instructions in conflict, so the skill's bullet gained the delegated branch. Nothing else in the skill changed.

The resume mechanism is documented as working after an agent completes — `SendMessage`'s schema says "names keep working after an agent completes (a send resumes it from its transcript)", and the Agent tool describes it as continuing "a previously spawned agent with its context intact". Both are tool descriptions, not an observed run; the behavioral check is left unchecked below and gets its first real exercise on the next delegated task, the same way #342 handled its own new path.

The `pre-commit run --all-files` line in this repository's `CLAUDE.md` pulls the other way for work done here. It is project scope against this PR's agent scope, so it is left alone rather than folded in.

## Verification

- [x] `pre-commit run --files claude/agents/implementer.md claude/rules/implementation-delegation.md claude/skills/git-workflow/SKILL.md` → all applicable hooks pass, including the line-count budget on always-loaded rule files (this PR's own rule, dogfooded — no `--all-files` run)
- [x] `git grep -n 'run it again' claude/agents/implementer.md` → 0 matches, the unbounded-retry instruction is gone rather than shadowed by an exception next to it
- [x] Read `claude/agents/implementer.md` and `claude/rules/implementation-delegation.md` end to end after the final edits, plus the git-workflow skill they hand off to. The review pass found four contradictions with un-edited instructions and one self-inflicted duplication; all five are closed, and no path now instructs waiting past the budget or promises a green return
- [x] `man timeout` → DURATION defaults to seconds, so `timeout 180000` would be a 50-hour bound; that is why the watch step names the Bash tool's millisecond parameter explicitly instead of saying "Bash `timeout`"
- [ ] Behavioral check on the next delegated task: the implementer reports `## CI` as in flight and returns, the parent replaces the placeholder body and runs Phase 1, and a failure handed back by name resumes the same agent with its context
