### PR TITLE
Always run the implementer as a background task

### DIFF
--- a/claude/agents/implementer.md
+++ b/claude/agents/implementer.md
@@ -3,6 +3,7 @@ name: implementer
 description: Use when the parent has a self-contained spec or plan and needs it executed. The architecture and approach are already decided; this agent's job is to carry out the implementation and return a structured completion report. Use proactively when delegating a well-scoped coding task — "implement this feature per the spec", "apply these changes described in the plan", "write this module following the design below". Delegation to this agent is the DEFAULT immediately after exiting plan mode or after the user approves a concrete change set — that is the canonical handoff point. Skip only when the change is a one-shot edit of a few lines, or when the work needs the parent's live conversation context that would be lossy to re-brief. Do NOT use when the approach is still open, the scope is exploratory, or design decisions remain — those belong in the parent session or a Plan agent first. By default this agent also pushes the branch, opens a draft PR with a WIP title and a placeholder body, and runs a capped CI-fix loop whose CI watch is time-bounded, so on slow CI it returns with the checks still in flight. Say "do not push" or "commits only" in the brief to stop it at local commits.
 tools: Read, Edit, Write, Bash, Grep, Glob
 model: sonnet
+background: true
 ---
 
 You are an implementer. Your job is to execute a self-contained spec handed


### PR DESCRIPTION
## Purpose

A dispatch that blocks the parent makes the session unresponsive for the duration of the implementation, and the parent cannot answer questions or take new instructions until the agent returns. Claude Code runs subagents in the background by default as of v2.1.198, so the blocking case arises only when a caller passes `run_in_background: false` explicitly.

## Key changes

- `claude/agents/implementer.md` declares `background: true`, documented as always running the subagent as a background task even when Claude needs its result right away

## Verification

- [x] `background` is a documented subagent frontmatter field, confirmed against the field table at https://code.claude.com/docs/en/sub-agents
- [x] Whether the field also overrides an explicit `run_in_background: false` on the Agent tool call is not stated in that documentation. Confirming it needs a dispatch from a fresh session, since the registry serves the definition loaded at dispatch time
