### PR TITLE
Skip userscripts whose body matches HEAD in the version-bump check

### DIFF
--- a/scripts/check_userscript_version.sh
+++ b/scripts/check_userscript_version.sh
@@ -18,6 +18,9 @@ for file in "$@"; do
   fi
 
   if git cat-file -e "HEAD:$file" 2>/dev/null; then
+    if git diff --quiet HEAD -- "$file"; then
+      continue
+    fi
     head_version=$(git show "HEAD:$file" | grep -m1 '^// @version' || true)
     if [ "$head_version" = "$work_version" ]; then
       echo "$file: content changed but // @version was not bumped"


### PR DESCRIPTION
## Purpose

`pre-commit run --all-files`, which `CLAUDE.md` documents under Key Commands, could not pass. The hook inferred that a file had changed from the fact that it was handed the path, and only ever compared `// @version` lines. That premise holds when `git commit` passes staged paths, and breaks under `--all-files`, where every unmodified userscript reports `content changed but // @version was not bumped` — a message that contradicts the state it describes.

## Key changes

- `scripts/check_userscript_version.sh` measures whether the body differs from `HEAD` before comparing versions, and skips a file that matches

## Verification

- [x] `pre-commit run --all-files` passes end to end, all nine hooks green, on a tree where it previously failed at `Check userscript version bump`
- [x] Behavior confirmed on a purpose-built git fixture, covering the case the fix targets and the three it must not break

  | Case | Expected | Result |
  | --- | --- | --- |
  | Unmodified file | pass | exit 0 |
  | Body changed, version unchanged | fail | exit 1, `content changed but // @version was not bumped` |
  | Body changed, version bumped | pass | exit 0 |
  | New file with no `// @version` line | fail | exit 1, `missing // @version line` |

CI never exercised this hook: `.github/workflows/ci.yml` runs `shellcheck` and `python-doctest` only, and no workflow invokes `pre-commit`. The failure was reachable only from a local `--all-files` run.
