### PR TITLE
Steer subagents away from the advisor tool

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -343,6 +343,16 @@
     "defaultMode": "auto"
   },
   "hooks": {
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SubagentStart\",\"additionalContext\":\"Advisor policy: do not call the advisor tool in this subagent unless your agent definition or task brief explicitly permits it. When blocked or genuinely uncertain, return early and report to the parent instead — the parent holds the advisor and the wider context needed to resolve it.\"}}'"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary

Adds a matcher-less `SubagentStart` hook that tells every spawned subagent not to call the advisor tool. The main session's advisor is untouched.

## Why

`advisorModel` is `fable`, and Claude Code attaches the configured advisor to a subagent whenever the subagent's own model satisfies the pairing check ([docs](https://code.claude.com/docs/en/advisor#choose-an-advisor-model): "Subagents inherit the configured advisor and apply the same pairing check against their own model"). Sonnet 5, Opus 5, and Opus 4.7 all accept a Fable advisor, so every subagent here gets one.

Across all transcripts under `~/.claude/projects/`, subagents account for 51 of 71 advisor calls (≈72%) and for ≈74% of the total advisor wall-clock, measured as the gap between each `server_tool_use` named `advisor` and its `advisor_tool_result`.

Value is lowest there: a subagent executes a spec the parent already decided, so the decision points the advisor targets sit in the main session.

## Approach

The advisor is server-executed. It appears in transcripts as `server_tool_use` and is absent from the [tools reference](https://code.claude.com/docs/en/tools-reference), whose names are the identifiers used in "permission rules, subagent tool lists, and hook matchers" — so `tools`, `disallowedTools`, `permissions.deny`, and `PreToolUse` matchers have nothing to bind to. `claude/agents/implementer.md` restricts `tools` to six entries and still records advisor calls.

Instructions are the only per-agent lever the docs leave: "There is no setting to cap or force advisor calls; if you want Claude to consult more or less often during a task, say so in your instructions." The alternative, `CLAUDE_CODE_DISABLE_ADVISOR_TOOL=1` or an unset `advisorModel`, is global and takes the main session's advisor with it.

A `SubagentStart` hook in `settings.json` delivers those instructions everywhere this repository needs them:

- `settings.json` hooks reach built-in, custom, and plugin subagents; plugin subagents ignore the `hooks` frontmatter field, so `pr-review-toolkit:*` is addressable only from here
- The event fires on subagent spawn, leaving the main session's Fable advisor in place
- Omitting `matcher` matches every agent type, which also sidesteps how a plugin-scoped `agent_type` is spelled
- The `unless your agent definition or task brief explicitly permits it` clause lets a caller re-enable the advisor for a single dispatch

`claude/agents/implementer.md` and `claude/agents/narrative-sweeper.md` fall under this hook, so no per-agent copy of the policy is added.

## Limitations

The harness injects an advisor tool description instructing every agent that holds it to consult before substantive work and before declaring a task complete. This hook competes with that instruction rather than overriding it: a nudge, not a gate. A hard block is not available for a server-side tool.

## Verification

- `jq -e '.hooks.SubagentStart' claude/settings.json` exits 0
- The hook command piped through `bash`, then `jq -e '.hookSpecificOutput.additionalContext'`, returns `"Advisor policy: do not call the advisor tool in this subagent unless your agent definition or task brief explicitly permits it. When blocked or genuinely uncertain, return early and report to the parent instead — the parent holds the advisor and the wider context needed to resolve it."`
- [x] `~/.claude/settings.json` symlinks to the tracked file, so the hook took effect on checkout without a deploy: each of the 5 subagents spawned afterwards carries the policy text in `~/.claude/projects/*/*/subagents/agent-*.jsonl` and records 0 `"name":"advisor"` blocks
- [x] Sample of 5 is too small to compare against the 51/71 baseline; re-run the call count after a week of normal use
