### PR TITLE
Include draft PRs in the gh-dash review-requested section

### DIFF
--- a/xdg-config/gh-dash/config.yml
+++ b/xdg-config/gh-dash/config.yml
@@ -12,11 +12,9 @@ smartFilteringAtLaunch: false
 
 # PR sections follow the categories on https://github.com/pulls/inbox
 # so incoming review requests and merge-ready PRs are visible at a glance.
-# "Needs your review" covers drafts too: GitHub requests code owners only
-# when a PR is marked ready for review, so a review request sitting on a
-# draft is always a deliberate ask from a human. gh-dash marks those rows
-# with its own draft icon.
 prSections:
+  # Drafts are included: GitHub auto-requests code owners only at
+  # ready-for-review, so a review request on a draft is a deliberate ask.
   - title: Needs your review
     filters: is:open review-requested:@me
   - title: Ready to merge

--- a/xdg-config/gh-dash/config.yml
+++ b/xdg-config/gh-dash/config.yml
@@ -10,11 +10,15 @@ repoPaths:
 # repos). Toggle per-section scoping to the current repo with `t`.
 smartFilteringAtLaunch: false
 
-# PR sections mirror the categories on https://github.com/pulls/inbox
+# PR sections follow the categories on https://github.com/pulls/inbox
 # so incoming review requests and merge-ready PRs are visible at a glance.
+# "Needs your review" covers drafts too: GitHub requests code owners only
+# when a PR is marked ready for review, so a review request sitting on a
+# draft is always a deliberate ask from a human. gh-dash marks those rows
+# with its own draft icon.
 prSections:
   - title: Needs your review
-    filters: is:open -is:draft review-requested:@me
+    filters: is:open review-requested:@me
   - title: Ready to merge
     filters: is:open -is:draft author:@me review:approved
   - title: Returned to you

--- a/xdg-config/gh-dash/config.yml
+++ b/xdg-config/gh-dash/config.yml
@@ -13,8 +13,8 @@ smartFilteringAtLaunch: false
 # PR sections follow the categories on https://github.com/pulls/inbox
 # so incoming review requests and merge-ready PRs are visible at a glance.
 prSections:
-  # Drafts are included: GitHub auto-requests code owners only at
-  # ready-for-review, so a review request on a draft is a deliberate ask.
+  # Drafts are included: code owners are never auto-requested while a PR
+  # is a draft, so a request here is one someone added explicitly.
   - title: Needs your review
     filters: is:open review-requested:@me
   - title: Ready to merge


### PR DESCRIPTION
## Summary

Drop `-is:draft` from the `Needs your review` section in the gh-dash config, so draft pull requests carrying a review request for me appear in the queue.

## Why

Code owners are never auto-requested while a pull request is a draft:

> Code owners are not automatically requested to review draft pull requests.

— [About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

So the automatic path that fills `review-requested:@me` with volume cannot fire on a draft. A draft reaching that section carries a reviewer someone added explicitly, which is the opposite of noise. Two cases can still put a draft there without a person deciding in the moment: a bot that opens draft PRs with a configured reviewer list, and a pull request opened ready, auto-requested, then converted back to draft — GitHub does not document whether pending requests survive that conversion, and I did not confirm it either way. Both are bounded enough to cost at most an occasional extra row.

`-is:draft` stays on the `author:@me` sections, where the drafts are my own and already have a dedicated tab.

## Verification

A draft pull request with a review request for me existed at the time of the change and was invisible under the old filter:

```
$ gh api -X GET search/issues -f q='is:open is:pr review-requested:@me' \
    --jq '.items[] | [(.draft|tostring), .html_url] | @tsv'
true	https://github.com/tacoms-inc-dev/camel-react-frontend/pull/2155
false	https://github.com/tacoms-inc-dev/camel-golang-backend/pull/9304
false	https://github.com/tacoms-inc-dev/camel-golang-backend/pull/9303
false	https://github.com/tacoms-inc-dev/camel-golang-backend/pull/9298
false	https://github.com/tacoms-inc-dev/camel-customize-api/pull/1245
```

That draft was opened by another person who requested my review directly, with no `ready_for_review` or `convert_to_draft` event in its timeline. The old filter matched 4 of these 5; the new filter matches all 5.

`yq '.prSections[0]'` parses the edited file and returns `filters: is:open review-requested:@me`, and the two keys the [gh-dash pr-section schema](https://gh-dash.dev/schema/pr-section.json) marks required (`title`, `filters`) are both still present.

## Known gap left open

`review-requested` drops a pull request once I submit any review:

> Requested reviewers are no longer listed in the search results after they review a pull request.

— [Searching issues and pull requests](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests)

A pull request I reviewed once and the author then pushed to without re-requesting stays out of the section. Addressing that needs a separate section on a different axis, out of scope here.
