### PR TITLE
Bound implementer verification cadence and grind loops

### DIFF
--- a/claude/agents/implementer.md
+++ b/claude/agents/implementer.md
@@ -135,6 +135,10 @@ suites, `--all-files` lint runs, and full builds to CI, unless the change
 itself is repo-wide (shared config, build tooling, a codemod across many
 files) or the spec asks for it.
 
+Run that set once per commit-sized unit of work, after the edits that
+make it up are in place. While chasing a single failure, re-run only the
+command that reproduces it.
+
 Report the exact commands and their results. If none applies, say so.
 Do not claim verification you did not perform.
 
@@ -142,6 +146,20 @@ State which checks you ran locally and which you delegated to CI. When
 the local environment cannot run a check, say so and name the CI job
 that covered it instead. On a commits-only dispatch (no CI runs), name the
 repo-wide checks nobody ran. Do not present a CI result as a local run.
+
+# Stopping a grind
+
+Stop and report instead of continuing when the work stops converging:
+
+- The same file needs a ninth edit
+- The same verification command fails three times in a row without the
+  error changing
+- A prescribed check is blocked by the environment (missing runtime,
+  container, or credential) rather than by the code
+
+Report what you tried and the current state. A grind that survives these
+bounds usually means the spec or the environment, not the code, is wrong
+— that is the parent's call.
 
 # Output format (default)
 
@@ -178,7 +196,8 @@ still has to watch, or "not run" plus the reason>
 
 # Constraints
 
-- Do not create or switch branches or worktrees, tag, or rewrite existing
+- Do not create or switch branches or worktrees, tag, merge the default
+  branch into the working branch, amend commits, or rewrite existing
   history. The parent owns workspace and branch setup.
 - Push and draft-PR creation are yours (see `Push, draft PR, and CI`). The
   PR's final title and body, code review, ready-for-review, and merge stay

--- a/claude/rules/implementation-delegation.md
+++ b/claude/rules/implementation-delegation.md
@@ -19,12 +19,23 @@ of implementing in the main session.
 - Exploratory scope or undecided design (belongs in the parent session
   or a Plan agent first)
 
+## Brief contents
+
+- Name the files the change touches and the entry points to start from
+- State the verification scope and cadence once as an outcome ("the
+  package's tests and lint pass before each commit"), not as per-step
+  instructions to run a command after individual edits
+- Prescribe a verification command only after confirming it runs on
+  this host; when a check only runs in CI, say so and name the job
+
 ## Ordering
 
 - Complete branch setup (pull the default branch, create the feature
   branch — one worktree+branch per implementer when running parallel
   dispatch) before dispatching; the subagent must not create branches
-  or worktrees
+  or worktrees, and must not merge the default branch mid-run — when
+  the branch needs newer default-branch commits, the parent merges and
+  re-dispatches
 - Every implementer dispatch, single or parallel, ends with the branch
   pushed, a draft PR open, and a time-bounded CI watch by default. To
   stop it at local commits, put "do not push" or "commits only" in the


### PR DESCRIPTION
## Why

implementer dispatches were taking long enough to be disruptive, with no diagnosis of where the time went. Measuring 55 implementer subagent transcripts (2026-06-14 to 2026-08-13, `~/.claude/projects/*/*/subagents/agent-*.jsonl`; 54 matched an implementer dispatch prompt exactly) located the cost:

| Metric | Value |
| --- | --- |
| active time (gaps > 5 min excluded) | 13.1h over 55 runs, median 6.1 min, mean 14.3 min |
| top 3 runs | 31% of all active time |
| model turn generation vs tool execution | 64% / 36% |
| verification execution (test + lint + build) | 97 min = 12% of active; test alone 34 min = 4% |
| exploration | 845 Read calls, plus 369 grep / 82 find / 51 ls through Bash |
| single edit followed straight by a verification run | 40 of 256 edit blocks (16%) |
| max edits to one file within a run | median 3, p75 5, p90 9, max 16 (n = 51) |

Running a verification command per edit is therefore not the main term. The time concentrates in exploration turns and in the tail runs that stop converging — one run made 41 verification calls against 10 edits and re-edited single files 9 to 12 times. Separately, two runs sat on a permission prompt before being denied (`git merge origin/main` for 21.9 min, `git commit --amend` for 5.4 min), both operations the parent rather than a background subagent is positioned to perform.

## What

`claude/rules/implementation-delegation.md`:

- A `Brief contents` section: the brief names the files and entry points the parent already located during planning, states verification scope and cadence once as an outcome rather than as per-edit instructions, and only prescribes a command after confirming it runs on this host.
- The branch-setup bullet now also assigns the mid-run default-branch merge to the parent.

`claude/agents/implementer.md`:

- The Verification section fixes the cadence at one pass per commit-sized unit, with single-command re-runs while chasing one failure.
- A `Stopping a grind` section stops the agent at a ninth edit to the same file, a third unchanged failure of the same command, or a check blocked by the environment. The ninth-edit threshold sits at the measured p90, firing on 6 of 51 runs.
- The Constraints bullet now names merging the default branch and amending commits as the parent's.

## Verification

`pre-commit run --files claude/rules/implementation-delegation.md claude/agents/implementer.md` (exit 0):

```
Trim Trailing Whitespace.......................................................Passed
Fix End of Files...............................................................Passed
Check for added large files....................................................Passed
Enforce line-count budget on always-loaded AI rule files.......................Passed
```

The effect of these rules is only observable in future implementer dispatches; nothing here measures it.
