### PR TITLE
Trim AGENTS.md and stop installing gopls-lsp at user scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,26 +19,6 @@ are symlinks pointing to files in this repository.
   `~/.codex/`, etc.) generally require a permission prompt
 - Check `scripts/deploy.sh` for the full list of symlink mappings
 
-## Key Commands
-
-```bash
-# Deploy/update dotfiles (creates symlinks)
-./scripts/deploy.sh
-
-# Validate shell scripts
-shellcheck scripts/*.sh bootstrap/*.sh
-
-# Run pre-commit hooks
-pre-commit run --all-files
-```
-
-## How to Add a New Dotfile
-
-1. Place the file in the repository root (e.g., `.newconfig`)
-1. Add a `link` call in `scripts/deploy.sh` under the appropriate category:
-   `link .newconfig "$HOME/.newconfig"`
-1. Run `./scripts/deploy.sh` to create the symlink
-
 ## Git Workflow
 
 - Always create a branch before making changes. When the user explicitly requests direct work on main, proceed after the default-branch guard hook's first deny — its retry is sanctioned for the rest of the session
@@ -58,8 +38,6 @@ pre-commit run --all-files
 ## Script Requirements
 
 - Bootstrap scripts use `/bin/bash` (not `/usr/bin/env bash`) for compatibility
-- All scripts must pass shellcheck validation
-- Use `set -eu` for error handling in critical scripts
 
 ## Machine-local Git Config
 

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -476,13 +476,13 @@
     "command": "bash ~/.claude/statusline-command.sh"
   },
   "enabledPlugins": {
-    "gopls-lsp@claude-plugins-official": false,
+    "gopls-lsp@claude-plugins-official": true,
     "codex@openai-codex": true,
     "pr-review-toolkit@claude-plugins-official": true,
-    "session-report@claude-plugins-official": false,
-    "claude-md-management@claude-plugins-official": false,
-    "skill-creator@claude-plugins-official": false,
-    "claude-code-setup@claude-plugins-official": false,
+    "session-report@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true,
+    "claude-code-setup@claude-plugins-official": true,
     "hookify@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true
   },

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -476,13 +476,13 @@
     "command": "bash ~/.claude/statusline-command.sh"
   },
   "enabledPlugins": {
-    "gopls-lsp@claude-plugins-official": true,
+    "gopls-lsp@claude-plugins-official": false,
     "codex@openai-codex": true,
     "pr-review-toolkit@claude-plugins-official": true,
-    "session-report@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true,
-    "skill-creator@claude-plugins-official": true,
-    "claude-code-setup@claude-plugins-official": true,
+    "session-report@claude-plugins-official": false,
+    "claude-md-management@claude-plugins-official": false,
+    "skill-creator@claude-plugins-official": false,
+    "claude-code-setup@claude-plugins-official": false,
     "hookify@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true
   },

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -476,7 +476,6 @@
     "command": "bash ~/.claude/statusline-command.sh"
   },
   "enabledPlugins": {
-    "gopls-lsp@claude-plugins-official": true,
     "codex@openai-codex": true,
     "pr-review-toolkit@claude-plugins-official": true,
     "session-report@claude-plugins-official": true,
@@ -538,6 +537,7 @@
   "autoUpdatesChannel": "stable",
   "tui": "fullscreen",
   "autoMemoryEnabled": false,
+  "skipWorkflowUsageWarning": true,
   "theme": "auto",
   "remoteControlAtStartup": true,
   "inputNeededNotifEnabled": true,
@@ -547,6 +547,5 @@
   "copyOnSelect": false,
   "feedbackSurveyState": {
     "lastShownTime": 1754272823676
-  },
-  "skipWorkflowUsageWarning": true
+  }
 }

--- a/scripts/claude-code-setup.sh
+++ b/scripts/claude-code-setup.sh
@@ -42,7 +42,6 @@ claude plugin marketplace add anthropics/claude-plugins-official
 claude plugin marketplace add openai/codex-plugin-cc
 claude plugin install codex@openai-codex
 claude plugin install pr-review-toolkit@claude-plugins-official
-claude plugin install gopls-lsp@claude-plugins-official
 claude plugin install session-report@claude-plugins-official
 claude plugin install claude-md-management@claude-plugins-official
 claude plugin install skill-creator@claude-plugins-official


### PR DESCRIPTION
## Summary

Two trims to what loads on every session in this repository: AGENTS.md content that a session can reconstruct from the codebase, and a plugin installed at user scope that only one kind of project needs.

## AGENTS.md

Every line of this file loads into context in every session that works here, so a line the codebase already answers is paid for on each run and drifts out of date on its own schedule.

- Key Commands: `shellcheck <paths>` and `pre-commit run --all-files` are the standard invocations of those tools, and `./scripts/deploy.sh` is documented twice in README.md, which AGENTS.md imports with `@README.md` and therefore already pays for
- How to Add a New Dotfile: the three steps restate the `link src dst` call list in `scripts/deploy.sh`, which the Symlink Architecture section already points at for the full set of symlink mappings
- `All scripts must pass shellcheck validation`: duplicates item 3 of the shell-script section in `claude/rules/software-development.md`, which loads in every session, and `.github/workflows/ci.yml` enforces it mechanically on every push
- `Use set -eu for error handling in critical scripts`: duplicates item 2 of that same section, and the Personal Tool Defaults section below still names `set -eu` in its own context

The deleted `shellcheck scripts/*.sh bootstrap/*.sh` had also fallen behind what CI actually covers: `.github/workflows/ci.yml` runs `**/*.sh` plus `bin/`, `xdg-config/git/hooks/`, `gh-extensions/`, `.bash_profile`, and `.bashrc`. Following the documented command would under-check the repository relative to what merge requires. `pre-commit` stays discoverable without the block: `.pre-commit-config.yaml` sits at the repository root, and the framework's generated hook at `.git/hooks/pre-commit` runs on every commit regardless.

The `/bin/bash` bullet stays because it names a convention that differs from the usual `/usr/bin/env bash` default, so the code alone would teach the wrong pattern. Symlink Architecture, Git Workflow, Language, Machine-local Git Config, and Personal Tool Defaults stay for the same reason: none is reconstructable by reading the repository. `@README.md` stays imported — the repository overview is what a session should read first, and its cost is the price of that.

## gopls-lsp

The plugin's only component is the gopls LSP server (`claude plugin details` reports 0 skills, 0 agents, 0 hooks, 0 MCP servers). `claude plugin install` defaults to user scope, so every project on this machine carried it while no repository in recent use contains Go. A project that needs it installs it where it applies: `claude plugin install gopls-lsp@claude-plugins-official -s project`, the same scope `terraform@claude-plugins-official` already uses for allmyinfra.

Dropping the install line from `scripts/claude-code-setup.sh` alongside the `enabledPlugins` entry is what makes the removal survive a bootstrap; the entry alone would come back on the next run of that script. `skipWorkflowUsageWarning` moves up in `claude/settings.json` because the CLI rewrote the file during uninstall and places the key there — same key, same value.

`Brewfile` still installs the `gopls` binary. Left alone, since an editor may use it directly.

## Considered and not done

Four more plugins have no recorded use across 623 startups: session-report, claude-md-management, skill-creator, claude-code-setup. Disabling them was the obvious parallel move, and the numbers do not support it — `claude plugin details` puts their combined always-on cost at roughly 491 tokens, under 0.05% of the context window. They stay enabled, since the surface is worth more than the tokens it costs. Six user-scope MCP servers were reviewed the same way; disabling one is a `/mcp disable <name>` call per project rather than a repository change, so none belongs here.

## Verification

- `git grep` for "Key Commands", "How to Add a New Dotfile", and "shellcheck validation" finds no remaining pointer anywhere in the repository
- Every surviving AGENTS.md heading still has a body
- `enabledPlugins` in `claude/settings.json` holds 8 entries, matching the 8 `claude plugin install` lines in `scripts/claude-code-setup.sh`, with gopls-lsp absent from both
