### PR TITLE
Exit the workflow CI watch on the first failing check

### DIFF
--- a/claude/agents/implementer.md
+++ b/claude/agents/implementer.md
@@ -145,7 +145,7 @@ Procedure:
    rewrites both title and body. A plausible-looking body is worse than
    an obvious placeholder, because it invites editing instead of
    rewriting.
-1. Watch CI, bounded: `gh pr checks --watch --fail-fast` with the
+1. Watch CI, bounded: `gh pr checks --watch --fail-fast -i 30` with the
    Bash tool's `timeout` parameter set to 180000 (milliseconds). Re-run
    it at most twice, and only when it returned `no checks reported`
    (workflows not yet registered against a just-created PR or a

--- a/claude/agents/implementer.md
+++ b/claude/agents/implementer.md
@@ -145,7 +145,7 @@ Procedure:
    rewrites both title and body. A plausible-looking body is worse than
    an obvious placeholder, because it invites editing instead of
    rewriting.
-1. Watch CI, bounded: `gh pr checks --watch --fail-fast -i 30` with the
+1. Watch CI, bounded: `gh pr checks --watch --fail-fast` with the
    Bash tool's `timeout` parameter set to 180000 (milliseconds). Re-run
    it at most twice, and only when it returned `no checks reported`
    (workflows not yet registered against a just-created PR or a

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -102,8 +102,9 @@ If any of the three fails:
 The sweep commits locally without pushing. Whenever it produced commits,
 push them together with any self-review and CI fixes in one push,
 regardless of whether the three checks passed, then re-run all three
-until all pass. After any push, re-arm `gh pr checks --watch --fail-fast`
-(the running watch is bound to the pre-push head).
+until all pass. After any push, and after a watch exits with checks still
+pending, re-arm `gh pr checks --watch --fail-fast` (the running watch is
+bound to the pre-push head).
 
 Note: `/pr-selfcheck` and the narrative sweep are mechanical checks, not
 a code review. Re-running them after fixes is expected. The

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -90,7 +90,10 @@ Launch all three in a single assistant message so they execute concurrently:
 - the `narrative-sweeper` agent — process-record narration in the comments
   and Markdown prose the branch added. Pass it the repository path and
   the branch name, and nothing else
-- `gh pr checks --watch` — CI monitoring. Run with `run_in_background: true`
+- `gh pr checks --watch --fail-fast -i 30` — CI monitoring. Run with
+  `run_in_background: true`. It returns as soon as one check fails, so a
+  fast job's failure is actionable while slower jobs are still running and
+  the checks it reports as failed are not the full set
 
 If any of the three fails:
 - Fix self-review "Must Fix" / "Should Fix" items
@@ -101,8 +104,9 @@ If any of the three fails:
 The sweep commits locally without pushing. Whenever it produced commits,
 push them together with any self-review and CI fixes in one push,
 regardless of whether the three checks passed, then re-run all three
-until all pass. After any push, re-arm `gh pr checks --watch` (the
-running watch is bound to the pre-push head).
+until all pass. After any push, re-arm
+`gh pr checks --watch --fail-fast -i 30` (the running watch is bound to
+the pre-push head).
 
 Note: `/pr-selfcheck` and the narrative sweep are mechanical checks, not
 a code review. Re-running them after fixes is expected. The
@@ -127,8 +131,8 @@ Once the review finishes, review the results:
    Skip it when the review produced no code changes — its previous pass
    already covers the branch
 1. Push the fixes and the sweep's commits in one push, then re-run
-   `/pr-selfcheck` and `gh pr checks --watch` to confirm the PR
-   is still consistent and CI passes.
+   `/pr-selfcheck` and `gh pr checks --watch --fail-fast -i 30` to
+   confirm the PR is still consistent and CI passes.
 
 The code review is single-pass — do not re-run after fixes.
 `/pr-selfcheck` and the narrative sweep run again in Phase 3 to catch
@@ -136,8 +140,9 @@ inconsistencies introduced by review fix changes.
 
 Never end a turn that claims ongoing waiting (delegated fix push,
 CI run, CI rerun, external state change) without an armed event
-source — a Monitor on the branch head, or `gh pr checks --watch`
-with `run_in_background: true`. After every `gh run rerun` or other
+source — a Monitor on the branch head, or
+`gh pr checks --watch --fail-fast -i 30` with `run_in_background: true`.
+After every `gh run rerun` or other
 re-kick, re-arm the watch before yielding. State what is being
 awaited in the final message before going idle.
 

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -91,9 +91,7 @@ Launch all three in a single assistant message so they execute concurrently:
   and Markdown prose the branch added. Pass it the repository path and
   the branch name, and nothing else
 - `gh pr checks --watch --fail-fast` — CI monitoring. Run with
-  `run_in_background: true`. It returns as soon as one check fails, so a
-  fast job's failure is actionable while slower jobs are still running and
-  the checks it reports as failed are not the full set
+  `run_in_background: true`
 
 If any of the three fails:
 - Fix self-review "Must Fix" / "Should Fix" items

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -90,7 +90,7 @@ Launch all three in a single assistant message so they execute concurrently:
 - the `narrative-sweeper` agent — process-record narration in the comments
   and Markdown prose the branch added. Pass it the repository path and
   the branch name, and nothing else
-- `gh pr checks --watch --fail-fast -i 30` — CI monitoring. Run with
+- `gh pr checks --watch --fail-fast` — CI monitoring. Run with
   `run_in_background: true`. It returns as soon as one check fails, so a
   fast job's failure is actionable while slower jobs are still running and
   the checks it reports as failed are not the full set
@@ -104,9 +104,8 @@ If any of the three fails:
 The sweep commits locally without pushing. Whenever it produced commits,
 push them together with any self-review and CI fixes in one push,
 regardless of whether the three checks passed, then re-run all three
-until all pass. After any push, re-arm
-`gh pr checks --watch --fail-fast -i 30` (the running watch is bound to
-the pre-push head).
+until all pass. After any push, re-arm `gh pr checks --watch --fail-fast`
+(the running watch is bound to the pre-push head).
 
 Note: `/pr-selfcheck` and the narrative sweep are mechanical checks, not
 a code review. Re-running them after fixes is expected. The
@@ -131,8 +130,8 @@ Once the review finishes, review the results:
    Skip it when the review produced no code changes — its previous pass
    already covers the branch
 1. Push the fixes and the sweep's commits in one push, then re-run
-   `/pr-selfcheck` and `gh pr checks --watch --fail-fast -i 30` to
-   confirm the PR is still consistent and CI passes.
+   `/pr-selfcheck` and `gh pr checks --watch --fail-fast` to confirm the
+   PR is still consistent and CI passes.
 
 The code review is single-pass — do not re-run after fixes.
 `/pr-selfcheck` and the narrative sweep run again in Phase 3 to catch
@@ -141,8 +140,8 @@ inconsistencies introduced by review fix changes.
 Never end a turn that claims ongoing waiting (delegated fix push,
 CI run, CI rerun, external state change) without an armed event
 source — a Monitor on the branch head, or
-`gh pr checks --watch --fail-fast -i 30` with `run_in_background: true`.
-After every `gh run rerun` or other
+`gh pr checks --watch --fail-fast` with `run_in_background: true`. After
+every `gh run rerun` or other
 re-kick, re-arm the watch before yielding. State what is being
 awaited in the final message before going idle.
 

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -140,9 +140,8 @@ Never end a turn that claims ongoing waiting (delegated fix push,
 CI run, CI rerun, external state change) without an armed event
 source — a Monitor on the branch head, or
 `gh pr checks --watch --fail-fast` with `run_in_background: true`. After
-every `gh run rerun` or other
-re-kick, re-arm the watch before yielding. State what is being
-awaited in the final message before going idle.
+every `gh run rerun` or other re-kick, re-arm the watch before yielding.
+State what is being awaited in the final message before going idle.
 
 ### Phase 4: Finalize PR for review readiness
 


### PR DESCRIPTION
## Summary

The git-workflow skill arms `gh pr checks --watch` at four points (Phase 1 launch, the post-push re-arm, the Phase 3 re-run, and the armed-event-source rule). Bare `--watch` loops until no check is pending, so on a run with a fast `lint` job and a slow `ci` job the lint failure is not surfaced until `ci` finishes. `--fail-fast` bounds the detection delay by the refresh interval rather than by the longest job in the run.

That flag also creates a second way for a watch to end, so the re-arm trigger widens with it: a `--fail-fast` return leaves checks pending, which the push-shaped and re-kick-shaped triggers do not cover. The gap is the Phase 1 handback branch, where the parent hands a CI failure to the implementer and pushes nothing, leaving the remaining checks unobserved.

## No explicit interval on these sites

The default is 10s, and since `--fail-fast` makes detection delay ≤ the refresh interval, naming a longer one works against the reason for adding the flag. Polling at 10s costs ~60 GraphQL queries over a 10-minute run against ~20 at 30s — negligible against the 5000 points/hour GraphQL limit — and makes a transient transport error proportionally more likely per unit time (expected hits ∝ p·T/i for per-poll failure probability p over a wait of T), which costs one re-arm.

`claude/agents/implementer.md` keeps `-i 30` and is unchanged here. Its watch runs in the foreground under a 180s bound, and `gh` appends a full check table per poll when stdout is not a TTY, so there the interval sets how much output lands in the subagent's context. These sites run with `run_in_background: true`, where the output goes to a file the parent reads on demand.

## Behavior

- `--fail-fast` breaks the watch loop as soon as any check reports failure, and requires `--watch` (`gh` rejects it standalone with a flag error)
- Exit code is 1 when a check has failed, 8 when checks are only pending
- A green exit still means every check completed and passed — the early break only fires on failure, so there is no false green
- The checks reported as failed at a fail-fast exit are not the full set; jobs still running may fail afterwards. Phase 1 re-runs all three checks until they pass, so the partial result never stands as the final verdict
- Exit code 1 is not exclusive to a failing check: a transport error during a poll also ends the watch with 1. This property is independent of `--fail-fast` and is left as is here

Verified against `gh pr checks --help` (gh 2.97.0, the installed version) and [`pkg/cmd/pr/checks/checks.go`](https://github.com/cli/cli/blob/trunk/pkg/cmd/pr/checks/checks.go), which `gh api repos/cli/cli/compare/v2.97.0...trunk` reports as unchanged between the installed tag and `trunk`.

## Scope

`claude/skills/git-workflow/SKILL.md` only: the command spelling at four sites, one re-arm trigger, and a paragraph refill. The diff adds no explanation of what `--fail-fast` does — the flag's meaning is carried by the flag itself and by the watch's own output, and no instruction branches on it. No phase ordering or fix-handling text changed.

## Follow-up

`SKILL.md`'s re-arm parenthetical, "the running watch is bound to the pre-push head", is false and predates this PR: `checks.go` re-issues the same query per poll against a rollup of `commits(last: 1)` (`api/query_builder.go:280`), so a surviving watch follows the branch head across a push. The instruction to re-arm holds; only the stated reason is wrong. Left for a separate PR.

## Verification

- [x] `git grep -n 'pr checks --watch' -- claude/` shows five occurrences, all carrying `--fail-fast`
