### PR TITLE
Correct four behavior claims in the git-workflow skill

### DIFF
--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -34,8 +34,8 @@ Prerequisite: the `agynio/gh-pr-review` gh extension is installed
 
 ## 1. Start Work
 
-1. Switch to the default branch and pull:
-   `git home`
+1. From the main clone, not a worktree, switch to the default branch and
+   pull: `git home`
 1. Create a worktree and branch (defaults to branching from origin's default branch):
    `git-worktree-create <branch-name>`
    - To branch from somewhere other than origin's default:
@@ -221,8 +221,7 @@ per actionable change; quiet periods stay silent.
    pre-push checks).
 
 1. Exit conditions:
-   - `STATE: MERGED` → execute Step 6 (Cleanup). `pr-monitor` exits on
-     its own at `MERGED` and at `CLOSED`, so neither needs a `TaskStop`.
+   - `STATE: MERGED` → execute Step 6 (Cleanup).
    - `STATE: CLOSED` without merge → skip cleanup.
    - Session ends → Monitor terminates with the session (best-effort).
 

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -103,8 +103,7 @@ The sweep commits locally without pushing. Whenever it produced commits,
 push them together with any self-review and CI fixes in one push,
 regardless of whether the three checks passed, then re-run all three
 until all pass. After any push, and after a watch exits with checks still
-pending, re-arm `gh pr checks --watch --fail-fast` (the running watch is
-bound to the pre-push head).
+pending, re-arm `gh pr checks --watch --fail-fast`.
 
 Note: `/pr-selfcheck` and the narrative sweep are mechanical checks, not
 a code review. Re-running them after fixes is expected. The

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -34,8 +34,8 @@ Prerequisite: the `agynio/gh-pr-review` gh extension is installed
 
 ## 1. Start Work
 
-1. Pull the latest default branch:
-   `git pull`
+1. Switch to the default branch and pull:
+   `git home`
 1. Create a worktree and branch (defaults to branching from origin's default branch):
    `git-worktree-create <branch-name>`
    - To branch from somewhere other than origin's default:
@@ -192,7 +192,9 @@ per actionable change; quiet periods stay silent.
    - `NEW_REVIEW: [BOT|USER] <author> <state>` — new PR review
      (summary body). `state` ∈ `COMMENTED` / `APPROVED` /
      `CHANGES_REQUESTED` / `DISMISSED`. Empty-body reviews filtered.
-   - `CI_FAILURE: <check name>` — new `FAILURE` on the PR's head SHA.
+   - `CI_FAILURE: <workflow run name>` — new `FAILURE` Actions run on
+     the PR's head SHA. Checks that are not Actions runs never produce
+     this line; reach them through `gh pr checks`.
 
 1. Re-fetch detail on each event with:
    - `gh pr view <number> --json state,isDraft,reviewDecision,latestReviews,statusCheckRollup,comments,updatedAt,mergedAt,headRefName`
@@ -219,9 +221,9 @@ per actionable change; quiet periods stay silent.
    pre-push checks).
 
 1. Exit conditions:
-   - `STATE: MERGED` → execute Step 6 (Cleanup), then `TaskStop` the
-     monitor.
-   - `STATE: CLOSED` without merge → `TaskStop`, skip cleanup.
+   - `STATE: MERGED` → execute Step 6 (Cleanup). `pr-monitor` exits on
+     its own at `MERGED` and at `CLOSED`, so neither needs a `TaskStop`.
+   - `STATE: CLOSED` without merge → skip cleanup.
    - Session ends → Monitor terminates with the session (best-effort).
 
 1. Conflict handling:


### PR DESCRIPTION
## Summary

Four claims in the git-workflow skill describe behavior its tools do not have. Each is corrected against a primary source; no phase ordering or procedure changes.

## Corrections

### Step 1: `git pull` → `git home`

`git pull` integrates into the branch already checked out (`man git-pull`), so it updates the default branch only when HEAD is already on it — which is not the case when Step 1 runs after work on a feature branch. `git home` resolves `refs/remotes/origin/HEAD`, switches to that branch, and pulls (`xdg-config/git/config:28-36`).

The step also gains a precondition, because `git home` runs `git switch`, which "refuses when the wanted ref is already checked out by another worktree" (`man git-switch`, `--ignore-other-worktrees`). The flow leaves the agent inside a worktree from Step 1.3 until Step 6, so a second task started before the first PR merges would begin Step 1 there and fail. `git pull` did not fail in that state — it succeeded against the wrong branch, which is the defect this correction removes.

### Phase 1: the re-arm parenthetical

"The running watch is bound to the pre-push head" is false. `checks.go` resolves the PR once and then re-issues its query every poll against a rollup of `statusCheckRollup: commits(last: 1)` (`api/query_builder.go:280`), which resolves live against the PR node, so a surviving watch follows the branch head across a push. The re-arm instruction stands on its own and the parenthetical is dropped rather than replaced — the reason for an instruction belongs in the PR that changes it.

### Phase 5: what `CI_FAILURE` names

`pr-monitor` emits `.name` from `gh run list` (`bin/pr-monitor:174-184`), which is the workflow run's name, not a check name. Measured on this repository: `gh run list --json name,workflowName` returns `Lint` and `Bootstrap`, while `gh pr checks --json name` for the same PR returns `shellcheck`, `python-doctest`, `bootstrap (macos-latest)`. cli/cli itself comments the field as ambiguous (`pkg/cmd/run/shared/shared.go:92`).

The source is also Actions-only. This repository's PRs carry two `Socket Security` checks with `"workflow":""` and no corresponding run, so a failure there produces no `CI_FAILURE` line at all — a silent gap the previous wording denied.

### Phase 5: the exit conditions

`pr-monitor` runs `exit 0` itself on `MERGED` and `CLOSED` in the same poll that prints the event (`bin/pr-monitor:217-219`), so the instruction to `TaskStop` afterwards targets a process that is already gone.

## Scope

`claude/skills/git-workflow/SKILL.md` only. The `TaskStop` under Conflict handling stays — the monitor is live at that point.

## Not changed, reported instead

- Phase 2 runs `/pr-review-toolkit:review-pr` after everything is committed and pushed, but that command scopes itself from `git status` and `git diff --name-only`, which are empty at that point. Fixing it means naming a diff range in the phase, which is a procedure change rather than a fact correction
- `git-worktree-create` errors unless run from the repository root (`bin/git-worktree-create:18-21`); Step 1 does not state that precondition
- The "PR Body Checklist" referenced from Steps 3 and 5 lives in `pr-guidelines.md`, which the skill never names, unlike `pr-reaction.md`

## Verification

- [x] Every corrected claim re-checked against the cited source: `man git-pull`, `xdg-config/git/config`, `bin/pr-monitor`, `gh run list` / `gh pr checks` output on this repository, and `cli/cli` at `trunk`, which `gh api repos/cli/cli/compare/v2.97.0...trunk` reports as unchanged from the installed 2.97.0 for the files cited
