### PR TITLE
Carry the run conclusion in pr-monitor CI events

### DIFF
--- a/bin/pr-monitor
+++ b/bin/pr-monitor
@@ -173,14 +173,14 @@ while true; do
   fi
   runs_json="$(gh run list --branch "$head_branch" --json databaseId,name,conclusion,headSha --limit 20 2>/dev/null || true)"
   if [ -n "$runs_json" ]; then
-    while IFS=$'\t' read -r run_id run_name; do
+    while IFS=$'\t' read -r run_id run_name run_conclusion; do
       [ -z "$run_id" ] && continue
       if [ -z "${seen_runs[$run_id]:-}" ]; then
-        [ "$first_poll" -eq 0 ] && echo "CI_FAILURE: $run_name"
+        [ "$first_poll" -eq 0 ] && echo "CI_FAILURE: $run_name ($run_conclusion)"
         seen_runs[$run_id]=1
       fi
     done < <(echo "$runs_json" | jq -r --arg sha "$head_sha" \
-      '.[] | select(.headSha == $sha and .conclusion == "FAILURE") | "\(.databaseId)\t\(.name)"' \
+      '.[] | select(.headSha == $sha and (.conclusion // "") != "" and .conclusion != "success") | "\(.databaseId)\t\(.name)\t\(.conclusion)"' \
       || true)
   fi
 

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -192,9 +192,10 @@ per actionable change; quiet periods stay silent.
    - `NEW_REVIEW: [BOT|USER] <author> <state>` — new PR review
      (summary body). `state` ∈ `COMMENTED` / `APPROVED` /
      `CHANGES_REQUESTED` / `DISMISSED`. Empty-body reviews filtered.
-   - `CI_FAILURE: <workflow run name>` — new `FAILURE` Actions run on
-     the PR's head SHA. Checks that are not Actions runs never produce
-     this line; reach them through `gh pr checks`.
+   - `CI_FAILURE: <workflow run name> (<conclusion>)` — an Actions run on
+     the PR's head SHA settled on a conclusion other than `success`; the
+     conclusion is the line's own last field. Checks that are not Actions
+     runs never produce this line; reach them through `gh pr checks`.
 
 1. Re-fetch detail on each event with:
    - `gh pr view <number> --json state,isDraft,reviewDecision,latestReviews,statusCheckRollup,comments,updatedAt,mergedAt,headRefName`


### PR DESCRIPTION
## Summary

`pr-monitor`'s CI event never fired. Its jq filter selected runs whose `.conclusion` equals `"FAILURE"`, but `gh run list` reports the REST spelling in lower case — measured on this repository (`{"conclusion":"success"}`) and on a repository with real failures (`gh run list -R cli/cli --status failure --json conclusion` → `{"conclusion":"failure"}`). The upper-case spelling belongs to the GraphQL `statusCheckRollup` enum, which is not this code path's source.

## Approach

The filter now selects runs that have settled on a conclusion other than `success`, and the conclusion string travels to the event line as its own field:

```
CI_FAILURE: Lint (timed_out)
```

Naming the one benign conclusion keeps the script free of a list of failure spellings, and `timed_out` / `cancelled` / `startup_failure` reach the reader as themselves rather than being flattened into a single event or silently dropped. What a given conclusion warrants is the reader's call, which is why the string is passed through rather than interpreted.

Runs still in flight report an empty or absent conclusion and are excluded, so an unfinished run cannot be read as a settled one.

## Verification

- [x] jq filter exercised against sample run data covering `failure`, `success`, `null`, `""`, `timed_out`, and a run on a different head SHA: only `failure` and `timed_out` on the matching SHA pass
- [x] `shellcheck bin/pr-monitor` clean
- [x] `pr-monitor 360` runs end to end and exits 0

The emit path itself was not exercised against a live failing run: `pr-monitor` suppresses events on its first poll, and no PR with a failing Actions run was available to watch from an earlier state.

## Related, not fixed here

`pr-monitor` guards its `STATE:` emit behind the first-poll check but not its `exit 0`, so arming it against a PR that is already merged or closed ends the process without emitting anything. Reproduced by the `pr-monitor 360` run above, which exited 0 silently. The skill's exit conditions read as though a `STATE:` line always precedes cleanup.
