### PR TITLE
Pass GitHub values through as pr-monitor events

### DIFF
--- a/bin/pr-monitor
+++ b/bin/pr-monitor
@@ -19,11 +19,11 @@
 #   NEW_COMMENT: [BOT|USER] <author> <path>:<line>
 #   NEW_TOP_COMMENT: [BOT|USER] <author>
 #   NEW_REVIEW: [BOT|USER] <author> <state>
-#   CI_RUN: <workflow run name> (<conclusion>)
+#   CHECK: <check name> (<conclusion>)
 #   POLL_ERROR: <call that failed>
 #
-# CI_RUN covers Actions runs concluding as anything but success; other
-# checks need `gh pr checks`.
+# CHECK covers every check on the head commit, Actions or not, settling
+# on anything but success.
 
 set -eu
 
@@ -66,7 +66,7 @@ prev_state=""
 prev_decision=""
 prev_isdraft=""
 prev_ci_sha=""
-declare -A seen_runs=()
+declare -A seen_checks=()
 declare -A poll_failed=()
 seen_comments="$(mktemp)"
 seen_top_comments="$(mktemp)"
@@ -158,10 +158,10 @@ emit_new() {
 }
 
 while true; do
-  pr_json="$(gh pr view "$pr" --json state,isDraft,reviewDecision,statusCheckRollup,headRefName,headRefOid 2>/dev/null || true)"
+  pr_json="$(gh pr view "$pr" --json state,isDraft,reviewDecision,statusCheckRollup,headRefOid 2>/dev/null || true)"
   # Requiring `.state` rather than mere parseability: `{}` parses, and an
   # empty `state` reaches the comparison below while an empty `headRefOid`
-  # resets `seen_runs` twice over, replaying every failing run.
+  # resets `seen_checks` twice over, replaying every failing check.
   if ! echo "$pr_json" | jq -e '.state? // empty' >/dev/null 2>&1; then
     poll_error "gh pr view"
     sleep "$interval"
@@ -171,7 +171,6 @@ while true; do
   state="$(echo "$pr_json" | jq -r '.state // ""')"
   isdraft="$(echo "$pr_json" | jq -r '.isDraft // ""')"
   decision="$(echo "$pr_json" | jq -r '.reviewDecision // ""')"
-  head_branch="$(echo "$pr_json" | jq -r '.headRefName // ""')"
   head_sha="$(echo "$pr_json" | jq -r '.headRefOid // ""')"
 
   if [ "$state" != "$prev_state" ]; then
@@ -199,35 +198,32 @@ while true; do
   fi
 
   if [ "$head_sha" != "$prev_ci_sha" ]; then
-    seen_runs=()
+    seen_checks=()
     prev_ci_sha="$head_sha"
   fi
-  # `gh run list` answers `[]` for a branch with no runs, so an empty or
-  # unparseable result means the call failed rather than that CI is clean.
-  runs_json="$(gh run list --branch "$head_branch" --json databaseId,name,conclusion,headSha,attempt --limit 20 2>/dev/null || true)"
-  if [ -z "$runs_json" ] || ! echo "$runs_json" | jq -e . >/dev/null 2>&1; then
-    poll_error "gh run list"
-    runs_json=""
-  else
-    poll_ok "gh run list"
-  fi
-  if [ -n "$runs_json" ]; then
-    # Keyed on the attempt: `gh run rerun` reuses the databaseId and
-    # leaves the head SHA alone, so a run-keyed map swallows every rerun.
-    while IFS=$'\t' read -r run_key run_name run_conclusion; do
-      [ -z "$run_key" ] && continue
-      if [ -z "${seen_runs[$run_key]:-}" ]; then
-        if [ "$first_poll" -eq 0 ]; then
-          echo "CI_RUN: $run_name ($run_conclusion)"
-        fi
-        seen_runs[$run_key]=1
-      fi
-    done < <(echo "$runs_json" | jq -r --arg sha "$head_sha" \
-      '.[] | select(.headSha == $sha and (.conclusion // "") != "" and .conclusion != "success") | "\(.databaseId):\(.attempt)\t\(.name)\t\(.conclusion)"' \
-      || true)
-  fi
+  # The rollup rides along on the poll above and covers every check on the
+  # head commit, Actions or not. `completedAt` moves with each rerun, so
+  # it keys attempts of one check apart. `SUCCESS` and `PENDING` are the
+  # values that mean nothing to report; the rest travel as they came.
+  while IFS=$'\t' read -r check_key check_name check_conclusion; do
+    [ -z "$check_key" ] && continue
+    if [ -z "${seen_checks[$check_key]:-}" ]; then
+      echo "CHECK: $check_name ($check_conclusion)"
+      seen_checks[$check_key]=1
+    fi
+  done < <(echo "$pr_json" | jq -r '
+    .statusCheckRollup[]?
+    | {n: (.name // .context // "?"), c: (.conclusion // .state // ""),
+       done: (.status // "COMPLETED"), at: (.completedAt // "")}
+    | select(.done == "COMPLETED" and .c != "" and .c != "SUCCESS" and .c != "PENDING")
+    | "\(.n):\(.at)\t\(.n)\t\(.c)"' || true)
 
   threads_json="$(gh api graphql -f owner="$owner" -f repo="$repo" -F num="$pr" -f query="$threads_query" 2>/dev/null || true)"
+  if [ -z "$threads_json" ]; then
+    poll_error "gh api graphql (threads)"
+  else
+    poll_ok "gh api graphql (threads)"
+  fi
   fresh_comments="$(echo "$threads_json" | jq -r --arg me "$me" '
     .data.repository.pullRequest.reviewThreads.nodes[]
     | select(.isResolved == false and .isOutdated == false)
@@ -243,6 +239,11 @@ while true; do
   # by the `REVIEW:` decision event, and an empty COMMENTED has nothing
   # to read.
   reviews_json="$(gh api graphql -f owner="$owner" -f repo="$repo" -F num="$pr" -f query="$reviews_query" 2>/dev/null || true)"
+  if [ -z "$reviews_json" ]; then
+    poll_error "gh api graphql (reviews)"
+  else
+    poll_ok "gh api graphql (reviews)"
+  fi
   fresh_top="$(echo "$reviews_json" | jq -r --arg me "$me" '
     .data.repository.pullRequest.comments.nodes[]
     | select(.author.login != $me)

--- a/bin/pr-monitor
+++ b/bin/pr-monitor
@@ -67,6 +67,7 @@ prev_decision=""
 prev_isdraft=""
 prev_ci_sha=""
 declare -A seen_runs=()
+declare -A poll_failed=()
 seen_comments="$(mktemp)"
 seen_top_comments="$(mktemp)"
 seen_reviews="$(mktemp)"
@@ -76,6 +77,20 @@ trap 'rm -f "$seen_comments" "$seen_top_comments" "$seen_reviews"' EXIT
 # arm time. Only transitions during this monitor's lifetime should wake
 # the operator. The flag is flipped after the first successful poll.
 first_poll=1
+
+# One line per outage, not per poll: an unauthorized token or an outage
+# persists for many intervals, and a line each time would drown the
+# silence the rest of the script maintains.
+poll_error() {
+  if [ -z "${poll_failed[$1]:-}" ]; then
+    echo "POLL_ERROR: $1"
+    poll_failed[$1]=1
+  fi
+}
+
+poll_ok() {
+  unset "poll_failed[$1]"
+}
 
 # `__typename` on each author is the authoritative Bot/User signal per
 # `pr-reaction.md`. It flows into the event line as a `[BOT]` or
@@ -144,13 +159,15 @@ emit_new() {
 
 while true; do
   pr_json="$(gh pr view "$pr" --json state,isDraft,reviewDecision,statusCheckRollup,headRefName,headRefOid 2>/dev/null || true)"
-  # Skip the poll on an empty OR malformed fetch: a non-empty but truncated
-  # response would make the unguarded `jq -r` extractions below exit nonzero
-  # and, under `set -e`, kill the monitor silently.
-  if [ -z "$pr_json" ] || ! echo "$pr_json" | jq -e . >/dev/null 2>&1; then
+  # Requiring `.state` rather than mere parseability: `{}` parses, and an
+  # empty `state` reaches the comparison below while an empty `headRefOid`
+  # resets `seen_runs` twice over, replaying every failing run.
+  if ! echo "$pr_json" | jq -e '.state? // empty' >/dev/null 2>&1; then
+    poll_error "gh pr view"
     sleep "$interval"
     continue
   fi
+  poll_ok "gh pr view"
   state="$(echo "$pr_json" | jq -r '.state // ""')"
   isdraft="$(echo "$pr_json" | jq -r '.isDraft // ""')"
   decision="$(echo "$pr_json" | jq -r '.reviewDecision // ""')"
@@ -171,8 +188,11 @@ while true; do
     prev_isdraft="$isdraft"
   fi
 
-  if [ -n "$decision" ] && [ "$decision" != "$prev_decision" ]; then
-    if [ "$first_poll" -eq 0 ]; then
+  # `prev_decision` tracks the empty value too: a dismissal clears
+  # `reviewDecision`, and holding the stale one here would then swallow
+  # the re-approval that follows.
+  if [ "$decision" != "$prev_decision" ]; then
+    if [ "$first_poll" -eq 0 ] && [ -n "$decision" ]; then
       echo "REVIEW: $decision"
     fi
     prev_decision="$decision"
@@ -183,12 +203,13 @@ while true; do
     prev_ci_sha="$head_sha"
   fi
   # `gh run list` answers `[]` for a branch with no runs, so an empty or
-  # unparseable result means the call failed. Swallowing it would read as
-  # a clean run and leave `seen_runs` unseeded for the next poll.
+  # unparseable result means the call failed rather than that CI is clean.
   runs_json="$(gh run list --branch "$head_branch" --json databaseId,name,conclusion,headSha,attempt --limit 20 2>/dev/null || true)"
   if [ -z "$runs_json" ] || ! echo "$runs_json" | jq -e . >/dev/null 2>&1; then
-    echo "POLL_ERROR: gh run list"
+    poll_error "gh run list"
     runs_json=""
+  else
+    poll_ok "gh run list"
   fi
   if [ -n "$runs_json" ]; then
     # Keyed on the attempt: `gh run rerun` reuses the databaseId and

--- a/bin/pr-monitor
+++ b/bin/pr-monitor
@@ -66,7 +66,7 @@ prev_state=""
 prev_decision=""
 prev_isdraft=""
 prev_ci_sha=""
-declare -A seen_checks=()
+declare -A prev_check=()
 declare -A poll_failed=()
 seen_comments="$(mktemp)"
 seen_top_comments="$(mktemp)"
@@ -163,7 +163,7 @@ while true; do
   pr_json="$(gh pr view "$pr" --json state,isDraft,reviewDecision,statusCheckRollup,headRefOid 2>/dev/null || true)"
   # Requiring `.state` rather than mere parseability: `{}` parses, and an
   # empty `state` reaches the comparison below while an empty `headRefOid`
-  # resets `seen_checks` twice over, replaying every failing check.
+  # resets `prev_check` twice over, replaying every failing check.
   if ! echo "$pr_json" | jq -e '.state? // empty' >/dev/null 2>&1; then
     poll_error "gh pr view"
     sleep "$interval"
@@ -199,35 +199,42 @@ while true; do
     prev_decision="$decision"
   fi
 
+  # A new head retires the old commit's checks, and a check that lands on
+  # the same value it held there would otherwise compare equal and stay
+  # silent.
   if [ "$head_sha" != "$prev_ci_sha" ]; then
-    seen_checks=()
+    prev_check=()
     prev_ci_sha="$head_sha"
   fi
   # The rollup rides along on the poll above and covers every check on the
-  # head commit, Actions or not. Its timestamp moves with each rerun or
-  # re-post, keying attempts of one check apart; a status context carries
-  # `startedAt` alone. Excluded are the values GitHub itself counts as
-  # passing or not yet settled; the rest travel as they came, so a value
-  # added later reports rather than vanishes.
+  # head commit, Actions or not. Every value it holds is tracked, settled
+  # or not, so a rerun passing back through a running state is a change
+  # again on the way out; the ones that never warrant waking anybody are
+  # the only names spelled here, so a value added later reports rather
+  # than vanishes.
   if ! echo "$pr_json" | jq -e '.statusCheckRollup | type == "array"' >/dev/null 2>&1; then
     poll_error "gh pr view (rollup)"
   else
     poll_ok "gh pr view (rollup)"
   fi
-  while IFS=$'\t' read -r check_key check_name check_conclusion; do
-    [ -z "$check_key" ] && continue
-    if [ -z "${seen_checks[$check_key]:-}" ]; then
-      echo "CHECK: $check_name ($check_conclusion)"
-      seen_checks[$check_key]=1
+  while IFS=$'\t' read -r check_name check_state; do
+    [ -z "$check_name" ] && continue
+    # `unseen` rather than an empty default: a check reporting COMPLETED
+    # with no conclusion holds the empty string, which would otherwise
+    # match a check never seen before and never report.
+    if [ "$check_state" != "${prev_check[$check_name]-unseen}" ]; then
+      case "$check_state" in
+        SUCCESS|NEUTRAL|SKIPPED|PENDING|EXPECTED|QUEUED|WAITING|REQUESTED|IN_PROGRESS) ;;
+        *) echo "CHECK: $check_name ($check_state)" ;;
+      esac
+      prev_check[$check_name]="$check_state"
     fi
   done < <(echo "$pr_json" | jq -r '
     .statusCheckRollup[]?
-    | {n: (.name // .context // "?"), c: (.conclusion // .state // ""),
-       done: (.status // "COMPLETED"), at: (.completedAt // .startedAt // "")}
-    | select(.done == "COMPLETED" and .c != "" and .c != "SUCCESS"
-             and .c != "NEUTRAL" and .c != "SKIPPED"
-             and .c != "PENDING" and .c != "EXPECTED")
-    | "\(.n):\(.at)\t\(.n)\t\(.c)"' || true)
+    | (.name // .context // "?") as $n
+    | (if (.status // "COMPLETED") == "COMPLETED"
+       then (.conclusion // .state // "") else .status end) as $c
+    | "\($n)\t\($c)"' || true)
 
   threads_json="$(gh api graphql -f owner="$owner" -f repo="$repo" -F num="$pr" -f query="$threads_query" 2>/dev/null || true)"
   # Testing the field rather than the string: GraphQL answers an error

--- a/bin/pr-monitor
+++ b/bin/pr-monitor
@@ -19,7 +19,7 @@
 #   NEW_COMMENT: [BOT|USER] <author> <path>:<line>
 #   NEW_TOP_COMMENT: [BOT|USER] <author>
 #   NEW_REVIEW: [BOT|USER] <author> <state>
-#   CHECK: <check name> (<conclusion>)
+#   CHECK: <check name> (<conclusion or state>)
 #   POLL_ERROR: <call that failed>
 #
 # CHECK covers every check on the head commit, Actions or not, settling
@@ -76,6 +76,8 @@ trap 'rm -f "$seen_comments" "$seen_top_comments" "$seen_reviews"' EXIT
 # First-poll seeding: do not emit events for state that already held at
 # arm time. Only transitions during this monitor's lifetime should wake
 # the operator. The flag is flipped after the first successful poll.
+# `CHECK` is the exception — a check already red when the monitor is
+# armed is the reader's problem now, so it reports rather than seeds.
 first_poll=1
 
 # One line per outage, not per poll: an unauthorized token or an outage
@@ -202,9 +204,16 @@ while true; do
     prev_ci_sha="$head_sha"
   fi
   # The rollup rides along on the poll above and covers every check on the
-  # head commit, Actions or not. `completedAt` moves with each rerun, so
-  # it keys attempts of one check apart. `SUCCESS` and `PENDING` are the
-  # values that mean nothing to report; the rest travel as they came.
+  # head commit, Actions or not. Its timestamp moves with each rerun or
+  # re-post, keying attempts of one check apart; a status context carries
+  # `startedAt` alone. Excluded are the values GitHub itself counts as
+  # passing or not yet settled; the rest travel as they came, so a value
+  # added later reports rather than vanishes.
+  if ! echo "$pr_json" | jq -e '.statusCheckRollup | type == "array"' >/dev/null 2>&1; then
+    poll_error "gh pr view (rollup)"
+  else
+    poll_ok "gh pr view (rollup)"
+  fi
   while IFS=$'\t' read -r check_key check_name check_conclusion; do
     [ -z "$check_key" ] && continue
     if [ -z "${seen_checks[$check_key]:-}" ]; then
@@ -214,12 +223,17 @@ while true; do
   done < <(echo "$pr_json" | jq -r '
     .statusCheckRollup[]?
     | {n: (.name // .context // "?"), c: (.conclusion // .state // ""),
-       done: (.status // "COMPLETED"), at: (.completedAt // "")}
-    | select(.done == "COMPLETED" and .c != "" and .c != "SUCCESS" and .c != "PENDING")
+       done: (.status // "COMPLETED"), at: (.completedAt // .startedAt // "")}
+    | select(.done == "COMPLETED" and .c != "" and .c != "SUCCESS"
+             and .c != "NEUTRAL" and .c != "SKIPPED"
+             and .c != "PENDING" and .c != "EXPECTED")
     | "\(.n):\(.at)\t\(.n)\t\(.c)"' || true)
 
   threads_json="$(gh api graphql -f owner="$owner" -f repo="$repo" -F num="$pr" -f query="$threads_query" 2>/dev/null || true)"
-  if [ -z "$threads_json" ]; then
+  # Testing the field rather than the string: GraphQL answers an error
+  # with a parseable body on stdout, which a non-empty test would read as
+  # a healthy poll and, worse, clear a running outage's suppression.
+  if ! echo "$threads_json" | jq -e '.data.repository.pullRequest.reviewThreads' >/dev/null 2>&1; then
     poll_error "gh api graphql (threads)"
   else
     poll_ok "gh api graphql (threads)"
@@ -239,7 +253,7 @@ while true; do
   # by the `REVIEW:` decision event, and an empty COMMENTED has nothing
   # to read.
   reviews_json="$(gh api graphql -f owner="$owner" -f repo="$repo" -F num="$pr" -f query="$reviews_query" 2>/dev/null || true)"
-  if [ -z "$reviews_json" ]; then
+  if ! echo "$reviews_json" | jq -e '.data.repository.pullRequest.reviews' >/dev/null 2>&1; then
     poll_error "gh api graphql (reviews)"
   else
     poll_ok "gh api graphql (reviews)"

--- a/bin/pr-monitor
+++ b/bin/pr-monitor
@@ -9,6 +9,23 @@
 # (claude/skills/git-workflow/SKILL.md) Phase 5 for the reaction protocol.
 #
 # Usage: pr-monitor <pr-number> [interval-seconds]
+#
+# Events, one per stdout line. Field values are GitHub's own and are
+# passed through rather than sorted into categories here, so a vocabulary
+# this script has never seen still reaches the reader intact:
+#
+#   STATE: <state>
+#   REVIEW: <reviewDecision>
+#   READY_FOR_REVIEW
+#   NEW_COMMENT: [BOT|USER] <author> <path>:<line>
+#   NEW_TOP_COMMENT: [BOT|USER] <author>
+#   NEW_REVIEW: [BOT|USER] <author> <state>
+#   CI_RUN: <workflow run name> (<conclusion>)
+#   POLL_ERROR: <call that failed>: <message>
+#
+# CI_RUN covers Actions runs whose conclusion is anything but success.
+# Checks that are not Actions runs never reach it; `gh pr checks` sees
+# those.
 
 set -eu
 
@@ -144,9 +161,7 @@ while true; do
 
   if [ "$state" != "$prev_state" ]; then
     if [ "$first_poll" -eq 0 ]; then
-      case "$state" in
-        MERGED|CLOSED) echo "STATE: $state" ;;
-      esac
+      echo "STATE: $state"
     fi
     prev_state="$state"
   fi
@@ -160,9 +175,7 @@ while true; do
 
   if [ -n "$decision" ] && [ "$decision" != "$prev_decision" ]; then
     if [ "$first_poll" -eq 0 ]; then
-      case "$decision" in
-        CHANGES_REQUESTED|APPROVED) echo "REVIEW: $decision" ;;
-      esac
+      echo "REVIEW: $decision"
     fi
     prev_decision="$decision"
   fi
@@ -171,16 +184,31 @@ while true; do
     seen_runs=()
     prev_ci_sha="$head_sha"
   fi
-  runs_json="$(gh run list --branch "$head_branch" --json databaseId,name,conclusion,headSha --limit 20 2>/dev/null || true)"
+  # `gh run list` answers `[]` for a branch with no runs, so an empty or
+  # unparseable result means the call itself failed. That gets its own
+  # event because silence here otherwise reads exactly like a clean run,
+  # while the GraphQL sections below keep emitting normally. A swallowed
+  # failure also leaves `seen_runs` unseeded, so the next poll would
+  # replay every run that was already settled at arm time.
+  runs_json="$(gh run list --branch "$head_branch" --json databaseId,name,conclusion,headSha,attempt --limit 20 2>/dev/null || true)"
+  if [ -z "$runs_json" ] || ! echo "$runs_json" | jq -e . >/dev/null 2>&1; then
+    echo "POLL_ERROR: gh run list"
+    runs_json=""
+  fi
   if [ -n "$runs_json" ]; then
-    while IFS=$'\t' read -r run_id run_name run_conclusion; do
-      [ -z "$run_id" ] && continue
-      if [ -z "${seen_runs[$run_id]:-}" ]; then
-        [ "$first_poll" -eq 0 ] && echo "CI_FAILURE: $run_name ($run_conclusion)"
-        seen_runs[$run_id]=1
+    # Keyed on the attempt, not the run: `gh run rerun` reuses the run's
+    # databaseId and bumps `attempt`, and a rerun leaves the head SHA
+    # alone, so a run-keyed map would swallow every result after the first.
+    while IFS=$'\t' read -r run_key run_name run_conclusion; do
+      [ -z "$run_key" ] && continue
+      if [ -z "${seen_runs[$run_key]:-}" ]; then
+        if [ "$first_poll" -eq 0 ]; then
+          echo "CI_RUN: $run_name ($run_conclusion)"
+        fi
+        seen_runs[$run_key]=1
       fi
     done < <(echo "$runs_json" | jq -r --arg sha "$head_sha" \
-      '.[] | select(.headSha == $sha and (.conclusion // "") != "" and .conclusion != "success") | "\(.databaseId)\t\(.name)\t\(.conclusion)"' \
+      '.[] | select(.headSha == $sha and (.conclusion // "") != "" and .conclusion != "success") | "\(.databaseId):\(.attempt)\t\(.name)\t\(.conclusion)"' \
       || true)
   fi
 

--- a/bin/pr-monitor
+++ b/bin/pr-monitor
@@ -10,9 +10,8 @@
 #
 # Usage: pr-monitor <pr-number> [interval-seconds]
 #
-# Events, one per stdout line. Field values are GitHub's own and are
-# passed through rather than sorted into categories here, so a vocabulary
-# this script has never seen still reaches the reader intact:
+# Events, one per stdout line. Field values are GitHub's own, passed
+# through rather than classified here:
 #
 #   STATE: <state>
 #   REVIEW: <reviewDecision>
@@ -21,11 +20,10 @@
 #   NEW_TOP_COMMENT: [BOT|USER] <author>
 #   NEW_REVIEW: [BOT|USER] <author> <state>
 #   CI_RUN: <workflow run name> (<conclusion>)
-#   POLL_ERROR: <call that failed>: <message>
+#   POLL_ERROR: <call that failed>
 #
-# CI_RUN covers Actions runs whose conclusion is anything but success.
-# Checks that are not Actions runs never reach it; `gh pr checks` sees
-# those.
+# CI_RUN covers Actions runs concluding as anything but success; other
+# checks need `gh pr checks`.
 
 set -eu
 
@@ -185,20 +183,16 @@ while true; do
     prev_ci_sha="$head_sha"
   fi
   # `gh run list` answers `[]` for a branch with no runs, so an empty or
-  # unparseable result means the call itself failed. That gets its own
-  # event because silence here otherwise reads exactly like a clean run,
-  # while the GraphQL sections below keep emitting normally. A swallowed
-  # failure also leaves `seen_runs` unseeded, so the next poll would
-  # replay every run that was already settled at arm time.
+  # unparseable result means the call failed. Swallowing it would read as
+  # a clean run and leave `seen_runs` unseeded for the next poll.
   runs_json="$(gh run list --branch "$head_branch" --json databaseId,name,conclusion,headSha,attempt --limit 20 2>/dev/null || true)"
   if [ -z "$runs_json" ] || ! echo "$runs_json" | jq -e . >/dev/null 2>&1; then
     echo "POLL_ERROR: gh run list"
     runs_json=""
   fi
   if [ -n "$runs_json" ]; then
-    # Keyed on the attempt, not the run: `gh run rerun` reuses the run's
-    # databaseId and bumps `attempt`, and a rerun leaves the head SHA
-    # alone, so a run-keyed map would swallow every result after the first.
+    # Keyed on the attempt: `gh run rerun` reuses the databaseId and
+    # leaves the head SHA alone, so a run-keyed map swallows every rerun.
     while IFS=$'\t' read -r run_key run_name run_conclusion; do
       [ -z "$run_key" ] && continue
       if [ -z "${seen_runs[$run_key]:-}" ]; then

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -177,10 +177,10 @@ is itself a monitored event, so an arm deferred until after the ready
 flip can never observe it. It polls every 60s and emits one stdout line
 per actionable change; quiet periods stay silent.
 
-1. Each event line is `<EVENT>: <details>`, carrying GitHub's own field
-   values. The steps below cover the events with a fixed procedure; read
-   any other line and judge from what it says. `pr-monitor`'s header
-   documents the full set.
+1. Each event line is `<EVENT>` or `<EVENT>: <details>`, carrying
+   GitHub's own field values. The steps below cover the events with a
+   fixed procedure; read any other line and judge from what it says.
+   `pr-monitor`'s header documents the full set.
 
 1. Re-fetch detail on each event with:
    - `gh pr view <number> --json state,isDraft,reviewDecision,latestReviews,statusCheckRollup,comments,updatedAt,mergedAt,headRefName`

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -177,25 +177,10 @@ is itself a monitored event, so an arm deferred until after the ready
 flip can never observe it. It polls every 60s and emits one stdout line
 per actionable change; quiet periods stay silent.
 
-1. Event lines:
-   - `STATE: MERGED` / `STATE: CLOSED` — top-level `state` changed.
-   - `REVIEW: CHANGES_REQUESTED` / `REVIEW: APPROVED` —
-     `reviewDecision` changed.
-   - `READY_FOR_REVIEW` — `isDraft` flipped to false.
-   - `NEW_COMMENT: [BOT|USER] <author> <path>:<line>` — new review-
-     thread comment, thread `isResolved == false` and
-     `isOutdated == false`. `[BOT|USER]` is a routing hint per
-     `pr-reaction.md`; the rule's full thread walk still governs
-     mutations.
-   - `NEW_TOP_COMMENT: [BOT|USER] <author>` — new top-level PR
-     comment.
-   - `NEW_REVIEW: [BOT|USER] <author> <state>` — new PR review
-     (summary body). `state` ∈ `COMMENTED` / `APPROVED` /
-     `CHANGES_REQUESTED` / `DISMISSED`. Empty-body reviews filtered.
-   - `CI_FAILURE: <workflow run name> (<conclusion>)` — an Actions run on
-     the PR's head SHA settled on a conclusion other than `success`; the
-     conclusion is the line's own last field. Checks that are not Actions
-     runs never produce this line; reach them through `gh pr checks`.
+1. Each event line is `<EVENT>: <details>`, carrying GitHub's own field
+   values. The steps below cover the events with a fixed procedure; read
+   any other line and judge from what it says. `pr-monitor`'s header
+   documents the full set.
 
 1. Re-fetch detail on each event with:
    - `gh pr view <number> --json state,isDraft,reviewDecision,latestReviews,statusCheckRollup,comments,updatedAt,mergedAt,headRefName`
@@ -215,11 +200,15 @@ per actionable change; quiet periods stay silent.
      user.
 
 1. React per `pr-reaction.md` (bot check, reply-channel routing,
-   thread resolve, cap for autonomous fix pushes).
+   thread resolve, cap for autonomous fix pushes). A `[BOT|USER]` label
+   on an event line is a routing hint; the rule's thread walk still
+   governs mutations.
 
-1. `CI_FAILURE`: get the `databaseId` from `gh run list`, inspect with
-   `gh run view --log-failed <databaseId>`, then fix and push (same
-   pre-push checks).
+1. `CI_RUN`: get the `databaseId` from `gh run list`, then inspect the
+   run — `gh run view --log-failed <databaseId>` reaches failed steps,
+   which a conclusion like `cancelled` or `timed_out` does not have, so
+   fall back to `gh run view <databaseId>` there. Fix and push under the
+   same pre-push checks.
 
 1. Exit conditions:
    - `STATE: MERGED` → execute Step 6 (Cleanup).

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -204,11 +204,10 @@ per actionable change; quiet periods stay silent.
    on an event line is a routing hint; the rule's thread walk still
    governs mutations.
 
-1. `CI_RUN`: get the `databaseId` from `gh run list`, then inspect the
-   run — `gh run view --log-failed <databaseId>` reaches failed steps,
-   which a conclusion like `cancelled` or `timed_out` does not have, so
-   fall back to `gh run view <databaseId>` there. Fix and push under the
-   same pre-push checks.
+1. `CHECK`: `gh pr checks` links the failing check. For an Actions job,
+   `gh run view --log-failed <databaseId>` from `gh run list` reaches the
+   failed steps, which a conclusion like `cancelled` or `timed_out` does
+   not have. Fix and push under the same pre-push checks.
 
 1. Exit conditions:
    - `STATE: MERGED` → execute Step 6 (Cleanup).

--- a/claude/skills/git-workflow/pr-reaction.md
+++ b/claude/skills/git-workflow/pr-reaction.md
@@ -1,7 +1,6 @@
 # PR Reaction
 
-How to react to PR events emitted by `bin/pr-monitor`. Event line spec
-lives in the git-workflow skill's `SKILL.md` Phase 5.
+How to react to PR events emitted by `bin/pr-monitor`.
 
 ## Targeting policy
 


### PR DESCRIPTION
## Summary

`pr-monitor` decided which GitHub values were worth reporting, and the skill restated the resulting vocabulary. Both halves become pass-through: the script emits the field's own value, and the skill prescribes reactions only for the events that have a fixed procedure. Fixing the vocabulary surfaced several conditions the monitor could not report at all.

## Key changes

- `STATE` and `REVIEW` drop their allowlists and emit whatever the field holds. `STATE` is unchanged in practice — the loop exits at `MERGED` and `CLOSED`, already its only reachable transitions
- Check events come from `statusCheckRollup`, which the poll already fetches, replacing a second call to `gh run list`. That call saw Actions runs only, so this repository's two `Socket Security` checks and any external commit status were unreportable. The rollup also names checks per job, so the event is `CHECK`, not `CI_FAILURE`
- A check reports when the value it holds changes, tracked per name. Keying on a timestamp had assumed one that always moves and is always present, which holds for neither a fast rerun nor a status context
- A failing poll emits `POLL_ERROR`, on every API call, once per outage rather than once per interval. Each guard tests for the shape its consumer reads, since a response arriving is not evidence the call succeeded
- `prev_decision` tracks the empty value, so a re-approval after a dismissal no longer compares equal to the approval before it
- The event formats move to `pr-monitor`'s header. Phase 5's catalogue collapses to one instruction: read the line, follow the prescribed reaction where there is one

## Verification

- [x] The monitor armed on this PR emitted `POLL_ERROR: gh api graphql (threads)` on a transient failure, did not repeat it, and the endpoint checked out healthy afterwards
- [x] Transition sequence over the real comparison: `FAILURE` → `IN_PROGRESS` → `FAILURE` reports twice, a repeated value once, `FAILURE` → `SUCCESS` → `FAILURE` twice, `SKIPPED` and the in-flight states never, and a settled check holding no conclusion once
- [x] The GraphQL guard returns non-zero against a live error response and 0 against this PR's real one
- [x] `jq -e '.statusCheckRollup | type == "array"'`: 0 on the live rollup, non-zero on the JSON `null` the field carries for an empty commit connection
- [x] `jq -e '.state? // empty'`: `0` for `{"state":"OPEN"}`, `4` for `{}` and for empty input, `5` for non-JSON
- [x] `timeout 70 pr-monitor 362`, all checks green: no output, exit 124

No failing check was available to exercise a live `CHECK` emit.

## Follow-ups

- A check that never settles, a required check that was never scheduled, and a green PR are all silent and indistinguishable. Closing it needs a staleness notion the script does not have
- A dismissal that clears `reviewDecision`, and a `gh pr ready --undo`, are both tracked but emit nothing
