### PR TITLE
Add claim-grounding signals to pr-selfcheck

### DIFF
--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -20,10 +20,14 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 1. When verifying a body claim needs file contents at the PR head,
    run `git fetch origin pull/<number>/head` once and read via
    `git show FETCH_HEAD:<path>`. When a body claim asserts repository
-   state at the PR head and shows the query it rests on, re-run that
-   query against `FETCH_HEAD` and report a mismatch as Must Fix. Do
-   not create local branches and do not run `git branch -D`/`-d`
-   (branch deletion blocks on a permission prompt)
+   state at the PR head and shows the query it rests on, re-run it as
+   `git grep <pattern> FETCH_HEAD` and report Must Fix when the result
+   contradicts the claim that query is cited for; incidental
+   differences such as line numbers or unrelated new hits are not a
+   contradiction, and a query with no tree-ish form is unverifiable
+   rather than a Must Fix. Do not create local branches and do not run
+   `git branch -D`/`-d` (branch deletion blocks on a permission
+   prompt)
 1. Read `~/.claude/skills/git-workflow/pr-guidelines.md` to load the PR Body Checklist
 1. For each URL found in the PR body, verify accessibility with WebFetch
    If a URL is unreachable (network error, 403, etc.), report it as "unverifiable" rather than a must-fix.
@@ -66,24 +70,26 @@ signals fire across the body, escalate to Must Fix.
 
 ### Claim-grounding signals
 
-Applies to the PR body only. The forked self-review has no access to
-the authoring session, so a claim is judged on the evidence the body
-itself carries, never on whether the author is likely to have run the
-check.
+Applies to the PR body only. Judge each claim on the evidence the body
+itself carries.
+
+Results that belong in the Checks panel (CI, lint, type-check,
+formatter) are outside this block — the redundancy signal above takes
+them out of the body rather than asking for their output.
 
 Flag each of these as Must Fix on a single occurrence:
 
-- A verification item marked complete whose line carries no command, output excerpt, exit code, or log line; when the diff is documentation or prose only and no command applies, naming what the item was checked against (the source, the spec, the linked issue) satisfies this
-- A negative or absence claim ("no X remains", "該当なし", "影響なし") that does not show the query, command, or enumeration it rests on
+- A `- [x]` verification item carrying no command, output excerpt, exit code, or log line, counting any code block or sub-bullet attached to it; when the item covers documentation or prose and no command applies, naming what it was checked against (the source, the spec, the linked issue) satisfies this
+- A negative or absence claim ("no X remains", "該当なし") that shows neither the query it rests on nor the scope it examined; template-mandated N/A fields are outside this block
 
 Flag each of these as Should Fix; if multiple signals fire across the
 body, escalate to Must Fix:
 
-- A claim about external tool, service, or platform behavior stated without a link to a primary source
-- A causal claim about the system under change ("because X locks the table", "this keeps Y traceable") with no evidence or source attached
+- A claim about the behavior of a tool, service, or platform this diff does not modify, carrying no link to or citation of a primary source (a man page section or `--help` output counts)
+- A causal claim asserting a mechanism a reader cannot check from the diff ("because X locks the table") with no evidence or source attached
 - A value presented as a measured or derived result whose derivation is neither shown nor linked; identifiers and version strings are not in scope
-- Rationale attributed to a linked issue, PR, or document without quoting the sentence it rests on
-- An absence claim whose shown query could under-match its own scope, through a line anchor, a single pattern, or a path filter narrower than the claim
+- Rationale attributed to a linked issue, PR, or document that neither quotes the one sentence it rests on nor links to the section carrying it
+- An absence claim whose shown query is visibly narrower than the claim it supports, through a regex anchored to line start or end, a single literal where the claim covers a family of spellings, or a path filter covering fewer paths than the claim
 
 ### Hard-wrap detection (GitHub-posted markdown)
 
@@ -115,7 +121,7 @@ Excluded from detection to avoid false positives:
 ## PR Self-Check Result
 
 ### Must Fix
-- (Critical issues: broken links, title/content mismatch, missing rationale for important changes)
+- (Critical issues: broken links, title/content mismatch, missing rationale for important changes, verification items and absence claims carrying no evidence)
 
 ### Should Fix
 - (Recommended improvements: missing source URLs, unclear scope description)
@@ -133,4 +139,4 @@ If there are no items for a severity level, write "None."
 
 - This check may be re-run after fixes (e.g., Phase 1 retry, Phase 3 consistency check in the git workflow)
 - Focus on the PR as a communication artifact for human reviewers, not on code correctness (CI covers that)
-- When in doubt, prefer "Should Fix" over "Must Fix" to avoid blocking on subjective issues
+- When in doubt, prefer "Should Fix" over "Must Fix" to avoid blocking on subjective issues. Each signal block above states its own severity, and its tests turn on whether something is present in the body, so those verdicts are settled by the block rather than by this preference

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -19,9 +19,11 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    `gh pr diff <number>`
 1. When verifying a body claim needs file contents at the PR head,
    run `git fetch origin pull/<number>/head` once and read via
-   `git show FETCH_HEAD:<path>`. Do not create local branches and do
-   not run `git branch -D`/`-d` (branch deletion blocks on a
-   permission prompt)
+   `git show FETCH_HEAD:<path>`. When a body claim asserts repository
+   state at the PR head and shows the query it rests on, re-run that
+   query against `FETCH_HEAD` and report a mismatch as Must Fix. Do
+   not create local branches and do not run `git branch -D`/`-d`
+   (branch deletion blocks on a permission prompt)
 1. Read `~/.claude/skills/git-workflow/pr-guidelines.md` to load the PR Body Checklist
 1. For each URL found in the PR body, verify accessibility with WebFetch
    If a URL is unreachable (network error, 403, etc.), report it as "unverifiable" rather than a must-fix.
@@ -61,6 +63,27 @@ signals fire across the body, escalate to Must Fix.
 - Records of direction changes made mid-implementation
 - References to the session, to plan-mode phases, or to individual commits within the branch
 - Rejected alternatives described at implementation-attempt granularity rather than as design alternatives weighed for the delivered design
+
+### Claim-grounding signals
+
+Applies to the PR body only. The forked self-review has no access to
+the authoring session, so a claim is judged on the evidence the body
+itself carries, never on whether the author is likely to have run the
+check.
+
+Flag each of these as Must Fix on a single occurrence:
+
+- A verification item marked complete whose line carries no command, output excerpt, exit code, or log line; when the diff is documentation or prose only and no command applies, naming what the item was checked against (the source, the spec, the linked issue) satisfies this
+- A negative or absence claim ("no X remains", "該当なし", "影響なし") that does not show the query, command, or enumeration it rests on
+
+Flag each of these as Should Fix; if multiple signals fire across the
+body, escalate to Must Fix:
+
+- A claim about external tool, service, or platform behavior stated without a link to a primary source
+- A causal claim about the system under change ("because X locks the table", "this keeps Y traceable") with no evidence or source attached
+- A value presented as a measured or derived result whose derivation is neither shown nor linked; identifiers and version strings are not in scope
+- Rationale attributed to a linked issue, PR, or document without quoting the sentence it rests on
+- An absence claim whose shown query could under-match its own scope, through a line anchor, a single pattern, or a path filter narrower than the claim
 
 ### Hard-wrap detection (GitHub-posted markdown)
 


### PR DESCRIPTION
## Purpose

Every named signal in pr-selfcheck detects surplus content, so a PR body that stays short and non-redundant passes the mechanical side of the self-review regardless of whether its claims carry any evidence. This adds a signal block on the other side: whether each claim in the body is grounded in something the reader can check.

## Key changes

- Claim-grounding signals: a completed verification item with no command, output, exit code, or log attached, and an absence claim that shows neither its query nor the scope it examined, are Must Fix on a single occurrence; unlinked external-behavior claims, unsourced causal claims, underived measured values, unanchored attributed rationale, and absence claims resting on a visibly narrow query are Should Fix that escalate together
- Step 3 now re-runs a body-stated query as `git grep <pattern> FETCH_HEAD` when the claim asserts repository state at the PR head, reusing the fetch the step already performs, and treats a query with no tree-ish form as unverifiable
- The severity preference in Important Notes and the Must Fix enumeration in Output Format both account for signal blocks that state their own severity, so the single-occurrence Must Fix pair does not sit beside guidance that contradicts it

## Notes

The self-review runs with `context: fork`, which the Claude Code documentation describes as "It won't have access to your conversation history" (https://code.claude.com/docs/en/skills.md, "Run skills in a subagent"). Its evidence set is therefore the PR metadata, the diff, files at the PR head, the checklist, and commands it runs itself. Claims about execution the author performed outside the PR stay out of reach of any detection-side signal; the two Must Fix bullets are objective presence tests on the body, which is why the severity preference now defers to the block that states them.

Re-running a body-stated query catches a claim that went stale against the head. It cannot catch a query that was wrong when written, since re-running it reproduces the same wrong answer — the "visibly narrower than the claim" bullet covers that case instead.

## Verification

- [x] pre-commit hooks on both commits → `Trim Trailing Whitespace...Passed`, `Fix End of Files...Passed`, `Check for added large files...Passed`
- [x] Signal wording measured against 92 PR-body findings drawn from this machine's retro-note records across 6 projects. Method: each finding was labelled with the defect axis it represents and with whether the current skill text detects it (a named signal, the loaded checklist alone, or neither), then judged again for whether a proposed bullet would fire on it. Newly caught over the 63 findings currently undetected or checklist-only, by axis: overclaim 10 of 21, deficiency 1 of 8, excess 0 of 3, procedure 0 of 15, out-of-scope 0 of 16. The 31 procedure and out-of-scope findings are unreachable by any body-text signal, so the overclaim row carries the change's value. Those records are machine-local and include findings from private repositories, so the labelling is not reproducible from this repository
- [ ] Effect on live PRs is not yet measured
