### PR TITLE
Reorganize the PR quality standard around five properties

### DIFF
--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -59,14 +59,14 @@ formatting or indentation.
 ## 3. Create a PR
 
 1. If the branch already has a PR (`gh pr view --json number,url`),
-   skip creation. Bring its title and body up to the PR Body Checklist
+   skip creation. Bring its title and body up to `pr-guidelines.md`
    using the section 5 procedure, display the PR URL to the user, then
    proceed to CI wait (step 4).
 1. Write the PR body to a fresh file under the session scratchpad
    directory using the Write tool (new filename per revision — a new
    file needs no prior Read step)
    - Follow the repository's PR template if one exists
-   - Follow the PR Body Checklist
+   - Follow `pr-guidelines.md`
 1. Create the PR as a draft:
    `gh pr create --draft --body-file <body file path>`
    - Never use `--body` for PR creation. The `#`-prefixed lines in the body

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -59,8 +59,8 @@ formatting or indentation.
 ## 3. Create a PR
 
 1. If the branch already has a PR (`gh pr view --json number,url`),
-   skip creation. Bring its title and body up to `pr-guidelines.md`
-   using the section 5 procedure, display the PR URL to the user, then
+   skip creation. Bring its title and body into conformance with
+   `pr-guidelines.md` using the section 5 procedure, display the PR URL to the user, then
    proceed to CI wait (step 4).
 1. Write the PR body to a fresh file under the session scratchpad
    directory using the Write tool (new filename per revision — a new

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -11,15 +11,16 @@ need why the change was made and the shape of the decision behind it;
 neither needs what the diff already shows.
 
 A body is ready when it holds all five properties below. Every rule in
-this file belongs to exactly one of them, and `/pr-selfcheck` evaluates
-them one at a time.
+the five property sections belongs to exactly one of them, and
+`/pr-selfcheck` evaluates them one at a time.
 
 - Decidable — a reviewer can decide approve or reject from the body
   alone, reading top-down
 - Grounded — every claim is checkable on the evidence the body itself
   carries
-- Necessary — the body carries nothing the diff, the Checks panel, or a
-  linked source already carries
+- Necessary — the body carries nothing the diff or the Checks panel
+  already carries, states each thing once, and takes from a linked
+  source no more than the summary that survives the link going dead
 - Scoped — the diff carries only what the stated intent needs, and the
   body accounts for all of it
 - Conformant — the body renders and behaves as intended on GitHub
@@ -30,16 +31,15 @@ them one at a time.
   etc.). The body alone should convey the intent and let a reviewer
   understand the purpose, what changed, and the impact.
 - Give the shape of the decision: the approach taken vs. the approaches
-  rejected, what was deliberately left out of scope, and risks or
-  things a reviewer should watch out for. "Approaches rejected" covers
-  design alternatives weighed for the delivered design.
+  rejected, and risks or things a reviewer should watch out for.
+  "Approaches rejected" covers design alternatives weighed for the
+  delivered design.
 - Inverted pyramid — place the most important information first. A
   reviewer reading only the first few lines should be able to tell what
   kind of PR this is and where to focus.
 - Progressive disclosure — surface only what a reviewer needs to
-  decide. Move implementation details, history, or full alternatives
-  narrative behind a link or to a "Notes" / "Background" section at the
-  end.
+  decide. Move implementation details or full alternatives narrative
+  behind a link or to a "Notes" / "Background" section at the end.
 - Future work, out-of-scope follow-ups, and "next PR" notes belong at
   the end of the body (e.g., in a "Follow-up" / "Notes" section). Do
   not surface them in the opening sections (purpose, scope, summary),
@@ -101,7 +101,10 @@ them one at a time.
   flight checklist when every item is "N/A" (collapse it to one line).
 - Keep CI, lint, formatter, type-check, and build / test command
   results (`go build`, `go test`, `go vet`, `pre-commit`) out of the
-  body, whether or not the repository's CI runs them.
+  body, whether or not the repository's CI runs them. Output that CI or
+  another automation posts on the PR itself (build status, terraform /
+  CDK plan output, lint and type-check results) stays where it was
+  posted; the body does not restate it.
 - Focus on what changes from the user's or system's perspective —
   behavior changes, new capabilities, removed limitations — rather than
   on implementation details (resources added, files touched).
@@ -119,9 +122,9 @@ them one at a time.
   the same list do not restate one another in different wording.
 - Rationale, background, or requirements that live elsewhere (issue,
   design doc, ADR, prior PR, official spec) are summarized under a
-  link, not copied. A bare link is itself a defect: the target is the
-  shortest summary that survives the link going dead, and anything past
-  that point is duplication.
+  link, not copied. A bare link is itself a defect: write the shortest
+  summary that survives the link going dead, and anything past that
+  point is duplication.
 - When the diff is self-explanatory — documentation or config edits
   whose changed lines a reviewer can read directly, especially in the
   team's own language — keep the body to what the diff cannot convey
@@ -131,11 +134,8 @@ them one at a time.
 - A section heading grants no exemption. "diff から読み取れない設計判断",
   "補足", or "詳細" does not excuse its contents from this property —
   each paragraph under it still has to be needed for the decision.
-- Length is not a criterion, and a body that is long because every part
-  of it is needed is correct as it is. When the body reads as
-  noticeably long for the size of the change, re-read it against this
-  property and Scoped; report what that pass finds, and nothing when it
-  finds nothing.
+- A body that is long because every part of it is needed is correct as
+  it is, and length itself is never a finding.
 
 ## Scoped
 
@@ -150,8 +150,10 @@ them one at a time.
 - The body conveys the holistic intent of the change — what the PR is
   trying to achieve across the whole diff — accounts for every file and
   change in it, and leaves no unexplained hunks.
-- Every changed code path is covered by CI, manual test steps in the PR
-  body, or another verification mechanism.
+- The body names a verification mechanism — CI, manual test steps, or
+  another check — for the code paths the diff changes. The test is
+  whether the body makes that claim; judging how adequate the coverage
+  is belongs to code review.
 - Keep the PR self-contained. Verification items, acceptance criteria,
   and follow-up actions that depend on changes outside this PR's diff
   (other repos, downstream releases, E2E flows) belong in the parent
@@ -171,15 +173,18 @@ them one at a time.
 - Do NOT use auto-close keywords (`Closes`, `Fixes`, `Resolves`).
 - Checkbox syntax (`- [ ]` / `- [x]`) is reserved for verification
   items: `- [x]` for one the author verified, `- [ ]` for one the user
-  is expected to verify or act on later so it can be ticked off. Prose
-  statements do not take a checkbox.
-- Inside GitHub PR / issue bodies and PR / issue comments only — that
-  is, Markdown posted through the GitHub web UI — do not hard-wrap
-  paragraphs or list items. Write each paragraph as a single line and
-  let the browser wrap it; use blank lines for paragraph breaks. GitHub
-  Flavored Markdown renders soft line breaks inside a paragraph as
-  visible breaks (or runs lines together awkwardly) only in these
-  contexts. Plain Markdown files (READMEs, ADRs, this guidelines file
+  is expected to verify or act on later so it can be ticked off, and
+  `- [ ]` carrying a one-line reason for an author-owed item that
+  Grounded exempts as unverifiable by the author. Prose statements do
+  not take a checkbox.
+- Inside GitHub issues, pull requests, and discussions — bodies and
+  comments alike, that is Markdown posted through the GitHub web UI —
+  do not hard-wrap paragraphs or list items. Write each paragraph as a
+  single line and let the browser wrap it; use blank lines for
+  paragraph breaks. GitHub Flavored Markdown renders soft line breaks
+  inside a paragraph as visible breaks only in these contexts
+  ([basic writing and formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)).
+  Plain Markdown files (READMEs, ADRs, this guidelines file
   itself, and any other in-repo documentation) follow standard Markdown
   rendering and may be hard-wrapped for file-side readability.
 

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -3,21 +3,28 @@
 Quality criteria for pull requests. Follow these when writing a PR body
 and when self-reviewing your own PR.
 
-A PR body serves two audiences: the reviewer deciding now, and the
-future reader who reaches this PR from `git log` or blame. Both need
-why the change was made and the shape of the decision behind it;
+A PR body is a summary that helps a reviewer decide, not a complete
+record of the change: everything else lives in the diff, the issue, or
+a linked source. It serves two audiences — the reviewer deciding now,
+and the future reader who reaches this PR from `git log` or blame. Both
+need why the change was made and the shape of the decision behind it;
 neither needs what the diff already shows.
 
-Every rule below belongs to exactly one of five properties — Decidable,
-Grounded, Necessary, Scoped, Conformant. A body is ready when it holds
-all five, and `/pr-selfcheck` evaluates them one at a time.
+A body is ready when it holds all five properties below. Every rule in
+this file belongs to exactly one of them, and `/pr-selfcheck` evaluates
+them one at a time.
+
+- Decidable — a reviewer can decide approve or reject from the body
+  alone, reading top-down
+- Grounded — every claim is checkable on the evidence the body itself
+  carries
+- Necessary — the body carries nothing the diff, the Checks panel, or a
+  linked source already carries
+- Scoped — the diff carries only what the stated intent needs, and the
+  body accounts for all of it
+- Conformant — the body renders and behaves as intended on GitHub
 
 ## Decidable
-
-A reviewer can decide approve or reject from the body alone, reading
-top-down. The body is a summary that helps them decide, not a complete
-record of the change: everything else lives in the diff, the issue, or
-a linked source.
 
 - State what changed and why (bug, feature, tech debt, compliance,
   etc.). The body alone should convey the intent and let a reviewer
@@ -45,8 +52,6 @@ a linked source.
   them.
 
 ## Grounded
-
-Every claim is checkable, on the evidence the body itself carries.
 
 - Attempt every verification within reach before drafting the
   Verification section: shell commands, API calls, file inspection,
@@ -87,9 +92,6 @@ Every claim is checkable, on the evidence the body itself carries.
   contradict the diff.
 
 ## Necessary
-
-The body carries nothing the diff, the Checks panel, or a linked source
-already carries.
 
 - Do not paraphrase the diff. Keep out file lists, line counts,
   percentage of lines removed, per-file summaries, enumerations of
@@ -137,9 +139,6 @@ already carries.
 
 ## Scoped
 
-The diff carries only what the stated intent needs, and the body
-accounts for all of it.
-
 - Describe the boundary of the change and call out anything
   intentionally left out of scope.
 - The PR diff itself is a deliverable. Edits, reformats, renames, and
@@ -161,8 +160,6 @@ accounts for all of it.
   should be split into finer-grained PRs.
 
 ## Conformant
-
-The body renders and behaves as intended on GitHub.
 
 - The title is a one-line summary in the team's review language. Any
   content that doesn't fit on one line — including issue references

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -18,9 +18,11 @@ the five property sections belongs to exactly one of them, and
   alone, reading top-down
 - Grounded — every claim is checkable on the evidence the body itself
   carries
-- Necessary — the body carries nothing the diff or the Checks panel
-  already carries, states each thing once, and takes from a linked
-  source no more than the summary that survives the link going dead
+- Necessary — the body carries nothing the PR already carries
+  elsewhere (the diff, its commits, the Checks panel, output an
+  automation posted on it), states each thing once, and takes from a
+  linked source no more than the summary that survives the link going
+  dead
 - Scoped — the diff carries only what the stated intent needs, and the
   body accounts for all of it
 - Conformant — the body renders and behaves as intended on GitHub

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -3,74 +3,179 @@
 Quality criteria for pull requests. Follow these when writing a PR body
 and when self-reviewing your own PR.
 
-## Writing Style
+A PR body serves two audiences: the reviewer deciding now, and the
+future reader who reaches this PR from `git log` or blame. Both need
+why the change was made and the shape of the decision behind it;
+neither needs what the diff already shows.
 
-A PR body is a summary that helps a reviewer decide, not a complete
-record of the change. Follow the Essence-first principle: surface
-what a reviewer needs to approve or reject the PR; everything else
-lives in the diff, the issue, or a linked source.
+Every rule below belongs to exactly one of five properties — Decidable,
+Grounded, Necessary, Scoped, Conformant. A body is ready when it holds
+all five, and `/pr-selfcheck` evaluates them one at a time.
 
-The title is a one-line summary in the team's review language. Any
-content that doesn't fit on one line — including issue references
-(`#123`, `org/repo#123`) — belongs in the body, not the title.
+## Decidable
 
-### Principles
+A reviewer can decide approve or reject from the body alone, reading
+top-down. The body is a summary that helps them decide, not a complete
+record of the change: everything else lives in the diff, the issue, or
+a linked source.
 
-- Why over what — The diff already shows what changed. The body
-  explains why, and the shape of the decision (the approach taken
-  vs. approaches rejected, what was deliberately left out of scope,
-  risks or things a reviewer should watch out for). Do not paraphrase
-  the diff (file lists, "added X to Y", per-file summaries).
-  "Approaches rejected" covers design alternatives weighed for the
-  delivered design; the sequence of implementation attempts made
-  along the way stays out of the body.
-- Single source of truth (DRY) — If the rationale, background, or
-  requirements live elsewhere (issue, design doc, ADR, prior PR,
-  official spec), do not duplicate them. Replace with a one-line
-  summary plus a link. Two copies drift apart over time.
-  This also applies to information that CI or automation posts on
-  the PR (build status, terraform/CDK plan output, lint results,
-  type check results): do not restate those facts in the body —
-  let the bot comments and checks panel speak for themselves.
-- Inverted pyramid — Place the most important information first. A
-  reviewer reading only the first few lines should be able to tell
-  what kind of PR this is and where to focus.
-- Progressive disclosure — Surface only what a reviewer needs to
+- State what changed and why (bug, feature, tech debt, compliance,
+  etc.). The body alone should convey the intent and let a reviewer
+  understand the purpose, what changed, and the impact.
+- Give the shape of the decision: the approach taken vs. the approaches
+  rejected, what was deliberately left out of scope, and risks or
+  things a reviewer should watch out for. "Approaches rejected" covers
+  design alternatives weighed for the delivered design.
+- Inverted pyramid — place the most important information first. A
+  reviewer reading only the first few lines should be able to tell what
+  kind of PR this is and where to focus.
+- Progressive disclosure — surface only what a reviewer needs to
   decide. Move implementation details, history, or full alternatives
-  narrative behind a link or to a "Notes" / "Background" section at
-  the end.
-- Diff scope discipline — The PR diff itself is a deliverable
-  Edits, reformats, renames, and "while I'm here" cleanups that fall
-  outside the PR's stated scope should not appear in the diff. Out-
-  of-scope hunks force the reviewer to separate "intent vs incidental"
-  and inflate review load. Adjacent incidental fixes (an obvious
-  typo) are tolerable in moderation, but the default is to leave them
-  for a separate PR. The body should convey the holistic intent of
-  the change — what the PR is trying to achieve across the whole
-  diff — and the diff should reflect only that intent.
-- Language follows the target repository, not the conversation —
-  honor any explicit rule in the repo's `CLAUDE.md` / `AGENTS.md`
-  first, otherwise match the existing PR / commit history. Don't let
-  the language of the chat with the user decide.
-
-### Style rules
-
-- Keep bullet points few and meaningful. Each bullet should convey a
-  distinct decision or outcome, not an individual code change.
-- Focus on what changes from the user's or system's perspective —
-  behavior changes, new capabilities, removed limitations, etc. —
-  rather than listing implementation details (resources added, files
-  touched).
+  narrative behind a link or to a "Notes" / "Background" section at the
+  end.
+- Future work, out-of-scope follow-ups, and "next PR" notes belong at
+  the end of the body (e.g., in a "Follow-up" / "Notes" section). Do
+  not surface them in the opening sections (purpose, scope, summary),
+  where they compete with the approve/reject decision.
 - Tables must stand alone. Give each table a caption or a one-line
-  lead-in that tells the reader what it shows (e.g., "Alert firings
-  in the past 7 days"). A reader who skips the surrounding prose
-  should still understand what the table represents. Avoid placing
-  tables mid-sentence where their meaning depends on parsing the
-  prose around them.
-- Future work, out-of-scope follow-ups, and "next PR" notes belong
-  at the end of the body (e.g., in a "Follow-up" / "Notes" section).
-  Do not surface them in the opening sections (purpose, scope,
-  summary), where they compete with the approve/reject decision.
+  lead-in that tells the reader what it shows (e.g., "Alert firings in
+  the past 7 days"). A reader who skips the surrounding prose should
+  still understand what the table represents. Avoid placing tables
+  mid-sentence where their meaning depends on parsing the prose around
+  them.
+
+## Grounded
+
+Every claim is checkable, on the evidence the body itself carries.
+
+- Attempt every verification within reach before drafting the
+  Verification section: shell commands, API calls, file inspection,
+  mocked failure modes, simulated missing-config tests. Punting
+  reachable items to "Pending" or "User to verify" is itself the
+  violation — overstating what is "untestable" is the common failure
+  mode.
+- List only items actually verified, each carrying its evidence: a
+  command, output excerpt, exit code, or log line, counting any code
+  block or sub-bullet attached to it. When the item covers
+  documentation or prose and no command applies, name what it was
+  checked against (the source, the spec, the linked issue).
+- Items that genuinely require interactive UI, user-only credentials,
+  target environments unreachable from a shell, or the live session
+  itself must be clearly distinguished with reproduction steps and a
+  one-line reason why the author could not verify them.
+- A negative or absence claim ("no X remains", "該当なし") shows the
+  query it rests on and the scope it examined; template-mandated N/A
+  fields are outside this rule. The shown query covers the whole claim
+  — a regex anchored to line start or end, a single literal where the
+  claim covers a family of spellings, or a path filter narrower than
+  the claim does not.
+- Provide official documentation URLs or other authoritative sources
+  that justify configuration values, tool choices, or version
+  selections. Especially important for dotfiles / infrastructure
+  changes where "why this value" matters. A claim about the behavior of
+  a tool, service, or platform this diff does not modify carries a link
+  to or citation of a primary source (a man page section or `--help`
+  output counts).
+- A causal claim asserting a mechanism a reader cannot check from the
+  diff ("because X locks the table") carries evidence or a source.
+- A value presented as a measured or derived result shows or links its
+  derivation; identifiers and version strings are outside this rule.
+- Rationale attributed to a linked issue, PR, or document quotes the
+  one sentence it rests on, or links to the section carrying it.
+- All URLs and anchor links resolve to the expected content.
+- The title accurately reflects the change, and the body does not
+  contradict the diff.
+
+## Necessary
+
+The body carries nothing the diff, the Checks panel, or a linked source
+already carries.
+
+- Do not paraphrase the diff. Keep out file lists, line counts,
+  percentage of lines removed, per-file summaries, enumerations of
+  added rules, linters, settings, constants, or values, self-paraphrase
+  of own edits ("edited file X", "bumped value from A to B", "added N
+  items", "raised timeout to M"), and per-item rendering of a pre-
+  flight checklist when every item is "N/A" (collapse it to one line).
+- Keep CI, lint, formatter, type-check, and build / test command
+  results (`go build`, `go test`, `go vet`, `pre-commit`) out of the
+  body, whether or not the repository's CI runs them.
+- Focus on what changes from the user's or system's perspective —
+  behavior changes, new capabilities, removed limitations — rather than
+  on implementation details (resources added, files touched).
+- The body records the delivered design, not the path to it. Keep out
+  chronological narration of implementation attempts ("first tried X,
+  it failed, so Y"), records of direction changes made mid-
+  implementation, references to the session, to plan-mode phases, or to
+  individual commits within the branch, and rejected alternatives
+  described at implementation-attempt granularity.
+- State a fact once. The same environment variable name, file name,
+  design decision, or summary of a linked source does not appear in two
+  places in the body.
+- Keep bullet points few and meaningful. Each bullet conveys a distinct
+  decision or outcome, not an individual code change, and bullets in
+  the same list do not restate one another in different wording.
+- Rationale, background, or requirements that live elsewhere (issue,
+  design doc, ADR, prior PR, official spec) are summarized under a
+  link, not copied. A bare link is itself a defect: the target is the
+  shortest summary that survives the link going dead, and anything past
+  that point is duplication.
+- When the diff is self-explanatory — documentation or config edits
+  whose changed lines a reviewer can read directly, especially in the
+  team's own language — keep the body to what the diff cannot convey
+  (rationale, scope boundary). When nothing remains to add, one line
+  such as "realigned stale wording with the actual code/config" is a
+  complete description.
+- A section heading grants no exemption. "diff から読み取れない設計判断",
+  "補足", or "詳細" does not excuse its contents from this property —
+  each paragraph under it still has to be needed for the decision.
+- Length is not a criterion, and a body that is long because every part
+  of it is needed is correct as it is. When the body reads as
+  noticeably long for the size of the change, re-read it against this
+  property and Scoped; report what that pass finds, and nothing when it
+  finds nothing.
+
+## Scoped
+
+The diff carries only what the stated intent needs, and the body
+accounts for all of it.
+
+- Describe the boundary of the change and call out anything
+  intentionally left out of scope.
+- The PR diff itself is a deliverable. Edits, reformats, renames, and
+  "while I'm here" cleanups that fall outside the PR's stated scope
+  should not appear in the diff. Out-of-scope hunks force the reviewer
+  to separate "intent vs incidental" and inflate review load. Adjacent
+  incidental fixes (an obvious typo) are tolerable in moderation, but
+  the default is to leave them for a separate PR.
+- The body conveys the holistic intent of the change — what the PR is
+  trying to achieve across the whole diff — accounts for every file and
+  change in it, and leaves no unexplained hunks.
+- Every changed code path is covered by CI, manual test steps in the PR
+  body, or another verification mechanism.
+- Keep the PR self-contained. Verification items, acceptance criteria,
+  and follow-up actions that depend on changes outside this PR's diff
+  (other repos, downstream releases, E2E flows) belong in the parent
+  issue.
+- A description that keeps growing is a prompt to ask whether the diff
+  should be split into finer-grained PRs.
+
+## Conformant
+
+The body renders and behaves as intended on GitHub.
+
+- The title is a one-line summary in the team's review language. Any
+  content that doesn't fit on one line — including issue references
+  (`#123`, `org/repo#123`) — belongs in the body, not the title.
+- Language follows the target repository, not the conversation — honor
+  any explicit rule in the repo's `CLAUDE.md` / `AGENTS.md` first,
+  otherwise match the existing PR / commit history. Don't let the
+  language of the chat with the user decide.
+- Do NOT use auto-close keywords (`Closes`, `Fixes`, `Resolves`).
+- Checkbox syntax (`- [ ]` / `- [x]`) is reserved for verification
+  items: `- [x]` for one the author verified, `- [ ]` for one the user
+  is expected to verify or act on later so it can be ticked off. Prose
+  statements do not take a checkbox.
 - Inside GitHub PR / issue bodies and PR / issue comments only — that
   is, Markdown posted through the GitHub web UI — do not hard-wrap
   paragraphs or list items. Write each paragraph as a single line and
@@ -81,103 +186,13 @@ content that doesn't fit on one line — including issue references
   itself, and any other in-repo documentation) follow standard Markdown
   rendering and may be hard-wrapped for file-side readability.
 
-## PR Body Checklist
-
-Used both when authoring a PR body and when self-reviewing it (via
-`/pr-selfcheck`). Cover every applicable item — each rule is stated
-once and applies to both perspectives.
-
-1. Purpose, scope, intent
-   - State what changed and why (bug, feature, tech debt, compliance,
-     etc.). The body alone should convey the intent and let a reviewer
-     understand the purpose, what changed, and the impact.
-   - Describe the boundary of the change and call out anything
-     intentionally left out of scope.
-   - Keep the PR self-contained. Verification items, acceptance
-     criteria, and follow-up actions that depend on changes outside
-     this PR's diff (other repos, downstream releases, E2E flows)
-     belong in the parent issue, not in the PR body.
-
-1. Sources and references
-   - Provide official documentation URLs or other authoritative
-     sources that justify configuration values, tool choices, or
-     version selections. Especially important for dotfiles /
-     infrastructure changes where "why this value" matters.
-   - All URLs and anchor links must resolve to the expected content
-
-1. Issue linking
-   - Do NOT use auto-close keywords (`Closes`, `Fixes`, `Resolves`)
-
-1. Verification
-   - Attempt every verification within reach before drafting this
-     section: shell commands, API calls, file inspection, mocked
-     failure modes, simulated missing-config tests. Punting reachable
-     items to "Pending" or "User to verify" is itself the violation —
-     overstating what is "untestable" is the common failure mode.
-   - List only items actually verified, with evidence (command
-     output, exit code, log excerpt). Never record what the diff or
-     GitHub UI already shows: line counts, `wc -l` of a file you
-     edited, the list of changed files, percentage removed,
-     paraphrase of own edits, or CI / lint / type-check results
-     (those live in the Checks panel and bot comments).
-   - Items that genuinely require interactive UI, user-only
-     credentials, target environments unreachable from a shell, or
-     the live session itself must be clearly distinguished with
-     reproduction steps and a one-line reason why the author could
-     not verify them.
-   - Use `- [ ] …` markdown checkboxes for items the user is
-     expected to verify or act on later, so they can be ticked off
-     after completion.
-   - Every changed code path is covered by CI, manual test steps in
-     the PR body, or another verification mechanism. All verification
-     items are scoped to this PR's diff alone; cross-component or E2E
-     items belong in the parent issue.
-
-1. Conciseness (Essence-first)
-   - The principles above (Why over what, DRY, Inverted pyramid,
-     Progressive disclosure, Diff scope discipline) apply directly
-     here — they are not restated as separate review questions.
-     A sentence that paraphrases the diff, duplicates a linked
-     source, or buries the lead is a violation regardless of which
-     principle names it.
-   - Never include in the body:
-     - Enumerations of added rules, linters, settings, constants,
-       or values (visible in the diff)
-     - CI job pass/fail, lint results, type-check results
-     - Self-paraphrase of own edits ("edited file X", "bumped value
-       from A to B", "added N items", "raised timeout to M")
-     - File lists, line counts, percentage of lines removed
-     - Per-item rendering of a pre-flight checklist when every item
-       is "N/A" — collapse to one line
-   - Bullets are few and meaningful, each conveying a distinct point
-   - When the diff is self-explanatory — documentation or config
-     edits whose changed lines a reviewer can read directly,
-     especially in the team's own language — keep the body to what
-     the diff cannot convey (rationale, scope boundary). When
-     nothing remains to add, one line such as "realigned stale
-     wording with the actual code/config" is a complete description.
-   - Length budget: the main description section (実装内容 or
-     equivalent) stays within roughly 10 lines — one background
-     paragraph plus change bullets. When the whole body excluding
-     template-mandated sections exceeds ~30 lines, treat it as a
-     Progressive disclosure violation: compress mechanism deep-dives,
-     history, and repeated explanations into a link or delete them.
-     `/pr-selfcheck` reports budget overruns as Should Fix.
-
-1. Title / body / diff consistency
-   - The title accurately reflects the change
-   - The body does not contradict the diff
-   - The body accounts for all files and changes in the diff; there
-     are no unexplained hunks.
-
 ## PR Body Template (fallback)
 
 Use this scaffold when the target repository has no `pull_request_template.md`.
 Repository templates always win — do not overlay this on top of one.
 Section names stay English; body language follows the repo (see
-"Language follows the target repository" above). Purpose / Key
-changes / Verification is the minimum. Sources / References /
-Issue-linking (checklist items 2-3) are inlined only when applicable.
+Conformant above). Purpose / Key changes / Verification is the minimum.
+Sources and issue links are inlined only when applicable.
 
 ```
 ## Purpose

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -25,8 +25,8 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    numbers or unrelated new hits are not a contradiction. Do not create
    local branches and do not run `git branch -D`/`-d` (branch deletion
    blocks on a permission prompt)
-1. Read `~/.claude/skills/git-workflow/pr-guidelines.md` to load the
-   five properties the PR body is judged against
+1. Locate and read `pr-guidelines.md`, bundled with the `git-workflow`
+   skill, to load the five properties the PR body is judged against
 1. For each URL found in the PR body, fetch it with WebFetch. A host
    that does not answer (network error, timeout, 403) makes the URL
    unverifiable; a 404 from a host that answered, or content that

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -21,83 +21,36 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    run `git fetch origin pull/<number>/head` once and read via
    `git show FETCH_HEAD:<path>`. When a body claim asserts repository
    state at the PR head and shows the query it rests on, re-run it as
-   `git grep <pattern> FETCH_HEAD` and report Must Fix when the result
-   contradicts the claim that query is cited for; incidental
-   differences such as line numbers or unrelated new hits are not a
-   contradiction, and a query with no tree-ish form is unverifiable
-   rather than a Must Fix. Do not create local branches and do not run
-   `git branch -D`/`-d` (branch deletion blocks on a permission
-   prompt)
-1. Read `~/.claude/skills/git-workflow/pr-guidelines.md` to load the PR Body Checklist
-1. For each URL found in the PR body, verify accessibility with WebFetch
-   If a URL is unreachable (network error, 403, etc.), report it as "unverifiable" rather than a must-fix.
-1. Analyze the PR against the review criteria below
-1. Output the result in the format described below
+   `git grep <pattern> FETCH_HEAD`; incidental differences such as line
+   numbers or unrelated new hits are not a contradiction. Do not create
+   local branches and do not run `git branch -D`/`-d` (branch deletion
+   blocks on a permission prompt)
+1. Read `~/.claude/skills/git-workflow/pr-guidelines.md` to load the
+   five properties the PR body is judged against
+1. For each URL found in the PR body, fetch it with WebFetch. A host
+   that does not answer (network error, timeout, 403) makes the URL
+   unverifiable; a 404 from a host that answered, or content that
+   contradicts what the body cites the URL for, is Must Fix
+1. Walk the five properties one at a time, in the order
+   `pr-guidelines.md` states them, judging the PR against that
+   property's rules and the severity table below
+1. Output the result in the format described below, reporting a line
+   for every property including those with no finding
 
-## Review Criteria
+## Severity
 
-Evaluate the PR against the PR Body Checklist loaded in Step 4 (`~/.claude/skills/git-workflow/pr-guidelines.md`).
+| Verdict | Condition |
+| --- | --- |
+| Must Fix | An objective presence or absence test on the body, or a contradiction confirmed against a checked source (the diff, `FETCH_HEAD`, a fetched URL) |
+| Should Fix | A judgment of degree: redundancy, ordering, bullet granularity |
+| Nice to Have | Wording or formatting with no effect on the decision |
+| Escalation | Two or more Should Fix within one property escalates that property to Must Fix |
+| Unverifiable | An unreachable URL, or a query with no tree-ish form. Reported as unverifiable, never Must Fix |
 
-In addition to the high-level checklist, apply the following concrete
-signals so detection does not rely on subagent interpretation alone.
+## Hard-wrap detection (GitHub-posted markdown)
 
-### Redundancy / essence-first signals
-
-Flag each as Should Fix; if multiple signals fire across the body,
-escalate to Must Fix.
-
-- Sentences or bullets that paraphrase what the diff already shows ("edited file X", "bumped value from A to B", "added N items", per-file summaries)
-- CI / lint / type-check / `go build` / `go test` / `go vet` / `pre-commit` results recorded in the Verification section (the Checks panel and bot comments are the authoritative source)
-- The same fact (environment variable name, file name, design decision, summary of a linked source) repeated in multiple places in the body
-- Bullets in the same list that restate the same decision or fact in different wording, with no distinct information per item
-- Content copied verbatim from a design doc, spec, linked issue, or primary source where a one-line summary plus link would suffice
-
-When the implementation-summary section exceeds ~10 lines, or the
-whole body (excluding template-mandated sections) exceeds ~30 lines,
-report the overrun itself as Should Fix (pr-guidelines: Length
-budget), and re-examine the body against the signals above to decide
-what to cut and whether to escalate.
-
-### Process-record signals
-
-Applies to the PR body only. Flag each as Should Fix; if multiple
-signals fire across the body, escalate to Must Fix.
-
-- Chronological narration of implementation attempts ("first tried X, it failed, so Y")
-- Records of direction changes made mid-implementation
-- References to the session, to plan-mode phases, or to individual commits within the branch
-- Rejected alternatives described at implementation-attempt granularity rather than as design alternatives weighed for the delivered design
-
-### Claim-grounding signals
-
-Applies to the PR body only. Judge each claim on the evidence the body
-itself carries.
-
-Results that belong in the Checks panel (CI, lint, type-check,
-formatter) are outside this block — the redundancy signal above takes
-them out of the body rather than asking for their output.
-
-Flag each of these as Must Fix on a single occurrence:
-
-- A `- [x]` verification item carrying no command, output excerpt, exit code, or log line, counting any code block or sub-bullet attached to it; when the item covers documentation or prose and no command applies, naming what it was checked against (the source, the spec, the linked issue) satisfies this
-- A negative or absence claim ("no X remains", "該当なし") that shows neither the query it rests on nor the scope it examined; template-mandated N/A fields are outside this block
-
-Flag each of these as Should Fix; if multiple signals fire across the
-body, escalate to Must Fix:
-
-- A claim about the behavior of a tool, service, or platform this diff does not modify, carrying no link to or citation of a primary source (a man page section or `--help` output counts)
-- A causal claim asserting a mechanism a reader cannot check from the diff ("because X locks the table") with no evidence or source attached
-- A value presented as a measured or derived result whose derivation is neither shown nor linked; identifiers and version strings are not in scope
-- Rationale attributed to a linked issue, PR, or document that neither quotes the one sentence it rests on nor links to the section carrying it
-- An absence claim whose shown query is visibly narrower than the claim it supports, through a regex anchored to line start or end, a single literal where the claim covers a family of spellings, or a path filter covering fewer paths than the claim
-
-### Hard-wrap detection (GitHub-posted markdown)
-
-For PR bodies, PR comments, issue bodies, and issue comments, GitHub
-Flavored Markdown renders soft line breaks inside a paragraph as
-visible breaks. Blank lines between paragraphs serve as paragraph
-separators and are allowed. Flag each violation as Should Fix;
-multiple violations across the body escalate to Must Fix.
+Conformant forbids hard-wrapping in GitHub-posted markdown. Apply this
+parser rather than judging line breaks by eye.
 
 A "block marker" below means a line starting with any of: `#`, `-`,
 `*`, `+`, a digit followed by `.` (e.g. `1.`), `>`, `|`, four spaces
@@ -121,13 +74,23 @@ Excluded from detection to avoid false positives:
 ## PR Self-Check Result
 
 ### Must Fix
-- (Critical issues: broken links, title/content mismatch, missing rationale for important changes, verification items and absence claims carrying no evidence)
+- [<property>] <finding>
 
 ### Should Fix
-- (Recommended improvements: missing source URLs, unclear scope description)
+- [<property>] <finding>
 
 ### Nice to Have
-- (Minor polish: wording, formatting)
+- [<property>] <finding>
+
+### Unverifiable
+- [<property>] <item, and why it could not be checked>
+
+### Property walk
+- Decidable: <one line>
+- Grounded: <one line>
+- Necessary: <one line>
+- Scoped: <one line>
+- Conformant: <one line>
 
 ### Verdict
 PASS | NEEDS_IMPROVEMENT
@@ -138,5 +101,4 @@ If there are no items for a severity level, write "None."
 ## Important Notes
 
 - This check may be re-run after fixes (e.g., Phase 1 retry, Phase 3 consistency check in the git workflow)
-- Focus on the PR as a communication artifact for human reviewers, not on code correctness (CI covers that)
-- When in doubt, prefer "Should Fix" over "Must Fix" to avoid blocking on subjective issues. Each signal block above states its own severity, and its tests turn on whether something is present in the body, so those verdicts are settled by the block rather than by this preference
+- Focus on the PR as a communication artifact, not on code correctness (CI covers that)

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -20,17 +20,26 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 1. When verifying a body claim needs file contents at the PR head,
    run `git fetch origin pull/<number>/head` once and read via
    `git show FETCH_HEAD:<path>`. When a body claim asserts repository
-   state at the PR head and shows the query it rests on, re-run it as
-   `git grep <pattern> FETCH_HEAD`; incidental differences such as line
-   numbers or unrelated new hits are not a contradiction. Do not create
-   local branches and do not run `git branch -D`/`-d` (branch deletion
-   blocks on a permission prompt)
+   state at the PR head and shows the query it rests on, re-run that
+   query with `FETCH_HEAD` as its tree-ish argument
+   (`git grep <pattern> FETCH_HEAD`). A result that contradicts the
+   claim is Must Fix; incidental differences such as line numbers or
+   unrelated new hits are not a contradiction. A query that takes no
+   tree-ish argument cannot be re-run at the PR head, and the claim
+   resting on it is unverifiable. Do not create local branches and do
+   not run `git branch -D`/`-d` (branch deletion blocks on a permission
+   prompt)
 1. Locate and read `pr-guidelines.md`, bundled with the `git-workflow`
    skill, to load the five properties the PR body is judged against
-1. For each URL found in the PR body, fetch it with WebFetch. A host
-   that does not answer (network error, timeout, 403) makes the URL
-   unverifiable; a 404 from a host that answered, or content that
-   contradicts what the body cites the URL for, is Must Fix
+1. For each URL found in the PR body, fetch it with WebFetch and
+   compare what comes back against what the body cites the URL for. A
+   fetch that returns no comparable content makes the URL unverifiable
+   — a network error, a timeout, a permission denial, any auth-gated
+   response (WebFetch is unauthenticated, so a correct link to a
+   private repository, issue, or dashboard answers with 404, 403, 401,
+   or a login page), a 429 or 5xx, and a domain `WebFetch` is denied
+   all land here. Must Fix only when fetched content contradicts the
+   citation
 1. Walk the five properties one at a time, in the order
    `pr-guidelines.md` states them, judging the PR against that
    property's rules and the severity table below
@@ -39,18 +48,22 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 
 ## Severity
 
-| Verdict | Condition |
+| Severity | Condition |
 | --- | --- |
-| Must Fix | An objective presence or absence test on the body, or a contradiction confirmed against a checked source (the diff, `FETCH_HEAD`, a fetched URL) |
-| Should Fix | A judgment of degree: redundancy, ordering, bullet granularity |
-| Nice to Have | Wording or formatting with no effect on the decision |
-| Escalation | Two or more Should Fix within one property escalates that property to Must Fix |
-| Unverifiable | An unreachable URL, or a query with no tree-ish form. Reported as unverifiable, never Must Fix |
+| Must Fix | The body or the diff misleads: it states something false or unsupported, or omits what the diff does |
+| Should Fix | The body or the diff is accurate but harder to use than it needs to be |
+| Nice to Have | Cosmetic, affecting neither |
+| Unverifiable | A check that produced nothing comparable against the claim (the `FETCH_HEAD` and URL steps above). Reported as unverifiable, never Must Fix |
+
+Two or more Should Fix findings within one property escalate that
+property: emit one Must Fix line naming the property, and keep the
+individual findings listed under Should Fix.
 
 ## Hard-wrap detection (GitHub-posted markdown)
 
 Conformant forbids hard-wrapping in GitHub-posted markdown. Apply this
-parser rather than judging line breaks by eye.
+parser rather than judging line breaks by eye. Each violation it finds
+is a Should Fix.
 
 A "block marker" below means a line starting with any of: `#`, `-`,
 `*`, `+`, a digit followed by `.` (e.g. `1.`), `>`, `|`, four spaces
@@ -96,7 +109,9 @@ Excluded from detection to avoid false positives:
 PASS | NEEDS_IMPROVEMENT
 ```
 
-If there are no items for a severity level, write "None."
+Write "None." under any of the four finding headings that has no
+items, Unverifiable included. The verdict is NEEDS_IMPROVEMENT when any
+Must Fix or Should Fix item is present, PASS otherwise.
 
 ## Important Notes
 


### PR DESCRIPTION
## Purpose

`pr-guidelines.md` and `pr-selfcheck/SKILL.md` each stated the same normative content: the guidelines said what a PR body should contain, and the selfcheck skill restated it as detector signals. Five topics were duplicated across both files, so each refinement landed in whichever file was open and the two drifted.

Severity showed the same fracture. Each signal block declared its own, a global "when in doubt prefer Should Fix" sat in Important Notes, and #364 had to add a sentence whose only job was to arbitrate between them.

This gives the standard a single owner and a shape that new rules attach to instead of accumulating beside.

## Key changes

- One standard, organized as five properties a body must hold — Decidable, Grounded, Necessary, Scoped, Conformant — each defined in one line at the top of `pr-guidelines.md`
  - the taxonomy was checked against published practice rather than chosen by preference: Bacchelli and Bird find code and change understanding is the key aspect of code reviewing, which is why Decidable leads; the kernel requires numbers behind performance claims, matching Grounded; Google, the kernel, Kubernetes, and git each state Scoped independently
- One owner for the standard and one for detection, split on whether a sentence says what the body should contain or how to obtain and judge evidence
  - `pr-guidelines.md` holds the rules; `pr-selfcheck/SKILL.md` holds the metadata and `FETCH_HEAD` procedures, URL fetching, the hard-wrap parser, the severity table, and the output format
  - `git-workflow/SKILL.md` changes in two places, where its steps named the "PR Body Checklist" section that no longer exists
  - references to `pr-guidelines.md` now name the file and the skill bundling it, with no `~/.claude/` path, because a skill loads from the personal directory, a project `.claude/skills/`, an added directory, or a plugin
- Severity derived from one table, and every property evaluated whether or not a signal names it
  - escalation is scoped to a property rather than to a signal block, and Necessary is broader than any old block, so escalation fires more readily
  - the checker walks the five properties one at a time and reports a line for each, so a rule with no bespoke signal still gets evaluated instead of being silently skipped

## Policy changes

Seven deliberate changes ride along with the relocation, so this is not a pure reorganization.

- Length is no longer a criterion
  - a body that is long because every part of it is needed passes with no finding, where the budget overrun was previously reported as Should Fix on its own
- A section heading grants no exemption from Necessary
  - without this a body can carry unlimited mechanism prose under a heading that asserts its own necessity, because every sentence is "why" and no what-side signal fires
- Lint, formatter, type-check, and build results stay out of the body whether or not the repository's CI runs them
  - the old "CI covers that" left the not-in-CI case undefined
- Checkbox syntax is reserved for verification items, in three documented meanings
  - author-verified, author-owed but pending with a reason, and user-owed; prose statements take no checkbox
- The DRY rule splits by case
  - duplicating the diff is always a violation, duplicating an external source only past the point where the body stands alone
  - a bare link is itself a defect: git's SubmittingPatches asks that an explanation "be understood without external resources"
- Both audiences are named — the reviewer deciding now, and the future reader arriving from `git log` or blame
  - Google notes that future developers search for and read these descriptions, and that audience is what justifies keeping the why while still cutting the what
- The broken-link verdict is settled
  - an unreachable or auth-gated URL is Unverifiable, and Must Fix is reserved for fetched content that contradicts the citation
  - WebFetch is unauthenticated, so a correct link to a private repository or dashboard answers with 404 or a login page

## Verification

- [x] Correspondence table built per `rule-authoring.md`, covering 92 origin rows — 69 moved, 14 changed, 9 dissolved — plus 7 rows with no origin, with no unit mapping to zero or two properties
  - method: every normative unit of both files at `main` was read from `git show main:<path>` and mapped bullet by bullet, with compound bullets split into single-destination units first
  - the 9 dissolved rows are the per-block severity declarations, #364's arbitration sentence, the "when in doubt" line, and two framing sentences that existed only to reconcile the duplicated structure
  - the table lives at `ikuwowfiles/pr-quality-correspondence.md`, which the global gitignore keeps out of the diff, so the counts are checkable on the authoring machine but not from a clone
- [x] `wc -l` on the two rewritten files → 337, against 341 at `main`
  - a count at or above the baseline would mean content was restated rather than moved
  - the margin is thin because review fixes added content with no counterpart at `main`: a primary-source citation for the GitHub line-break claim, a definition mapping findings to the overall verdict, and the expanded classification of what a URL fetch can return
- [x] `git grep 'PR Body Checklist\|Essence-first\|Length budget'` → no matches, so no reference names a section that no longer exists
- [x] `git grep -n '~/.claude' -- claude/skills/git-workflow/pr-guidelines.md claude/skills/pr-selfcheck/SKILL.md` → exit 1, no output
  - two `~/.claude` references remain elsewhere under `claude/skills/` (`retro-note/SKILL.md`, `retrospective/analysis.md`), both outside this PR's scope
  - `claude/routines/weekly-improvement.md:54` keeps its repository-relative path, which is unchanged
- [x] `/pr-selfcheck` under the rewritten skill resolved `pr-guidelines.md` from the name alone and reported against all five properties, so the reference survives without a path
  - observed in the authoring session; reproducing it means invoking the skill against this PR from a Claude Code session
- [x] `/pr-selfcheck` against #364, a body written and merged under the old rules, returned one Should Fix — an unchecked verification item carrying no reason it could not be run
  - that is the author-owed pending case this PR adds to Conformant, so the new rule fires on a body it did not shape without flooding it

## Sources

- https://research.tudelft.nl/en/publications/expectations-outcomes-and-challenges-of-modern-code-review/
- https://google.github.io/eng-practices/review/developer/cl-descriptions.html
- https://google.github.io/eng-practices/review/developer/small-cls.html
- https://www.kernel.org/doc/html/latest/process/submitting-patches.html
- https://git-scm.com/docs/SubmittingPatches
- https://www.kubernetes.dev/docs/guide/pull-requests/
