### PR TITLE
Rule the altitude of information inside a PR body section

### DIFF
--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -94,7 +94,7 @@ Launch all three in a single assistant message so they execute concurrently:
   `run_in_background: true`
 
 If any of the three fails:
-- Fix self-review "Must Fix" / "Should Fix" items
+- Fix self-review "Fix" items, and the "Note" items worth acting on
 - Move anything the sweep escalated into the PR body
 - Fix CI failures (`gh run view --log-failed`), or hand them back to
   the implementer when one is dispatched

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -120,6 +120,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     value from A to B", "added N items", "raised timeout to M")
   - Keep out per-item rendering of a pre-flight checklist when every
     item is "N/A" — collapse it to one line
+  - Keep out a summary of text the diff introduces, such as a rule,
+    definition, or table row it adds; name what changed and leave the
+    new text to be read where it lives
 - Keep CI, lint, formatter, type-check, and build / test command
   results (`go build`, `go test`, `go vet`, `pre-commit`) out of the
   body

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -120,9 +120,10 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     value from A to B", "added N items", "raised timeout to M")
   - Keep out per-item rendering of a pre-flight checklist when every
     item is "N/A" — collapse it to one line
-  - Keep out a summary of text the diff introduces, such as a rule,
-    definition, or table row it adds; name what changed and leave the
-    new text to be read where it lives
+  - When the change replaces something, name what it replaced and what
+    replaced it; what the replacement contains is in the diff, so
+    describing a rule, definition, or table row the change introduces
+    is paraphrase even when its consequence is attached
 - Keep CI, lint, formatter, type-check, and build / test command
   results (`go build`, `go test`, `go vet`, `pre-commit`) out of the
   body

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -73,8 +73,8 @@ the five property sections belongs to exactly one of them, and
   - Overstating what is "untestable" is the common failure mode
 - List only items actually verified, each carrying its evidence: a
   command, output excerpt, exit code, or log line
-  - Evidence counts when it sits in a code block or sub-bullet attached
-    to the item
+  - A code block or sub-bullet attached to the item counts as evidence
+    the item carries
   - When the item covers documentation or prose and no command applies,
     name what it was checked against (the source, the spec, the linked
     issue)
@@ -93,9 +93,9 @@ the five property sections belongs to exactly one of them, and
   selections
   - Especially important for dotfiles / infrastructure changes where
     "why this value" matters
-  - A claim about the behavior of a tool, service, or platform this
-    diff does not modify carries a link to or citation of a primary
-    source (a man page section or `--help` output counts)
+- A claim about the behavior of a tool, service, or platform this diff
+  does not modify carries a link to or citation of a primary source (a
+  man page section or `--help` output counts)
 - A causal claim asserting a mechanism a reader cannot check from the
   diff ("because X locks the table") carries evidence or a source
 - A value presented as a measured or derived result shows or links its

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -38,9 +38,6 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   rejected, and risks or things a reviewer should watch out for
   - "Approaches rejected" covers design alternatives weighed for the
     delivered design
-  - Name a rejected alternative when a reviewer would arrive at it and
-    ask; ruling out an option nobody would propose argues by contrast
-    and earns no space
 - Inverted pyramid — place the most important information first
   - A reviewer reading only the first few lines can tell what kind of
     PR this is and where to focus
@@ -140,7 +137,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Keep out references to the session, to plan-mode phases, or to
     individual commits within the branch
   - Keep out rejected alternatives described at implementation-attempt
-    granularity
+    granularity, and alternatives a reviewer would not arrive at and
+    ask about
 - State a fact once
   - The same environment variable name, file name, design decision, or
     summary of a linked source does not appear in two places in the

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -120,10 +120,10 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     value from A to B", "added N items", "raised timeout to M")
   - Keep out per-item rendering of a pre-flight checklist when every
     item is "N/A" — collapse it to one line
-  - When the change replaces something, name what it replaced and what
-    replaced it; what the replacement contains is in the diff, so
-    describing a rule, definition, or table row the change introduces
-    is paraphrase even when its consequence is attached
+  - Name a change in a line and leave its detail to the diff, which the
+    reviewer can open; spelling out what an added rule, definition, or
+    table row says is detail, whether quoted, summarized, or given with
+    its consequence
 - Keep CI, lint, formatter, type-check, and build / test command
   results (`go build`, `go test`, `go vet`, `pre-commit`) out of the
   body

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -11,8 +11,9 @@ need why the change was made and the shape of the decision behind it;
 neither needs what the diff already shows.
 
 A body is ready when it holds all five properties below. Every rule in
-the five property sections belongs to exactly one of them, and
-`/pr-selfcheck` evaluates them one at a time.
+the five property sections belongs to exactly one of them, and within a
+section the top-level line is the rule while the lines beneath it
+qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 
 - Decidable — a reviewer can decide approve or reject from the body
   alone, reading top-down
@@ -43,14 +44,14 @@ the five property sections belongs to exactly one of them, and
 - Progressive disclosure — surface only what a reviewer needs to decide
   - Implementation details and full alternatives narrative move behind
     a link or to a "Notes" / "Background" section at the end
-- The top level of a section carries the change or claim itself, so the
-  section reads from its top-level lines alone
-  - Rationale, evidence, superseded behavior, and mechanical
-    consequences nest beneath the item they support
-- A heading that claims selection ("Key changes", "要点") carrying more
-  peers than a reader can hold is a prompt to group them rather than to
-  keep listing
-  - The PR Body Template's 3-5 bullets is the target
+- In a bulleted section, the top level carries the change or claim
+  itself, so the section reads from its top-level lines alone
+  - Supporting material — rationale, evidence, the behavior this change
+    replaces, mechanical consequences, and the like — does not displace
+    it from the top level
+- When one top-level item in a section supports, qualifies, or follows
+  from another, it belongs beneath that one rather than beside it
+  - A long flat list is usually a hierarchy that was never encoded
 - Future work, out-of-scope follow-ups, and "next PR" notes belong at
   the end of the body (e.g., in a "Follow-up" / "Notes" section)
   - Do not surface them in the opening sections (purpose, scope,
@@ -139,9 +140,8 @@ the five property sections belongs to exactly one of them, and
   - The same environment variable name, file name, design decision, or
     summary of a linked source does not appear in two places in the
     body
-- Keep bullet points few and meaningful
-  - Each bullet conveys a distinct decision or outcome, not an
-    individual code change
+- Each bullet conveys a distinct decision or outcome, not an individual
+  code change
   - Bullets in the same list do not restate one another in different
     wording
 - Rationale, background, or requirements that live elsewhere (issue,

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -182,9 +182,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - The body conveys the holistic intent of the change — what the PR is
   trying to achieve across the whole diff — and accounts for the diff
   well enough that no part of it arrives unexplained
-  - Coverage is a gradient, not a sentence per hunk: the decisions a
-    reviewer's judgement rests on are stated in full, and the detail
-    below them is carried in as little as a clause
+  - Every file and every change in it is accounted for, the decisions a
+    reviewer's judgement rests on are stated in full, and the rest may
+    be carried in as little as a clause
 - The body names a verification mechanism — CI, manual test steps, or
   another check — for the code paths the diff changes
   - The test is whether the body makes that claim

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -77,8 +77,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Overstating what is "untestable" is the common failure mode
 - List only items actually verified, each carrying its evidence: a
   command, output excerpt, exit code, or log line
-  - A code block or sub-bullet attached to the item counts as evidence
-    the item carries
+  - Evidence carried in a code block or sub-bullet attached to the item
+    counts as evidence the item carries
   - When the item covers documentation or prose and no command applies,
     name what it was checked against (the source, the spec, the linked
     issue)
@@ -106,8 +106,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   asserts completeness, a uniqueness claim, a coverage figure — shows or
   links its derivation
   - Identifiers, version strings, and figures that only describe the
-    change are outside this rule; a count being off by a little is a
-    Nice to Have, not a defect in the claim
+    change are outside this rule
 - Rationale attributed to a linked issue, PR, or document quotes the
   one sentence it rests on, or links to the section carrying it
 - All URLs and anchor links resolve to the expected content

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -69,8 +69,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - Attempt every verification within reach before drafting the
   Verification section: shell commands, API calls, file inspection,
   mocked failure modes, simulated missing-config tests
-  - Punting reachable items to "Pending" or "User to verify" is itself
-    the violation
+  - Punting a reachable item to "Pending" or "User to verify" violates
+    this rule
   - Overstating what is "untestable" is the common failure mode
 - List only items actually verified, each carrying its evidence: a
   command, output excerpt, exit code, or log line
@@ -117,7 +117,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Keep out self-paraphrase of own edits ("edited file X", "bumped
     value from A to B", "added N items", "raised timeout to M")
   - Keep out per-item rendering of a pre-flight checklist when every
-    item is "N/A", collapsing it to one line
+    item is "N/A" — collapse it to one line
 - Keep CI, lint, formatter, type-check, and build / test command
   results (`go build`, `go test`, `go vet`, `pre-commit`) out of the
   body
@@ -149,7 +149,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   link, not copied
   - A bare link is itself a defect: write the shortest summary that
     survives the link going dead
-  - Anything past that point is duplication
+  - Anything past that shortest summary is duplication
 - When the diff is self-explanatory — documentation or config edits
   whose changed lines a reviewer can read directly, especially in the
   team's own language — keep the body to what the diff cannot convey
@@ -167,11 +167,11 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 
 - Describe the boundary of the change and call out anything
   intentionally left out of scope
-- The PR diff itself is a deliverable
-  - Edits, reformats, renames, and "while I'm here" cleanups that fall
-    outside the PR's stated scope should not appear in the diff
-  - Out-of-scope hunks force the reviewer to separate "intent vs
-    incidental" and inflate review load
+- Edits, reformats, renames, and "while I'm here" cleanups that fall
+  outside the PR's stated scope should not appear in the diff
+  - The PR diff itself is a deliverable, and out-of-scope hunks force
+    the reviewer to separate "intent vs incidental" and inflate review
+    load
   - Adjacent incidental fixes (an obvious typo) are tolerable in
     moderation, but the default is to leave them for a separate PR
 - The body conveys the holistic intent of the change — what the PR is
@@ -181,10 +181,10 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   another check — for the code paths the diff changes
   - The test is whether the body makes that claim
   - Judging how adequate the coverage is belongs to code review
-- Keep the PR self-contained
-  - Verification items, acceptance criteria, and follow-up actions that
-    depend on changes outside this PR's diff (other repos, downstream
-    releases, E2E flows) belong in the parent issue
+- Keep the PR self-contained: verification items, acceptance criteria,
+  and follow-up actions that depend on changes outside this PR's diff
+  (other repos, downstream releases, E2E flows) belong in the parent
+  issue
 - A description that keeps growing is a prompt to ask whether the diff
   should be split into finer-grained PRs
 
@@ -194,10 +194,10 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Any content that doesn't fit on one line — including issue
     references (`#123`, `org/repo#123`) — belongs in the body, not the
     title
-- Language follows the target repository, not the conversation
+- Language follows the target repository, not the language of the chat
+  with the user
   - Honor any explicit rule in the repo's `CLAUDE.md` / `AGENTS.md`
     first, otherwise match the existing PR / commit history
-  - Don't let the language of the chat with the user decide
 - Do NOT use auto-close keywords (`Closes`, `Fixes`, `Resolves`)
 - Checkbox syntax (`- [ ]` / `- [x]`) is reserved for verification
   items

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -99,9 +99,12 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   man page section or `--help` output counts)
 - A causal claim asserting a mechanism a reader cannot check from the
   diff ("because X locks the table") carries evidence or a source
-- A value presented as a measured or derived result shows or links its
-  derivation
-  - Identifiers and version strings are outside this rule
+- A value the reader would rely on to stop checking — a count that
+  asserts completeness, a uniqueness claim, a coverage figure — shows or
+  links its derivation
+  - Identifiers, version strings, and figures that only describe the
+    change are outside this rule; a count being off by a little is a
+    Nice to Have, not a defect in the claim
 - Rationale attributed to a linked issue, PR, or document quotes the
   one sentence it rests on, or links to the section carrying it
 - All URLs and anchor links resolve to the expected content

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -177,12 +177,14 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     load
   - Adjacent incidental fixes (an obvious typo) are tolerable in
     moderation, but the default is to leave them for a separate PR
-- The body conveys the holistic intent of the change — what the PR is
-  trying to achieve across the whole diff — and accounts for the diff
-  well enough that no part of it arrives unexplained
-  - Every file and every change in it is accounted for, the decisions a
-    reviewer's judgement rests on are stated in full, and the rest may
-    be carried in as little as a clause
+- The body states the intent of the change — what the PR is trying to
+  achieve across the whole diff — and every part of the diff sits inside
+  that intent
+  - A hunk sits inside when a reviewer holding that intent is not
+    surprised to find it, which a mechanical consequence of a described
+    change does without being named
+  - A hunk outside it is a disagreement between the body and the diff,
+    and the author chooses which of the two moves
 - The body names a verification mechanism — CI, manual test steps, or
   another check — for the code paths the diff changes
   - The test is whether the body makes that claim

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -38,6 +38,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   rejected, and risks or things a reviewer should watch out for
   - "Approaches rejected" covers design alternatives weighed for the
     delivered design
+  - Name a rejected alternative when a reviewer would arrive at it and
+    ask; ruling out an option nobody would propose argues by contrast
+    and earns no space
 - Inverted pyramid — place the most important information first
   - A reviewer reading only the first few lines can tell what kind of
     PR this is and where to focus
@@ -178,8 +181,11 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Adjacent incidental fixes (an obvious typo) are tolerable in
     moderation, but the default is to leave them for a separate PR
 - The body conveys the holistic intent of the change — what the PR is
-  trying to achieve across the whole diff — accounts for every file and
-  change in it, and leaves no unexplained hunks
+  trying to achieve across the whole diff — and accounts for the diff
+  well enough that no part of it arrives unexplained
+  - Coverage is a gradient, not a sentence per hunk: the decisions a
+    reviewer's judgement rests on are stated in full, and the detail
+    below them is carried in as little as a clause
 - The body names a verification mechanism — CI, manual test steps, or
   another check — for the code paths the diff changes
   - The test is whether the body makes that claim

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -30,172 +30,194 @@ the five property sections belongs to exactly one of them, and
 ## Decidable
 
 - State what changed and why (bug, feature, tech debt, compliance,
-  etc.). The body alone should convey the intent and let a reviewer
-  understand the purpose, what changed, and the impact.
+  etc.)
+  - The body alone conveys the intent and lets a reviewer understand
+    the purpose, what changed, and the impact
 - Give the shape of the decision: the approach taken vs. the approaches
-  rejected, and risks or things a reviewer should watch out for.
-  "Approaches rejected" covers design alternatives weighed for the
-  delivered design.
-- Inverted pyramid — place the most important information first. A
-  reviewer reading only the first few lines should be able to tell what
-  kind of PR this is and where to focus.
-- Progressive disclosure — surface only what a reviewer needs to
-  decide. Move implementation details or full alternatives narrative
-  behind a link or to a "Notes" / "Background" section at the end.
+  rejected, and risks or things a reviewer should watch out for
+  - "Approaches rejected" covers design alternatives weighed for the
+    delivered design
+- Inverted pyramid — place the most important information first
+  - A reviewer reading only the first few lines can tell what kind of
+    PR this is and where to focus
+- Progressive disclosure — surface only what a reviewer needs to decide
+  - Implementation details and full alternatives narrative move behind
+    a link or to a "Notes" / "Background" section at the end
 - The top level of a section carries the change or claim itself, so the
-  section reads from its top-level lines alone. Rationale, evidence,
-  superseded behavior, and mechanical consequences nest beneath the item
-  they support.
+  section reads from its top-level lines alone
+  - Rationale, evidence, superseded behavior, and mechanical
+    consequences nest beneath the item they support
 - A heading that claims selection ("Key changes", "要点") carrying more
   peers than a reader can hold is a prompt to group them rather than to
-  keep listing. The PR Body Template's 3-5 bullets is the target.
+  keep listing
+  - The PR Body Template's 3-5 bullets is the target
 - Future work, out-of-scope follow-ups, and "next PR" notes belong at
-  the end of the body (e.g., in a "Follow-up" / "Notes" section). Do
-  not surface them in the opening sections (purpose, scope, summary),
-  where they compete with the approve/reject decision.
-- Tables must stand alone. Give each table a caption or a one-line
-  lead-in that tells the reader what it shows (e.g., "Alert firings in
-  the past 7 days"). A reader who skips the surrounding prose should
-  still understand what the table represents. Avoid placing tables
-  mid-sentence where their meaning depends on parsing the prose around
-  them.
+  the end of the body (e.g., in a "Follow-up" / "Notes" section)
+  - Do not surface them in the opening sections (purpose, scope,
+    summary), where they compete with the approve/reject decision
+- Tables must stand alone
+  - Give each table a caption or a one-line lead-in that tells the
+    reader what it shows (e.g., "Alert firings in the past 7 days")
+  - A reader who skips the surrounding prose still understands what the
+    table represents
+  - Avoid placing tables mid-sentence where their meaning depends on
+    parsing the prose around them
 
 ## Grounded
 
 - Attempt every verification within reach before drafting the
   Verification section: shell commands, API calls, file inspection,
-  mocked failure modes, simulated missing-config tests. Punting
-  reachable items to "Pending" or "User to verify" is itself the
-  violation — overstating what is "untestable" is the common failure
-  mode.
+  mocked failure modes, simulated missing-config tests
+  - Punting reachable items to "Pending" or "User to verify" is itself
+    the violation
+  - Overstating what is "untestable" is the common failure mode
 - List only items actually verified, each carrying its evidence: a
-  command, output excerpt, exit code, or log line, counting any code
-  block or sub-bullet attached to it. When the item covers
-  documentation or prose and no command applies, name what it was
-  checked against (the source, the spec, the linked issue).
+  command, output excerpt, exit code, or log line
+  - Evidence counts when it sits in a code block or sub-bullet attached
+    to the item
+  - When the item covers documentation or prose and no command applies,
+    name what it was checked against (the source, the spec, the linked
+    issue)
 - Items that genuinely require interactive UI, user-only credentials,
   target environments unreachable from a shell, or the live session
   itself must be clearly distinguished with reproduction steps and a
-  one-line reason why the author could not verify them.
+  one-line reason why the author could not verify them
 - A negative or absence claim ("no X remains", "該当なし") shows the
-  query it rests on and the scope it examined; template-mandated N/A
-  fields are outside this rule. The shown query covers the whole claim
-  — a regex anchored to line start or end, a single literal where the
-  claim covers a family of spellings, or a path filter narrower than
-  the claim does not.
+  query it rests on and the scope it examined
+  - Template-mandated N/A fields are outside this rule
+  - The shown query covers the whole claim — a regex anchored to line
+    start or end, a single literal where the claim covers a family of
+    spellings, or a path filter narrower than the claim does not
 - Provide official documentation URLs or other authoritative sources
   that justify configuration values, tool choices, or version
-  selections. Especially important for dotfiles / infrastructure
-  changes where "why this value" matters. A claim about the behavior of
-  a tool, service, or platform this diff does not modify carries a link
-  to or citation of a primary source (a man page section or `--help`
-  output counts).
+  selections
+  - Especially important for dotfiles / infrastructure changes where
+    "why this value" matters
+  - A claim about the behavior of a tool, service, or platform this
+    diff does not modify carries a link to or citation of a primary
+    source (a man page section or `--help` output counts)
 - A causal claim asserting a mechanism a reader cannot check from the
-  diff ("because X locks the table") carries evidence or a source.
+  diff ("because X locks the table") carries evidence or a source
 - A value presented as a measured or derived result shows or links its
-  derivation; identifiers and version strings are outside this rule.
+  derivation
+  - Identifiers and version strings are outside this rule
 - Rationale attributed to a linked issue, PR, or document quotes the
-  one sentence it rests on, or links to the section carrying it.
-- All URLs and anchor links resolve to the expected content.
+  one sentence it rests on, or links to the section carrying it
+- All URLs and anchor links resolve to the expected content
 - The title accurately reflects the change, and the body does not
-  contradict the diff.
+  contradict the diff
 
 ## Necessary
 
-- Do not paraphrase the diff. Keep out file lists, line counts,
-  percentage of lines removed, per-file summaries, enumerations of
-  added rules, linters, settings, constants, or values, self-paraphrase
-  of own edits ("edited file X", "bumped value from A to B", "added N
-  items", "raised timeout to M"), and per-item rendering of a pre-
-  flight checklist when every item is "N/A" (collapse it to one line).
+- Do not paraphrase the diff
+  - Keep out file lists, line counts, percentage of lines removed,
+    per-file summaries, and enumerations of added rules, linters,
+    settings, constants, or values
+  - Keep out self-paraphrase of own edits ("edited file X", "bumped
+    value from A to B", "added N items", "raised timeout to M")
+  - Keep out per-item rendering of a pre-flight checklist when every
+    item is "N/A", collapsing it to one line
 - Keep CI, lint, formatter, type-check, and build / test command
   results (`go build`, `go test`, `go vet`, `pre-commit`) out of the
-  body, whether or not the repository's CI runs them. Output that CI or
-  another automation posts on the PR itself (build status, terraform /
-  CDK plan output, lint and type-check results) stays where it was
-  posted; the body does not restate it.
+  body
+  - This holds whether or not the repository's CI runs them
+  - Output that CI or another automation posts on the PR itself (build
+    status, terraform / CDK plan output, lint and type-check results)
+    stays where it was posted, and the body does not restate it
 - Focus on what changes from the user's or system's perspective —
   behavior changes, new capabilities, removed limitations — rather than
-  on implementation details (resources added, files touched).
-- The body records the delivered design, not the path to it. Keep out
-  chronological narration of implementation attempts ("first tried X,
-  it failed, so Y"), records of direction changes made mid-
-  implementation, references to the session, to plan-mode phases, or to
-  individual commits within the branch, and rejected alternatives
-  described at implementation-attempt granularity.
-- State a fact once. The same environment variable name, file name,
-  design decision, or summary of a linked source does not appear in two
-  places in the body.
-- Keep bullet points few and meaningful. Each bullet conveys a distinct
-  decision or outcome, not an individual code change, and bullets in
-  the same list do not restate one another in different wording.
+  on implementation details (resources added, files touched)
+- The body records the delivered design, not the path to it
+  - Keep out chronological narration of implementation attempts ("first
+    tried X, it failed, so Y") and records of direction changes made
+    mid-implementation
+  - Keep out references to the session, to plan-mode phases, or to
+    individual commits within the branch
+  - Keep out rejected alternatives described at implementation-attempt
+    granularity
+- State a fact once
+  - The same environment variable name, file name, design decision, or
+    summary of a linked source does not appear in two places in the
+    body
+- Keep bullet points few and meaningful
+  - Each bullet conveys a distinct decision or outcome, not an
+    individual code change
+  - Bullets in the same list do not restate one another in different
+    wording
 - Rationale, background, or requirements that live elsewhere (issue,
   design doc, ADR, prior PR, official spec) are summarized under a
-  link, not copied. A bare link is itself a defect: write the shortest
-  summary that survives the link going dead, and anything past that
-  point is duplication.
+  link, not copied
+  - A bare link is itself a defect: write the shortest summary that
+    survives the link going dead
+  - Anything past that point is duplication
 - When the diff is self-explanatory — documentation or config edits
   whose changed lines a reviewer can read directly, especially in the
   team's own language — keep the body to what the diff cannot convey
-  (rationale, scope boundary). When nothing remains to add, one line
-  such as "realigned stale wording with the actual code/config" is a
-  complete description.
-- A section heading grants no exemption. "diff から読み取れない設計判断",
-  "補足", or "詳細" does not excuse its contents from this property —
-  each paragraph under it still has to be needed for the decision.
+  (rationale, scope boundary)
+  - When nothing remains to add, one line such as "realigned stale
+    wording with the actual code/config" is a complete description
+- A section heading grants no exemption
+  - "diff から読み取れない設計判断", "補足", or "詳細" does not excuse its
+    contents from this property — each paragraph under it still has to
+    be needed for the decision
 - A body that is long because every part of it is needed is correct as
-  it is, and length itself is never a finding.
+  it is, and length itself is never a finding
 
 ## Scoped
 
 - Describe the boundary of the change and call out anything
-  intentionally left out of scope.
-- The PR diff itself is a deliverable. Edits, reformats, renames, and
-  "while I'm here" cleanups that fall outside the PR's stated scope
-  should not appear in the diff. Out-of-scope hunks force the reviewer
-  to separate "intent vs incidental" and inflate review load. Adjacent
-  incidental fixes (an obvious typo) are tolerable in moderation, but
-  the default is to leave them for a separate PR.
+  intentionally left out of scope
+- The PR diff itself is a deliverable
+  - Edits, reformats, renames, and "while I'm here" cleanups that fall
+    outside the PR's stated scope should not appear in the diff
+  - Out-of-scope hunks force the reviewer to separate "intent vs
+    incidental" and inflate review load
+  - Adjacent incidental fixes (an obvious typo) are tolerable in
+    moderation, but the default is to leave them for a separate PR
 - The body conveys the holistic intent of the change — what the PR is
   trying to achieve across the whole diff — accounts for every file and
-  change in it, and leaves no unexplained hunks.
+  change in it, and leaves no unexplained hunks
 - The body names a verification mechanism — CI, manual test steps, or
-  another check — for the code paths the diff changes. The test is
-  whether the body makes that claim; judging how adequate the coverage
-  is belongs to code review.
-- Keep the PR self-contained. Verification items, acceptance criteria,
-  and follow-up actions that depend on changes outside this PR's diff
-  (other repos, downstream releases, E2E flows) belong in the parent
-  issue.
+  another check — for the code paths the diff changes
+  - The test is whether the body makes that claim
+  - Judging how adequate the coverage is belongs to code review
+- Keep the PR self-contained
+  - Verification items, acceptance criteria, and follow-up actions that
+    depend on changes outside this PR's diff (other repos, downstream
+    releases, E2E flows) belong in the parent issue
 - A description that keeps growing is a prompt to ask whether the diff
-  should be split into finer-grained PRs.
+  should be split into finer-grained PRs
 
 ## Conformant
 
-- The title is a one-line summary in the team's review language. Any
-  content that doesn't fit on one line — including issue references
-  (`#123`, `org/repo#123`) — belongs in the body, not the title.
-- Language follows the target repository, not the conversation — honor
-  any explicit rule in the repo's `CLAUDE.md` / `AGENTS.md` first,
-  otherwise match the existing PR / commit history. Don't let the
-  language of the chat with the user decide.
-- Do NOT use auto-close keywords (`Closes`, `Fixes`, `Resolves`).
+- The title is a one-line summary in the team's review language
+  - Any content that doesn't fit on one line — including issue
+    references (`#123`, `org/repo#123`) — belongs in the body, not the
+    title
+- Language follows the target repository, not the conversation
+  - Honor any explicit rule in the repo's `CLAUDE.md` / `AGENTS.md`
+    first, otherwise match the existing PR / commit history
+  - Don't let the language of the chat with the user decide
+- Do NOT use auto-close keywords (`Closes`, `Fixes`, `Resolves`)
 - Checkbox syntax (`- [ ]` / `- [x]`) is reserved for verification
-  items: `- [x]` for one the author verified, `- [ ]` for one the user
-  is expected to verify or act on later so it can be ticked off, and
-  `- [ ]` carrying a one-line reason for an author-owed item that
-  Grounded exempts as unverifiable by the author. Prose statements do
-  not take a checkbox.
+  items
+  - `- [x]` marks one the author verified
+  - `- [ ]` marks one the user is expected to verify or act on later so
+    it can be ticked off
+  - `- [ ]` carrying a one-line reason marks an author-owed item that
+    Grounded exempts as unverifiable by the author
+  - Prose statements do not take a checkbox
 - Inside GitHub issues, pull requests, and discussions — bodies and
   comments alike, that is Markdown posted through the GitHub web UI —
-  do not hard-wrap paragraphs or list items. Write each paragraph as a
-  single line and let the browser wrap it; use blank lines for
-  paragraph breaks. GitHub Flavored Markdown renders soft line breaks
-  inside a paragraph as visible breaks only in these contexts
-  ([basic writing and formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)).
-  Plain Markdown files (READMEs, ADRs, this guidelines file
-  itself, and any other in-repo documentation) follow standard Markdown
-  rendering and may be hard-wrapped for file-side readability.
+  do not hard-wrap paragraphs or list items
+  - Write each paragraph as a single line and let the browser wrap it
+  - Use blank lines for paragraph breaks
+  - GitHub Flavored Markdown renders soft line breaks inside a
+    paragraph as visible breaks only in these contexts
+    ([basic writing and formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax))
+  - Plain Markdown files (READMEs, ADRs, this guidelines file itself,
+    and any other in-repo documentation) follow standard Markdown
+    rendering and may be hard-wrapped for file-side readability
 
 ## PR Body Template (fallback)
 

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -42,6 +42,13 @@ the five property sections belongs to exactly one of them, and
 - Progressive disclosure — surface only what a reviewer needs to
   decide. Move implementation details or full alternatives narrative
   behind a link or to a "Notes" / "Background" section at the end.
+- The top level of a section carries the change or claim itself, so the
+  section reads from its top-level lines alone. Rationale, evidence,
+  superseded behavior, and mechanical consequences nest beneath the item
+  they support.
+- A heading that claims selection ("Key changes", "要点") carrying more
+  peers than a reader can hold is a prompt to group them rather than to
+  keep listing. The PR Body Template's 3-5 bullets is the target.
 - Future work, out-of-scope follow-ups, and "next PR" notes belong at
   the end of the body (e.g., in a "Follow-up" / "Notes" section). Do
   not surface them in the opening sections (purpose, scope, summary),

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -23,7 +23,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    state at the PR head and shows the query it rests on, re-run that
    query with `FETCH_HEAD` as its tree-ish argument
    (`git grep <pattern> FETCH_HEAD`). A result that contradicts the
-   claim is Must Fix; incidental differences such as line numbers or
+   claim is a Fix; incidental differences such as line numbers or
    unrelated new hits are not a contradiction. A query that takes no
    tree-ish argument cannot be re-run at the PR head, and the claim
    resting on it is unverifiable. Do not create local branches and do
@@ -38,7 +38,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    response (WebFetch is unauthenticated, so a correct link to a
    private repository, issue, or dashboard answers with 404, 403, 401,
    or a login page), a 429 or 5xx, and a domain `WebFetch` is denied
-   all land here. Must Fix only when fetched content contradicts the
+   all land here. A Fix only when fetched content contradicts the
    citation
 1. Walk the five properties one at a time, in the order
    `pr-guidelines.md` states them, judging the PR against that
@@ -50,20 +50,15 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 
 | Severity | Condition |
 | --- | --- |
-| Must Fix | A reviewer acting on the body would be misled about what the change does, would reach a part of the diff the body never accounts for, or would treat a claim the body makes as settled when the body does not carry what settles it |
-| Should Fix | The body or the diff is accurate enough to act on but harder to use than it needs to be |
-| Nice to Have | An inaccuracy or blemish that changes neither what the reviewer understands nor where they look |
-| Unverifiable | A check that produced nothing comparable against the claim (the `FETCH_HEAD` and URL steps above). Reported as unverifiable, never Must Fix |
-
-Two or more Should Fix findings within one property escalate that
-property: emit one Must Fix line naming the property, and keep the
-individual findings listed under Should Fix.
+| Fix | Acting on it is required before the PR is ready: a reviewer acting on the body would be misled about what the change does, would reach a part of the diff the body never accounts for, or would treat a claim the body makes as settled when the body does not carry what settles it |
+| Note | Surfaced for the reader's judgement, and the reader decides whether to act: a blemish that changes nothing for the reviewer, or a finding the checker is not confident about, stated with the reason for the doubt |
+| Unverifiable | A check that produced nothing comparable against the claim (the `FETCH_HEAD` and URL steps above). Reported as unverifiable, never Fix |
 
 ## Hard-wrap detection (GitHub-posted markdown)
 
 Conformant forbids hard-wrapping in GitHub-posted markdown. Apply this
 parser rather than judging line breaks by eye. Each violation it finds
-is a Should Fix.
+is a Fix.
 
 A "block marker" below means a line starting with any of: `#`, `-`,
 `*`, `+`, a digit followed by `.` (e.g. `1.`), `>`, `|`, four spaces
@@ -86,13 +81,10 @@ Excluded from detection to avoid false positives:
 ```
 ## PR Self-Check Result
 
-### Must Fix
+### Fix
 - [<property>] <finding>
 
-### Should Fix
-- [<property>] <finding>
-
-### Nice to Have
+### Note
 - [<property>] <finding>
 
 ### Unverifiable
@@ -109,9 +101,9 @@ Excluded from detection to avoid false positives:
 PASS | NEEDS_IMPROVEMENT
 ```
 
-Write "None." under any of the four finding headings that has no
+Write "None." under any of the three finding headings that has no
 items, Unverifiable included. The verdict is NEEDS_IMPROVEMENT when any
-Must Fix or Should Fix item is present, PASS otherwise.
+Fix item is present, PASS otherwise.
 
 ## Important Notes
 

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -72,7 +72,7 @@ of indent, or a fenced code marker (``` or ~~~).
 Violations:
 
 - Two or more consecutive non-empty lines with no blank line between them, where neither line begins with a block marker (this catches paragraph-internal soft breaks while leaving tight lists, headings, and other block constructs alone)
-- An indented continuation line directly following a list-item line (`- `, `* `, `+ `, or `N. `) with no blank line between them; a blank-line gap before the indent denotes a valid continuation paragraph and is not a violation
+- An indented continuation line directly following a list-item line (`- `, `* `, `+ `, or `N. `) with no blank line between them, where that indented line does not itself begin with a list marker — an indented list marker opens a nested list item, which is a block construct rather than a wrapped continuation of the prose above; a blank-line gap before the indent denotes a valid continuation paragraph and is not a violation
 
 Excluded from detection to avoid false positives:
 

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -50,7 +50,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 
 | Severity | Condition |
 | --- | --- |
-| Fix | Acting on it is required before the PR is ready: a reviewer acting on the body would be misled about what the change does, would reach a part of the diff the body never accounts for, or would treat a claim the body makes as settled when the body does not carry what settles it |
+| Fix | Acting on it is required before the PR is ready: a reviewer acting on the body would be misled about what the change does, would reach a part of the diff the body never accounts for, or would treat a claim the change rests on as settled when the body does not carry what settles it |
 | Note | Surfaced for the reader's judgement, and the reader decides whether to act: a blemish that changes nothing for the reviewer, or a finding the checker is not confident about, stated with the reason for the doubt |
 | Unverifiable | A check that produced nothing comparable against the claim (the `FETCH_HEAD` and URL steps above). Reported as unverifiable, never Fix |
 

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -50,7 +50,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 
 | Severity | Condition |
 | --- | --- |
-| Must Fix | A reviewer acting on the body would be misled about what the change does, or would stop checking something they should check |
+| Must Fix | A reviewer acting on the body would be misled about what the change does, would reach a part of the diff the body never accounts for, or would treat a claim the body makes as settled when the body does not carry what settles it |
 | Should Fix | The body or the diff is accurate enough to act on but harder to use than it needs to be |
 | Nice to Have | An inaccuracy or blemish that changes neither what the reviewer understands nor where they look |
 | Unverifiable | A check that produced nothing comparable against the claim (the `FETCH_HEAD` and URL steps above). Reported as unverifiable, never Must Fix |

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -72,7 +72,7 @@ of indent, or a fenced code marker (``` or ~~~).
 Violations:
 
 - Two or more consecutive non-empty lines with no blank line between them, where neither line begins with a block marker (this catches paragraph-internal soft breaks while leaving tight lists, headings, and other block constructs alone)
-- An indented continuation line directly following a list-item line (`- `, `* `, `+ `, or `N. `) with no blank line between them, where that indented line does not itself begin with a list marker — an indented list marker opens a nested list item, which is a block construct rather than a wrapped continuation of the prose above; a blank-line gap before the indent denotes a valid continuation paragraph and is not a violation
+- An indented continuation line directly following a list-item line (`- `, `* `, `+ `, or `N. `) with no blank line between them, where that indented line does not itself begin with `- `, `* `, `+ `, or `N. ` — a blank-line gap before the indent denotes a valid continuation paragraph and is not a violation
 
 Excluded from detection to avoid false positives:
 

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -50,9 +50,9 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 
 | Severity | Condition |
 | --- | --- |
-| Must Fix | The body or the diff misleads: it states something false or unsupported, or omits what the diff does |
-| Should Fix | The body or the diff is accurate but harder to use than it needs to be |
-| Nice to Have | Cosmetic, affecting neither |
+| Must Fix | A reviewer acting on the body would be misled about what the change does, or would stop checking something they should check |
+| Should Fix | The body or the diff is accurate enough to act on but harder to use than it needs to be |
+| Nice to Have | An inaccuracy or blemish that changes neither what the reviewer understands nor where they look |
 | Unverifiable | A check that produced nothing comparable against the claim (the `FETCH_HEAD` and URL steps above). Reported as unverifiable, never Must Fix |
 
 Two or more Should Fix findings within one property escalate that


### PR DESCRIPTION
## Purpose

`Decidable` already governs arrangement across a body — inverted pyramid for order, progressive disclosure for what to defer to the end. Neither says anything about arrangement inside a section, so a section can hold a flat run of same-sized peers mixing the change itself with its rationale, its evidence, and mechanical detail, and pass every property. The reader re-derives a hierarchy the writer never encoded.

`AIRULES.md` already carries half the answer — 「箇条書きの項目はなるべく小さく、1項目1文を基本とし、文末に句点を付けない（複数文の場合は子箇条書きに分ける）」, with PR bodies named in its scope. It went unenforced because `/pr-selfcheck` judges a body against the five properties in `pr-guidelines.md`, and that rule was not among them.

## Key changes

- `Decidable` gains two rules: in a bulleted section the top level carries the change or claim itself so the section reads from its top-level lines alone, and an item that supports, qualifies, or follows from another belongs beneath it rather than beside it
  - the second tests the relation between items rather than counting them, so it carries no threshold; a section whose items really are all independent is a signal about the diff, which `Scoped` already owns
  - counting leaves `Necessary`, whose bullet rule now keeps only distinctness, so one defect no longer draws a finding under two properties
- `pr-guidelines.md` is reformatted to satisfy the rule it now states, converting its rule bullets to a one-sentence top line with their qualifications nested beneath, and lifting onto that line the requirements that sat behind a thesis sentence
  - the file held 45 top-level bullets and nested none of them, the largest flat list among the 17 markdown files under `claude/rules/` and `claude/skills/` at the merge base
    - counted per file with `grep -c '^- '` and `grep -c '^ \+- '` over `git ls-tree -r --name-only main -- claude/rules claude/skills`
- Findings carry one of two severities, `Fix` and `Note`, severed by whether acting on them is required before the PR is ready rather than by whether a statement is true
  - three tiers stood behind two behaviours, since the git workflow acted on Must Fix and Should Fix identically, and the escalation rule that turned two minor findings into a blocker goes with them
  - `Fix` reaches a claim the change rests on, so a missing citation on a passing remark no longer blocks alongside one under the load-bearing claim
  - `Note` is where the call belongs to the reader rather than the checker, which covers a blemish and equally a finding the checker is not confident about
- Three rules that licensed unbounded prose are bounded: a rejected alternative is named when a reviewer would arrive at it and ask, `Scoped` judges whether a hunk sits inside the stated intent, and `Grounded`'s derivation rule reaches a value the reader relies on to stop checking rather than one that only describes the change
  - "Approaches rejected" accepted any contrast, and "leaves no unexplained hunks" reads as an obligation to give every hunk its own item, which is where a flat run of same-weight bullets comes from
- `pr-selfcheck/SKILL.md`'s hard-wrap parser stops matching nested list items, which it would otherwise flag throughout every body now that nesting is the required shape

## Where a reformat can change a rule

Splitting a sentence can change what a rule requires while every clause survives, so a clause-level check passes and the policy still moves. Two rules in `Grounded` sit on that edge and are each verified against `main` separately.

- The evidence rule turns on whether "counting any code block or sub-bullet attached to it" reads as widening what counts as evidence or as a condition restricting where it may sit
  - the inclusive sense is the one `main` carries and the one kept here, so the inline `- [x] <command> → <output>` form the file's own template prescribes stays valid
- The primary-source requirement for external-tool behavior turns on whether it stands alone or qualifies the rule about URLs justifying configuration values
  - it fires on any claim about a tool this diff does not modify, so it is a `Grounded` rule in its own right rather than a child of the configuration-value rule

## Verification

- [x] Clause mapping built against `git show main:claude/skills/git-workflow/pr-guidelines.md`, covering the 37 rule bullets the reformat carried over, with every clause landing at exactly one destination and none dropped or duplicated
  - the rules this branch adds are new text rather than carried-over clauses, so they are outside what the mapping checks
  - wording changes are confined to splitting at sentence boundaries, dropping the trailing period, and promoting a trailing subordinate clause to an independent sentence
  - the record is at `ikuwowfiles/pr-guidelines-reformat-check.md`, gitignored, so it is checkable on the authoring machine but not from a clone
- [x] The two restored rules carry the same requirement they carry at `main`, checked by diffing each against `git show main:claude/skills/git-workflow/pr-guidelines.md`
- [x] The five property definitions and the PR Body Template block survive untouched → `diff` of the header property list and of the template block against `main` both exit 0
- [x] Every rule in the five property sections is present at the top level, not only in a child, checked by reading each section with its sub-bullets filtered out
- [x] No rule belongs to two properties → grouping and nesting appear only under `Decidable`, distinctness and non-restatement only under `Necessary`, and no rule in either counts bullets



