### PR TITLE
Set Scoped's obligation by weight rather than by coverage

### DIFF
--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -25,7 +25,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   linked source no more than the summary that survives the link going
   dead
 - Scoped — the diff carries only what the stated intent needs, and the
-  body accounts for all of it
+  body names the changes in it that carry weight
 - Conformant — the body renders and behaves as intended on GitHub
 
 ## Decidable
@@ -182,12 +182,15 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Adjacent incidental fixes (an obvious typo) are tolerable in
     moderation, but the default is to leave them for a separate PR
 - The body states the intent of the change — what the PR is trying to
-  achieve across the whole diff — and every part of the diff sits inside
-  that intent
-  - A hunk sits inside when a reviewer holding that intent is not
-    surprised to find it, which a mechanical consequence of a described
-    change does without being named
-  - A hunk outside it is a disagreement between the body and the diff,
+  achieve across the whole diff — and names the changes in it that carry
+  weight: one that moves behavior, and one large enough to redirect how
+  a reviewer reads the diff
+  - Weight is the threshold, not presence: a mechanical consequence of a
+    described change needs no mention of its own, and neither does an
+    edit too small to change what a reviewer would do
+  - A change carrying weight can sit inside a file the body already
+    names, or among lines a reformat moved
+  - One left unnamed is a disagreement between the body and the diff,
     and the author chooses which of the two moves
 - The body names a verification mechanism — CI, manual test steps, or
   another check — for the code paths the diff changes

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -183,13 +183,15 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     moderation, but the default is to leave them for a separate PR
 - The body states the intent of the change — what the PR is trying to
   achieve across the whole diff — and names the changes in it that carry
-  weight: one that moves behavior, and one large enough to redirect how
-  a reviewer reads the diff
-  - Weight is the threshold, not presence: a mechanical consequence of a
-    described change needs no mention of its own, and neither does an
-    edit too small to change what a reviewer would do
-  - A change carrying weight can sit inside a file the body already
-    names, or among lines a reformat moved
+  weight
+  - A change carries weight when a reviewer would do something different
+    for knowing it, because it changes behavior or because it is
+    consequential enough on its own to redirect the review
+  - A mechanical consequence of a described change is owed no mention of
+    its own, and neither is an edit that changes nothing a reviewer does
+  - Naming the file a change sits in does not name the change: one
+    carrying weight can sit inside a file the body already names, or
+    among lines a reformat moved
   - One left unnamed is a disagreement between the body and the diff,
     and the author chooses which of the two moves
 - The body names a verification mechanism — CI, manual test steps, or

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -25,7 +25,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   linked source no more than the summary that survives the link going
   dead
 - Scoped — the diff carries only what the stated intent needs, and the
-  body names the changes in it that carry weight
+  body conveys the change as a whole
 - Conformant — the body renders and behaves as intended on GitHub
 
 ## Decidable
@@ -181,19 +181,13 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     load
   - Adjacent incidental fixes (an obvious typo) are tolerable in
     moderation, but the default is to leave them for a separate PR
-- The body states the intent of the change — what the PR is trying to
-  achieve across the whole diff — and names the changes in it that carry
-  weight
-  - A change carries weight when a reviewer would do something different
-    for knowing it, because it changes behavior or because it is
-    consequential enough on its own to redirect the review
-  - A mechanical consequence of a described change is owed no mention of
-    its own, and neither is an edit that changes nothing a reviewer does
-  - Naming the file a change sits in does not name the change: one
-    carrying weight can sit inside a file the body already names, or
-    among lines a reformat moved
-  - One left unnamed is a disagreement between the body and the diff,
-    and the author chooses which of the two moves
+- The body conveys the change as a whole: the intent behind it, and the
+  parts a reader needs in order to hold that intent, with the rest left
+  to the diff
+  - A reader who finishes the body and then opens the diff finds what
+    the body led them to expect
+  - Where they do not, the body and the diff disagree, and the author
+    chooses which of the two moves
 - The body names a verification mechanism — CI, manual test steps, or
   another check — for the code paths the diff changes
   - The test is whether the body makes that claim

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -50,7 +50,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 
 | Severity | Condition |
 | --- | --- |
-| Fix | Acting on it is required before the PR is ready: a reviewer acting on the body would be misled about what the change does, would reach a part of the diff the body never accounts for, or would treat a claim the change rests on as settled when the body does not carry what settles it |
+| Fix | Acting on it is required before the PR is ready: a reviewer acting on the body would be misled about what the change does, would reach a change carrying weight that the body never names, or would treat a claim the change rests on as settled when the body does not carry what settles it |
 | Note | Surfaced for the reader's judgement, and the reader decides whether to act: a blemish that changes nothing for the reviewer, or a finding the checker is not confident about, stated with the reason for the doubt |
 | Unverifiable | A check that produced nothing comparable against the claim (the `FETCH_HEAD` and URL steps above). Reported as unverifiable, never Fix |
 

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -50,7 +50,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 
 | Severity | Condition |
 | --- | --- |
-| Fix | Acting on it is required before the PR is ready: a reviewer acting on the body would be misled about what the change does, would reach a change carrying weight that the body never names, or would treat a claim the change rests on as settled when the body does not carry what settles it |
+| Fix | Acting on it is required before the PR is ready: a reviewer acting on the body would be misled about what the change does, would find in the diff a change the body did not prepare them for, or would treat a claim the change rests on as settled when the body does not carry what settles it |
 | Note | Surfaced for the reader's judgement, and the reader decides whether to act: a blemish that changes nothing for the reviewer, or a finding the checker is not confident about, stated with the reason for the doubt |
 | Unverifiable | A check that produced nothing comparable against the claim (the `FETCH_HEAD` and URL steps above). Reported as unverifiable, never Fix |
 


### PR DESCRIPTION
## Purpose

`Scoped` asked that every part of the diff sit inside the stated intent. That is a claim about each part, and a claim about each part gets discharged by whatever enumeration answers it most cheaply — naming the changed files answers it, and a change inside a file the body already names is then outside the property's reach. The property came to test whether the body listed the areas it touched rather than whether it conveyed the change.

## Key changes

- `Scoped` now asks that a reader take the whole of the change from the body: the intent behind it, the parts needed to hold that intent, and the rest left to the diff
  - the test is whether the diff matches what the body led the reader to expect, so a list of files does not answer it, and no threshold is needed to say which parts must appear
  - what is given up is the per-part obligation: the body is no longer asked to account for all of the diff, and a change a reader was already prepared for needs no line of its own
- `/pr-selfcheck`'s `Fix` condition asked the same question per part and moves with it, so the rule and the checker's blocking condition state one requirement

## Evidence this rests on

Three rounds of `/pr-selfcheck` against frozen PRs are recorded in ikuwow/dotfiles#371, which is a measurement branch and is not proposed for merge. Rounds 1 and 2 ran the rules as they stand, over sixteen runs between them; round 3 ran a different candidate.

Fourteen of those sixteen runs resolved `Scoped` to the changed-file list, unanimously across round 1's ten. The two that read the diff finer are the two that found a rule the diff added and the body named nowhere. That observation is what this change acts on, and it holds whichever base a run compared against, which is why it is the only measurement cited here.

Round 3's recall figures are not usable and neither support this change nor contradict it. Its fixture lets a run compare against a `main` that already carries the change under test, and across it and round 2 five of twelve runs took that comparison and none of them reached the addition.

## Verification

- [x] The per-part obligation is gone from both sites that carried it → `git grep -n -E 'accounts for all of it|every part of the diff|the body never accounts for'` over the tree returns nothing, against one hit each before the change
  - `across the whole diff` no longer appears in the rule; the property is stated as one about the body rather than about each part
- [x] The property definition, the rule, and the severity table state the same requirement, checked by reading the three against each other
- [x] Every figure cited above is reproducible from #371's branch → rounds 1 to 3 and the preregistration are committed there
- [ ] Whether the change moves what `/pr-selfcheck` reports is not measured here — the fixture that would measure it is confounded, and the intended check is to watch live PRs after merge

## Notes

An earlier revision of this branch bounded the obligation by a defined threshold instead of removing it, naming the tests a change had to meet to be owed a mention. It is worth recording because it was rejected on a design ground rather than a measured one: a rule that defines a threshold and its exemptions builds a per-change adjudication, which is the shape that produced the file-list reading in the first place. The wording that shipped states the property and leaves the judgement where it was.

That revision also carried one line this one does not — that naming the file a change sits in does not name the change. It closed the measured failure directly, and its loss is the part of this change most worth watching: whether the property alone keeps a body from answering with the areas it touched.

ikuwow/dotfiles#369 records the instability that prompted this work and is not closed by this change. Run-to-run disagreement is round 1's result, which involves no planted defect and no base selection: no defect was reported by all ten runs, and four of five were reported by exactly one.
