### PR TITLE
Keep mechanically derived changes out of the PR body

### DIFF
--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -119,9 +119,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     value from A to B", "added N items", "raised timeout to M")
   - Keep out per-item rendering of a pre-flight checklist when every
     item is "N/A" — collapse it to one line
-  - Keep out changes that follow mechanically from another change
-    already stated (documentation updated to match a code change,
-    counts adjusted to match a removed item)
+  - Keep out mention of a change that follows mechanically from another
+    change the body already states (documentation updated to match a
+    code change, counts adjusted to match a removed item)
   - Name a change in a line and leave its detail to the diff, which the
     reviewer can open; spelling out what an added rule, definition, or
     table row says is detail, whether quoted, summarized, or given with

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -47,8 +47,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - In a bulleted section, the top level carries the change or claim
   itself, so the section reads from its top-level lines alone
   - Supporting material — rationale, evidence, the behavior this change
-    replaces, mechanical consequences, and the like — does not displace
-    it from the top level
+    replaces, and the like — does not displace it from the top level
 - When one top-level item in a section supports, qualifies, or follows
   from another, it belongs beneath that one rather than beside it
   - A long flat list is usually a hierarchy that was never encoded
@@ -120,6 +119,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     value from A to B", "added N items", "raised timeout to M")
   - Keep out per-item rendering of a pre-flight checklist when every
     item is "N/A" — collapse it to one line
+  - Keep out changes that follow mechanically from another change
+    already stated (documentation updated to match a code change,
+    counts adjusted to match a removed item)
   - Name a change in a line and leave its detail to the diff, which the
     reviewer can open; spelling out what an added rule, definition, or
     table row says is detail, whether quoted, summarized, or given with


### PR DESCRIPTION
## Purpose

Necessary filters a PR body by two tests: whether a line paraphrases the diff, and whether it restates another line in different wording. A change the reader can derive from a change the body already states passes both. "The header now reflects four properties" next to "dropped the fifth property" names an outcome rather than an edit, and shares no wording with the line it follows from, so nothing in the file kept it out.

## Key changes

- Necessary gains a rule keyed on derivability: a change that follows mechanically from another change already stated stays in the diff
- Decidable's supporting-material example list drops "mechanical consequences", which named as legitimate nested content the class Necessary now prohibits outright, so the two properties no longer license opposite treatments of the same content

## Verification

- [x] `git grep -n "mechanical" -- claude/` → the only hit in `pr-guidelines.md` is the new Necessary bullet; the remaining hits are `git-workflow/SKILL.md` (phases described as "mechanical checks") and `retrospective/analysis.md` (a `mechanize` disposition), both unrelated to this rule
- [x] `pr-selfcheck` needs no edit: its step 6 walks "the five properties one at a time, in the order `pr-guidelines.md` states them", so a rule added under a property is evaluated from the next run onward
