### PR TITLE
Restate what Decidable asks the body to deliver

### DIFF
--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -32,8 +32,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 
 - State what changed and why (bug, feature, tech debt, compliance,
   etc.)
-  - Purpose and impact come from the body; how the change achieves
-    them is the diff's to show
+  - Purpose and impact come from the body; the changed lines
+    themselves are the diff's to show
 - Give the shape of the decision: the approach taken vs. the approaches
   rejected, and risks or things a reviewer should watch out for
   - "Approaches rejected" covers design alternatives weighed for the

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -15,8 +15,8 @@ the five property sections belongs to exactly one of them, and within a
 section the top-level line is the rule while the lines beneath it
 qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 
-- Decidable — a reviewer can decide approve or reject from the body
-  alone, reading top-down
+- Decidable — reading top-down, a reviewer arrives at the diff knowing
+  what the change is for and where their attention belongs
 - Grounded — every claim is checkable on the evidence the body itself
   carries
 - Necessary — the body carries nothing the PR already carries
@@ -32,8 +32,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 
 - State what changed and why (bug, feature, tech debt, compliance,
   etc.)
-  - The body alone conveys the intent and lets a reviewer understand
-    the purpose, what changed, and the impact
+  - Purpose and impact come from the body; how the change achieves
+    them is the diff's to show
 - Give the shape of the decision: the approach taken vs. the approaches
   rejected, and risks or things a reviewer should watch out for
   - "Approaches rejected" covers design alternatives weighed for the


### PR DESCRIPTION
## Purpose

`Decidable` licensed approving a PR without opening the diff: it asked that a reviewer be able to decide approve or reject from the body alone, and the first rule under it repeated that claim. A body cannot stand in for the code, and a standard granting that it can invites bodies that try to — which is the failure `Necessary` then has to catch as diff paraphrase.

The property now names the outcome one step earlier, the one the rules under it were already serving: a reviewer arrives at the diff knowing what the change is for and where their attention belongs.

Item 1 of #376, tracked in #379.

## Key changes

- The property states an outcome the body can hold on its own, and the rule under it divides the work with the diff instead of standing in for it
- The rest of `Decidable` is untouched: inverted pyramid, progressive disclosure, the shape of the decision, and the altitude rules already serve the restated outcome
- The `Decidable` rule now points the same way as `Necessary`'s prohibition on diff paraphrase, where it previously pulled against it

## Notes

The opening-sections rule still names the approve/reject judgement ("where they compete with the approve/reject decision"). That names the call a reviewer eventually makes, not a claim about what the body suffices for, so it holds under the restated outcome and stays as it is.

`/pr-selfcheck` needs no change. Its property walk reads whatever `pr-guidelines.md` states, and the property name is unchanged.

The property keeps its name. #382 holds the open question about the frame the five properties form — whether `Scoped`'s body-side rule belongs under `Decidable` — and this change settles none of it.

## Verification

- [x] `git grep -n "body alone\|approve or reject" -- claude/` → no matches; the only surviving hit for the old framing is `approve/reject decision` at `pr-guidelines.md:57`, kept for the reason above
- [x] `git grep -c "^- Decidable\|^- Grounded\|^- Necessary\|^- Scoped\|^- Conformant" -- claude/skills/git-workflow/pr-guidelines.md` → `5`, so the five-property list still carries one line per property
- [x] `git grep -n "Decidable" -- claude/ | grep -v pr-guidelines.md` → `claude/skills/pr-selfcheck/SKILL.md:94`, its output-format template line, which carries no outcome wording
- [x] `git diff main -- claude/skills/git-workflow/pr-guidelines.md --stat` → `1 file changed, 4 insertions(+), 4 deletions(-)`, confined to the two sites
- CI runs shellcheck and a doctest pass over `claude/hooks/*.py` (`.github/workflows/ci.yml`). This change is Markdown only and reaches neither job, so a green run is not evidence for it
