### PR TITLE
Take the four rule candidates recovered from superseded issues

### DIFF
--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -34,10 +34,16 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   etc.)
   - Purpose and impact come from the body; the changed lines
     themselves are the diff's to show
+  - The why names what prompted this change now — the incident, the
+    investigation that could not conclude, the request — and the class
+    it belongs to does not stand in for that
 - Give the shape of the decision: the approach taken vs. the approaches
   rejected, and risks or things a reviewer should watch out for
   - "Approaches rejected" covers design alternatives weighed for the
     delivered design
+  - Where the change sits next to behavior callers depend on, name the
+    invariant it holds, so a reviewer knows what the diff is not free
+    to move
 - Inverted pyramid — place the most important information first
   - A reviewer reading only the first few lines can tell what kind of
     PR this is and where to focus
@@ -48,9 +54,14 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   itself, so the section reads from its top-level lines alone
   - Supporting material — rationale, evidence, the behavior this change
     replaces, and the like — does not displace it from the top level
-- When one top-level item in a section supports, qualifies, or follows
-  from another, it belongs beneath that one rather than beside it
+- When one top-level item supports, qualifies, or follows from another,
+  it belongs beneath that one rather than beside it, in whichever
+  section that one sits
   - A long flat list is usually a hierarchy that was never encoded
+  - Sections carry what a reviewer or an operator needs (purpose, key
+    changes, prerequisites, verification), so a section gathering items
+    by a shared property — "safety valves", "performance notes" —
+    empties when this is applied, and its heading goes with it
 - Future work, out-of-scope follow-ups, and "next PR" notes belong at
   the end of the body (e.g., in a "Follow-up" / "Notes" section)
   - Do not surface them in the opening sections (purpose, scope,
@@ -98,6 +109,11 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   man page section or `--help` output counts)
 - A causal claim asserting a mechanism a reader cannot check from the
   diff ("because X locks the table") carries evidence or a source
+- Naming an external tool or service in a step the reader is meant to
+  follow — verification, rollout, rollback, monitoring — asserts the
+  project uses it, and the body shows what settles that: a dependency
+  or config file, the project's own documentation, or the user saying
+  so
 - A value the reader would rely on to stop checking — a count that
   asserts completeness, a uniqueness claim, a coverage figure — shows or
   links its derivation

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -30,20 +30,18 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 
 ## Decidable
 
-- State what changed and why (bug, feature, tech debt, compliance,
-  etc.)
+- State what changed, and what prompted it now — the incident, the
+  investigation that could not conclude, the request, the obligation
+  that came due
   - Purpose and impact come from the body; the changed lines
     themselves are the diff's to show
-  - The why names what prompted this change now — the incident, the
-    investigation that could not conclude, the request — and the class
-    it belongs to does not stand in for that
 - Give the shape of the decision: the approach taken vs. the approaches
   rejected, and risks or things a reviewer should watch out for
   - "Approaches rejected" covers design alternatives weighed for the
     delivered design
-  - Where the change sits next to behavior callers depend on, name the
-    invariant it holds, so a reviewer knows what the diff is not free
-    to move
+  - Where the diff changes something other code reaches — a function
+    signature, a config key, an exit code, a file another script reads
+    — name the invariant it still holds
 - Inverted pyramid — place the most important information first
   - A reviewer reading only the first few lines can tell what kind of
     PR this is and where to focus
@@ -56,12 +54,10 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     replaces, and the like — does not displace it from the top level
 - When one top-level item supports, qualifies, or follows from another,
   it belongs beneath that one rather than beside it, in whichever
-  section that one sits
+  section that one sits, unless another rule here places it in a
+  section of its own
   - A long flat list is usually a hierarchy that was never encoded
-  - Sections carry what a reviewer or an operator needs (purpose, key
-    changes, prerequisites, verification), so a section gathering items
-    by a shared property — "safety valves", "performance notes" —
-    empties when this is applied, and its heading goes with it
+  - A section this empties loses its heading with it
 - Future work, out-of-scope follow-ups, and "next PR" notes belong at
   the end of the body (e.g., in a "Follow-up" / "Notes" section)
   - Do not surface them in the opening sections (purpose, scope,
@@ -112,8 +108,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - Naming an external tool or service in a step the reader is meant to
   follow — verification, rollout, rollback, monitoring — asserts the
   project uses it, and the body shows what settles that: a dependency
-  or config file, the project's own documentation, or the user saying
-  so
+  file, a config file, or the project's own documentation
 - A value the reader would rely on to stop checking — a count that
   asserts completeness, a uniqueness claim, a coverage figure — shows or
   links its derivation


### PR DESCRIPTION
## Purpose

Four candidate rules for `pr-guidelines.md` were recovered from #363 and PR #317 when those were closed as superseded, and #377 holds them until each is tested against the five-property file: whether the property it would join already reaches the case, and whether a body failing it leaves a reviewer worse off.

All four survived that test, and none ships in the form it was drafted. Two land inside the rule they qualify, one lands as a rewrite of the rule it was drafted to sit beneath, and one lands as a change of reach plus a qualifier. The forms differ because a candidate that restates or negates a rule already in the file is one `claude/rules/rule-authoring.md` asks to fold into that rule instead.

They land now because #376 freezes the ruleset before its first measurement round, and these carry no measurement of their own.

## Key changes

- `Decidable`'s opening rule is rewritten to carry the first candidate from #363, since the rule offered a class of change as its own answer and a candidate appended beneath it would have contradicted the line above
- The second candidate from #363 lands beneath the `Decidable` rule it qualifies
- The candidate PR #317's closing comment placed next to `Grounded`'s primary-source requirement lands there, since that requirement stops short of it
- The remaining candidate from PR #317 lands as a scope change to an existing `Decidable` rule, plus one qualifier carrying the part the scope change does not imply
- No candidate was declined, which #377 names as not the expected outcome

## Notes

The section candidate was drafted as a new rule about what earns a section. The rule it would have sat beside relocates an item beneath the one it qualifies, which is what dissolves a section gathering items by a shared property, and it was held back only by reaching within one section. What the relocation does not settle is the emptied heading, so that is what the qualifier carries.

The relocation rule now yields to any rule here that places an item in a section of its own, which is what keeps it from claiming the deferred material and follow-up notes that other `Decidable` rules place at the end of the body.

`/pr-selfcheck` needs no edit. Its property walk reads whatever this file states.

## Verification

- [x] Each rule this PR adds or changes answers the question of exactly one property, which is the file's own invariant. Read against the five property statements: what prompted a change and what invariant it holds are both what a reviewer needs before opening the diff, and where an item sits relative to the one it qualifies is the same reading, so all four belong to `Decidable`; what settles that a project uses a named tool is a claim's evidence, so it belongs to `Grounded`. No rule this PR touches states a requirement a second property also states
- [x] The scope the section candidate changes was real: `git show main:claude/skills/git-workflow/pr-guidelines.md | grep -n 'top-level item'` → line 51, `- When one top-level item in a section supports, qualifies, or follows`, which reaches only items sharing a section
- [x] The gap the tool-usage candidate fills was real: the `Grounded` rule it sits beside covers "a claim about the behavior of a tool, service, or platform this diff does not modify", which is what the tool does rather than whether this project runs it. This is also the reading PR #317's closing comment recorded when it recovered the candidate
- [x] The `Grounded` rule admits only sources a reader of the body can reach, so it does not collide with the same section's treatment of the live session as unverifiable, or with `Necessary` keeping session references out of the body
- CI runs two jobs (`.github/workflows/ci.yml`): shellcheck over the repository's shell scripts, and a doctest pass over `claude/hooks/*.py`. This change is Markdown only and reaches neither, so a green run is not evidence for it
