### PR TITLE
Resolve the base a pr-selfcheck reads a file against from the PR

### DIFF
--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -29,16 +29,17 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    resting on it is unverifiable. Do not create local branches and do
    not run `git branch -D`/`-d` (branch deletion blocks on a permission
    prompt)
-1. When a check needs a file as it stood before the change, resolve the
-   base from the PR rather than from the default branch. Record the head
-   with `git rev-parse FETCH_HEAD` after the fetch above, fetch the
-   `baseRefName` from step 1, and take `git merge-base FETCH_HEAD <head
-   sha>`; read the file at that commit. The default branch's tip has
-   moved past the merge point whenever anything landed since the branch
-   was cut, so `git show main:<path>` answers about a tree the PR was
-   never proposed against, and a change already merged there reads as
-   text the diff did not add. `gh pr diff` is computed against the
-   correct base and needs none of this
+1. When a check needs a file as it stood before the change, read it at
+   the merge base of the PR head and the PR's own base branch. Run
+   `git fetch origin <baseRefName>` with the value the metadata step
+   returned and capture `git rev-parse FETCH_HEAD` as the base tip, then
+   run `git fetch origin pull/<number>/head`. Take
+   `git merge-base <base tip> FETCH_HEAD` and read through
+   `git show <merge base>:<path>`. Keep that order: each fetch repoints
+   `FETCH_HEAD`, and ending on the head is what leaves the form above
+   reading the head for every later check. The default branch is not
+   that merge base once anything has landed since the branch was cut,
+   and a change already merged there reads as text the diff did not add
 1. Locate and read `pr-guidelines.md`, bundled with the `git-workflow`
    skill, to load the five properties the PR body is judged against
 1. For each URL found in the PR body, fetch it with WebFetch and

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -14,7 +14,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 ## Steps
 
 1. Retrieve PR metadata:
-   `gh pr view <number> --json title,body,url,additions,deletions,files`
+   `gh pr view <number> --json title,body,url,additions,deletions,files,baseRefName`
 1. Retrieve the diff:
    `gh pr diff <number>`
 1. When verifying a body claim needs file contents at the PR head,
@@ -29,6 +29,16 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    resting on it is unverifiable. Do not create local branches and do
    not run `git branch -D`/`-d` (branch deletion blocks on a permission
    prompt)
+1. When a check needs a file as it stood before the change, resolve the
+   base from the PR rather than from the default branch. Record the head
+   with `git rev-parse FETCH_HEAD` after the fetch above, fetch the
+   `baseRefName` from step 1, and take `git merge-base FETCH_HEAD <head
+   sha>`; read the file at that commit. The default branch's tip has
+   moved past the merge point whenever anything landed since the branch
+   was cut, so `git show main:<path>` answers about a tree the PR was
+   never proposed against, and a change already merged there reads as
+   text the diff did not add. `gh pr diff` is computed against the
+   correct base and needs none of this
 1. Locate and read `pr-guidelines.md`, bundled with the `git-workflow`
    skill, to load the five properties the PR body is judged against
 1. For each URL found in the PR body, fetch it with WebFetch and


### PR DESCRIPTION
## Purpose

`/pr-selfcheck` told a run how to reach the PR head and nothing about the other side of the comparison, so a run needing a file as it stood before the change took the default branch. That tip has moved past the merge point whenever anything landed since the branch was cut, and a change already merged there reads as text the diff never added.

The stability harness caught this as a confound before it was recognised as a defect in the check. Across rounds 2 and 3, which ran a fixture whose body cited `main` as its verification base, the five of twelve runs that took that comparison all missed the change the diff added and the body never named, against four of the seven that did not. Those counts and the runs behind them are recorded in `1afe180` on the retained `measure-pr-selfcheck-run-to-run-agreement` branch, which is where the harness and its rounds live under this repository's measurement-data policy.

## Key changes

- A run reads a pre-change file at the merge base of the PR head and the PR's own base branch
- The metadata step collects the field that resolves it, so the later step needs no extra query
- The two fetches are ordered so the last one is the head, which is what the existing head-reading form and every check after it depend on

## Notes

This is a narrower change than #380 as written. That issue asked for the whole evidence collection to be prescribed, on the reading that a run verifies the body's claims and never goes the other way to look for what the body does not mention. A baseline round against a fixture without the base confound reports ten of ten runs going the other way and raising the omission to `Fix`, so the collection gap it posits is not visible at that difficulty. That round, its evidence-route table and the limits of what it can say are recorded in https://github.com/ikuwow/dotfiles/issues/380#issuecomment-5379451425.

The step performs its own head fetch rather than resting on the step above having needed one. Their trigger conditions are independent: a check reading a file only as it stood before the change never fires the step that fetches the head, and this working tree's `FETCH_HEAD` is left over from earlier fetches, so `git rev-parse FETCH_HEAD` would return a plausible unrelated sha rather than failing.

## Verification

- [x] The recipe resolves the base on a PR whose base is not the default branch, `#385`: `gh pr view 385 --json baseRefName` → `fixture/cleanup-flags-base`; fetching `pull/385/head` and that ref and taking their merge base → `50250147c745265cebc7fd7fc595cab4f208f09c`
- [x] Reading the changed file at that commit shows the change under test absent, which is what makes it visible as an addition: `git show 5025014:bin/git-cleanup-branches | grep -c keep_globs` → `0`, against `3` at the PR head
- [x] The amended step 1 command returns the added field: `gh pr view 385 --json title,body,url,additions,deletions,files,baseRefName` → `baseRefName` is `fixture/cleanup-flags-base`
- [x] `gh pr diff` reports against the merge base, checked on `#383`, whose base has since advanced: `gh pr diff 383` is 26 lines and matches `git diff c18429f 4aec33d` (the merge base against the head) apart from the abbreviation width of the `index` line's blob hashes, while `git diff origin/main 4aec33d` is 51 lines. A run staying within the diff was never exposed to the defect
- [x] The prescribed order leaves `FETCH_HEAD` on the head, run against `#385`: after `git fetch origin fixture/cleanup-flags-base` then `git fetch origin pull/385/head`, `git rev-parse FETCH_HEAD` → `11d95d1` (the head), `git merge-base 5025014 FETCH_HEAD` → `5025014`, and `git show FETCH_HEAD:bin/git-cleanup-branches | grep -c keep_globs` → `3`, so the head-reading form still answers about the head
- [x] The reverse order does not: fetching the head first and the base second leaves `git rev-parse FETCH_HEAD` → `5025014`, the base, which is what a head read would then answer about
- CI runs two jobs (`.github/workflows/ci.yml`): shellcheck over the repository's shell scripts, and a doctest pass over `claude/hooks/*.py`. This change is Markdown only and reaches neither, so a green run is not evidence for it
