### PR TITLE
Give Necessary the direction of the read its rules were missing

### DIFF
--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -19,11 +19,10 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   what the change is for and where their attention belongs
 - Grounded — every claim is checkable on the evidence the body itself
   carries
-- Necessary — the body carries nothing the PR already carries
-  elsewhere (the diff, its commits, the Checks panel, output an
-  automation posted on it), states each thing once, and takes from a
-  linked source no more than the summary that survives the link going
-  dead
+- Necessary — read a line of the body and the reader can say where else
+  its content lives: the diff, the branch's commits, the Checks panel,
+  a linked source, elsewhere in the body, or nowhere. A line answering
+  with anything but the last is carried twice
 - Scoped — the diff carries only what the stated intent needs, and the
   body conveys the change as a whole
 - Conformant — the body renders and behaves as intended on GitHub
@@ -122,6 +121,14 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 
 ## Necessary
 
+- Take the body a line at a time and name where else that line's content
+  lives — the diff, the branch's commits, the Checks panel, a linked
+  source, another line of this body, or nowhere
+  - A line answering with anything but `nowhere` is content the reader
+    reaches more cheaply where it already sits
+  - The rules below are where this walk lands most often, together with
+    the `nowhere` cases it does not reach on its own. A line that fails
+    the walk is a finding whether or not one of them names it
 - Do not paraphrase the diff
   - Keep out file lists, line counts, percentage of lines removed,
     per-file summaries, and enumerations of added rules, linters,
@@ -160,10 +167,10 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - The same environment variable name, file name, design decision, or
     summary of a linked source does not appear in two places in the
     body
+  - Two bullets in one list saying the same thing in different wording
+    are one fact stated twice
 - Each bullet conveys a distinct decision or outcome, not an individual
   code change
-  - Bullets in the same list do not restate one another in different
-    wording
 - Rationale, background, or requirements that live elsewhere (issue,
   design doc, ADR, prior PR, official spec) are summarized under a
   link, not copied

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -19,10 +19,11 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   what the change is for and where their attention belongs
 - Grounded — every claim is checkable on the evidence the body itself
   carries
-- Necessary — read a line of the body and the reader can say where else
-  its content lives: the diff, the branch's commits, the Checks panel,
-  a linked source, elsewhere in the body, or nowhere. A line answering
-  with anything but the last is carried twice
+- Necessary — read each line of the body for where else its content
+  already lives, and the body carries nothing the diff, its commits,
+  the Checks panel or an automation's output carry, states each thing
+  once, and takes from a linked source no more than the summary that
+  survives the link going dead
 - Scoped — the diff carries only what the stated intent needs, and the
   body conveys the change as a whole
 - Conformant — the body renders and behaves as intended on GitHub
@@ -124,11 +125,13 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - Take the body a line at a time and name where else that line's content
   lives — the diff, the branch's commits, the Checks panel, a linked
   source, another line of this body, or nowhere
-  - A line answering with anything but `nowhere` is content the reader
-    reaches more cheaply where it already sits
-  - The rules below are where this walk lands most often, together with
-    the `nowhere` cases it does not reach on its own. A line that fails
-    the walk is a finding whether or not one of them names it
+  - What the answer forfeits is the part it already carries: detail the
+    diff or the commits show, output the Checks panel holds, a fact
+    another line of the body states, and anything past the shortest
+    summary a linked source needs
+  - A line the walk lands on is a finding whether or not a rule below
+    names it, and the rules below reach lines answering `nowhere` that
+    the walk does not
 - Do not paraphrase the diff
   - Keep out file lists, line counts, percentage of lines removed,
     per-file summaries, and enumerations of added rules, linters,


### PR DESCRIPTION
## Purpose

`Necessary` stated a list of things to keep out of a PR body. #381 puts the defect this way: a rule of that shape "is discharged by reading the body and reporting that none of them is there, which is an answer available for any body at no cost". That is also why it varies with whatever a run happened to notice.

The property now opens with the read its rules were serving: take the body a line at a time and name where else that line's content lives. That gives the check a starting point and something to hold it against, which is the shape `Grounded` already has and the reason two runs of `Grounded` do the same work.

## Key changes

- `Necessary` opens with the walk, and the property's line in the five-property list gains the read that produces the bounds it already stated
- Each answer forfeits only the part it already carries, which is what keeps the walk from failing the linked-source summary the section requires and the change name `Decidable` and `Scoped` require
- The prohibitions stay, and a line the walk lands on is a finding whether or not a named rule covers it
- One bullet moves under the rule it restates

## Notes

#381 asked which prohibitions survive being derived from the walk and which have to stay named. All of them stay, for two reasons.

Several are the `nowhere` cases the walk does not reach: a pre-flight checklist rendered per item when every item is `N/A`, build and lint results in a repository whose CI does not run them, and the path taken to the delivered design. Their content lives nowhere else, so the walk alone would admit them, and the issue names this asymmetry as the substance of the work rather than a detail of the wording.

The other reason is that replacing named cases with a general test has never been shown to help. #372 made that move under `Scoped`, and the round built to measure it produced figures its own PR body sets aside: "Round 3's recall figures are not usable and neither support this change nor contradict it." So the move is unmeasured rather than refuted, and a wholesale rewrite of this property would rest on the same untested premise.

The walk says "a line" without defining it for headings, table rows, or a line carrying two claims. Left as is: `Conformant` already fixes one item to one line in GitHub-posted markdown, and the granularity a checker needs follows from that, so a clause spelling it out would restate another property inside this one.

## Verification

- [x] The premise holds under the rules as they stand. All ten `Necessary` walk lines from the stability harness's baseline round are quoted in https://github.com/ikuwow/dotfiles/issues/381#issuecomment-5379613947: each reports which prohibited items are absent, and none names where a line's content already lives. The harness output stays untracked under this repository's measurement-data policy, so that comment is where these two items are checkable
- [x] One of those ten reported a violation, so the list does fire, at one run in ten: run 3's line and the finding behind it are quoted in the same comment
- [x] Every clause of the property's line in the five-property list has a home in the section: `grep -n 'State a fact once'` → line 169, and `grep -n 'shortest summary'` → lines 180 and 182
- [x] The moved bullet kept its policy: `grep -n 'different wording'` → line 173, now under `State a fact once` rather than beside it
- [x] The file's top-level bullet count moves from 49 to 50, the one added walk (`grep -c '^- '` at `main` and at the head)
- CI runs two jobs (`.github/workflows/ci.yml`): shellcheck over the repository's shell scripts, and a doctest pass over `claude/hooks/*.py`. This change is Markdown only and reaches neither, so a green run is not evidence for it
