### PR TITLE
Name the read Scoped's rules already perform

### DIFF
--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -24,8 +24,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   the Checks panel or an automation's output carry, states each thing
   once, and takes from a linked source no more than the summary that
   survives the link going dead
-- Scoped — the diff carries only what the stated intent needs, and the
-  body conveys the change as a whole
+- Scoped — the diff read against the body carries only what the stated
+  intent needs and nothing the body did not lead the reader to expect,
+  and the body says how the change is verified
 - Conformant — the body renders and behaves as intended on GitHub
 
 ## Decidable

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -26,7 +26,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   survives the link going dead
 - Scoped — the diff read against the body carries only what the stated
   intent needs and nothing the body did not lead the reader to expect,
-  and the body says how the change is verified
+  and the body conveys the change as a whole: its boundary, and how it
+  is verified within this PR
 - Conformant — the body renders and behaves as intended on GitHub
 
 ## Decidable


### PR DESCRIPTION
## Purpose

#382 asks whether `Scoped`'s two axes separate, with the candidate move being to put its body-side rule under `Decidable` so one property owns the reader arriving at the diff prepared and finding what they expected.

They do not separate, and the reason is the test #376 states for the whole five-property frame: what makes a property bind is which artifact the check reads first and what it holds that read against. Both of `Scoped`'s axes read the diff first — one holds it against the stated intent, the other against the account the body gave. `Decidable` reads the body first and asks whether it orients the reviewer. The move would put a diff-first rule under a body-first property, which is the mixing the frame exists to end.

## Key changes

- `Scoped`'s line in the five-property list names the read its rules perform, the way `Grounded` and `Necessary` already do
- That line also carries the verification claim the section requires, which it previously left out

No rule moves, and the `## Scoped` section is unchanged.

## Notes

The naming objection #382 raises survives the decision: `Scoped` describes the diff axis and not the body axis. It is left as it is, because both axes are readings of the diff, and because renaming a property reaches the checker's output format and the recorded rounds that group findings by property name.

One thing this leaves open. The verification-mechanism rule under `Scoped` is decided by reading the body alone — the test is whether the body makes the claim — so it does not perform the read the rest of the section performs. Whether it belongs under `Scoped`, under `Grounded` with the other rules about what a claim owes, or somewhere else is its own decision with its own reasoning, and is not folded in here.

Two things review raised and this PR leaves alone. The line's "only what the stated intent needs" reads as absolute against the section's tolerance for an adjacent obvious typo in moderation; that clause is the wording at `main` and is outside what this change touches. And the section says that on a disagreement between body and diff the author chooses which of the two moves, which the line's read direction does not settle; the read names the test and the section keeps the remedy, as elsewhere in the file.

The measurements #382 was designed to wait for do not exist. #380 shipped without a post round after its baseline came back at the ceiling, and #381 shipped on judgment, as its closing note records (https://github.com/ikuwow/dotfiles/issues/381#issuecomment-5379783766). What is known is that the body-side rule fires: nine of the ten `Fix` findings in the baseline round name `Scoped` and quote this rule, recorded in https://github.com/ikuwow/dotfiles/issues/380#issuecomment-5379451425. Whether it is the most productive rule in the set, which #382 gives as the reason to hold the move back, remains unmeasured.

## Verification

- [x] Each of the section's six top-level rules was checked against the line rather than the line against its predecessor. `claude/rules/rule-authoring.md` requires that correspondence when a rule document is compressed or simplified; this line grows rather than shrinks, so the check is applied by analogy, for the same reason — a summary that stops reaching a rule drops it as surely as a deletion would:

  | `## Scoped` rule | reached by the line |
  | --- | --- |
  | describe the boundary, call out what is left out of scope | "its boundary" |
  | out-of-scope edits do not appear in the diff | "only what the stated intent needs" |
  | the body conveys the change as a whole | verbatim |
  | the body names a verification mechanism | "how it is verified" |
  | keep the PR self-contained | "within this PR" |
  | a description that keeps growing prompts a split | not reached, as in the line at `main` |
- [x] The rules it summarises are unchanged: the only hunk is `@@ -27,2 +27,4 @@` (`git diff main -U0`, 4 insertions and 2 deletions), and diffing the `## Scoped` section between `main` and the head exits 0
- [x] The property names the checker reports under are untouched, so the recorded rounds stay comparable: `git diff main --stat -- claude/skills/pr-selfcheck/SKILL.md` is empty, and its output-format line is still `- Scoped: <one line>` at line 108
- CI runs two jobs (`.github/workflows/ci.yml`): shellcheck over the repository's shell scripts, and a doctest pass over `claude/hooks/*.py`. This change is Markdown only and reaches neither, so a green run is not evidence for it
