### PR TITLE
Give the Necessary walk a unit and Grounded the verification-mechanism rule

### DIFF
--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -18,7 +18,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - Decidable — reading top-down, a reviewer arrives at the diff knowing
   what the change is for and where their attention belongs
 - Grounded — every claim is checkable on the evidence the body itself
-  carries
+  carries, and the code paths the diff changes have a verification
+  mechanism named
 - Necessary — read each line of the body for where else its content
   already lives, and the body carries nothing the diff, its commits,
   the Checks panel or an automation's output carry, states each thing
@@ -26,8 +27,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   survives the link going dead
 - Scoped — the diff read against the body carries only what the stated
   intent needs and nothing the body did not lead the reader to expect,
-  and the body conveys the change as a whole: its boundary, and how it
-  is verified within this PR
+  and the body conveys the change as a whole: its boundary, and what it
+  holds within this PR
 - Conformant — the body renders and behaves as intended on GitHub
 
 ## Decidable
@@ -74,6 +75,10 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 
 ## Grounded
 
+- The body names a verification mechanism — CI, manual test steps, or
+  another check — for the code paths the diff changes
+  - The test is whether the body makes that claim
+  - Judging how adequate the coverage is belongs to code review
 - Attempt every verification within reach before drafting the
   Verification section: shell commands, API calls, file inspection,
   mocked failure modes, simulated missing-config tests
@@ -218,10 +223,6 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     the body led them to expect
   - Where they do not, the body and the diff disagree, and the author
     chooses which of the two moves
-- The body names a verification mechanism — CI, manual test steps, or
-  another check — for the code paths the diff changes
-  - The test is whether the body makes that claim
-  - Judging how adequate the coverage is belongs to code review
 - Keep the PR self-contained: verification items, acceptance criteria,
   and follow-up actions that depend on changes outside this PR's diff
   (other repos, downstream releases, E2E flows) belong in the parent

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -131,6 +131,11 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     diff or the commits show, output the Checks panel holds, a fact
     another line of the body states, and anything past the shortest
     summary a linked source needs
+  - A heading is a line the walk takes, and answers for its own text
+    rather than for the lines beneath it
+  - A table is one line of the walk, its lead-in and its rows together
+  - A line carrying more than one claim is answered a claim at a time,
+    and each claim forfeits or survives on its own answer
   - A line the walk lands on is a finding whether or not a rule below
     names it, and the rules below reach lines answering `nowhere` that
     the walk does not

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -18,8 +18,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - Decidable — reading top-down, a reviewer arrives at the diff knowing
   what the change is for and where their attention belongs
 - Grounded — every claim is checkable on the evidence the body itself
-  carries, and the code paths the diff changes have a verification
-  mechanism named
+  carries, and the body names a verification mechanism for the code
+  paths the diff changes
 - Necessary — read each line of the body for where else its content
   already lives, and the body carries nothing the diff, its commits,
   the Checks panel or an automation's output carry, states each thing
@@ -28,7 +28,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - Scoped — the diff read against the body carries only what the stated
   intent needs and nothing the body did not lead the reader to expect,
   and the body conveys the change as a whole: its boundary, and what it
-  holds within this PR
+  leaves to the parent issue
 - Conformant — the body renders and behaves as intended on GitHub
 
 ## Decidable
@@ -75,10 +75,6 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 
 ## Grounded
 
-- The body names a verification mechanism — CI, manual test steps, or
-  another check — for the code paths the diff changes
-  - The test is whether the body makes that claim
-  - Judging how adequate the coverage is belongs to code review
 - Attempt every verification within reach before drafting the
   Verification section: shell commands, API calls, file inspection,
   mocked failure modes, simulated missing-config tests
@@ -96,6 +92,10 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   target environments unreachable from a shell, or the live session
   itself must be clearly distinguished with reproduction steps and a
   one-line reason why the author could not verify them
+- The body names a verification mechanism — CI, manual test steps, or
+  another check — for the code paths the diff changes
+  - The test is whether the body makes that claim
+  - Judging how adequate the coverage is belongs to code review
 - A negative or absence claim ("no X remains", "該当なし") shows the
   query it rests on and the scope it examined
   - Template-mandated N/A fields are outside this rule
@@ -138,9 +138,10 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     summary a linked source needs
   - A heading is a line the walk takes, and answers for its own text
     rather than for the lines beneath it
-  - A table is one line of the walk, its lead-in and its rows together
+  - A table row is a line of the walk, read with the caption or lead-in
+    that says what the table shows
   - A line carrying more than one claim is answered a claim at a time,
-    and each claim forfeits or survives on its own answer
+    and each claim forfeits what its own answer names
   - A line the walk lands on is a finding whether or not a rule below
     names it, and the rules below reach lines answering `nowhere` that
     the walk does not


### PR DESCRIPTION
## Purpose

#376 closed with two questions left open, filed as #389 and #390. Both are settled here by the test #376 states for the whole five-property frame: what makes a property bind is which artifact the check reads first and what it holds that read against.

## Key changes

- The `Necessary` walk states its unit for a heading, a table row, and a line carrying more than one claim, the three shapes left over once `Conformant` has fixed one item to one line in GitHub-posted markdown (#389)
- The verification-mechanism rule moves from `Scoped` to `Grounded`, the property whose read it performs (#390)
- Both properties' lines in the five-property list follow the rule to its new home, and `Scoped`'s names the self-containment rule that clause now has to reach

## Notes

`Scoped`'s other rules are decided by reading the diff and holding it against the stated intent or against the account the body gave. The verification-mechanism rule is decided by reading the body alone, since its own sub-bullet makes the test whether the body makes the claim. A section carrying two read directions is what #376 records the property doing under the harness, where "`Scoped`: 10 of 10 in round 1 resolve it to the changed-file list". `Grounded` reads the body first and already governs the Verification section in its opening rules. The rule sits after those rules rather than above them, so its coverage-judgement sub-bullet reads as its own qualifier and not as a preamble over the rules that do demand the author attempt what is reachable.

The move's cost is that a finding on that rule is reported under a different property name afterwards, which is the cost #382 weighed against a different move. Here it is zero, measured against every finding the harness has recorded — see Verification.

#387 left the walk's unit undefined, holding that "a clause spelling it out would restate another property inside this one" because `Conformant` already fixes one item to one line in GitHub-posted markdown. That reasoning bounds this change rather than blocking it: the paragraph and list-item case is still left to the derivation, and only the three shapes outside it are named.

Two things review raised and this PR leaves alone. `Grounded` now holds both the rule that a named mechanism needs no evidence and the rule that a listed verification item carries its evidence, which a body line naming CI meets one way and not the other; that tension is in the evidence rule's wording, predates this branch, and is a change of its own. And the heading rule says what a heading answers for as well as that the walk takes it, which one reviewer read as restating `Necessary`'s "a section heading grants no exemption"; the clause stays, because without it the walk can answer for a heading by pointing at the lines beneath it and forfeit every heading in the body.

## Verification

- [x] Each rule `## Scoped` keeps was checked against its reworded line, the correspondence `claude/rules/rule-authoring.md` requires when a summary changes:

  | `## Scoped` rule | reached by the line |
  | --- | --- |
  | describe the boundary, call out what is left out of scope | "its boundary" |
  | out-of-scope edits do not appear in the diff | "only what the stated intent needs" |
  | the body conveys the change as a whole | verbatim |
  | keep the PR self-contained | "what it leaves to the parent issue" |
  | a description that keeps growing prompts a split | not reached, as in the line at `main` |
- [x] `Grounded`'s line grows and loses nothing: the hunk at `git diff main -U0` appends to the existing clause rather than replacing it, so every rule it reached before is still reached, and the moved rule is reached by "the body names a verification mechanism for the code paths the diff changes"
- [x] The moved rule is byte-identical at its new home: `grep -A3 '^- The body names a verification mechanism'` run against `git show main:claude/skills/git-workflow/pr-guidelines.md` and against the head file compare equal (`diff` → exit 0)
- [x] The file's top-level rule count is unchanged: `grep -c '^- '` gives 50 at `main` and 50 at the head, so the move added and dropped nothing and the walk's three additions are sub-bullets
- [x] All 57 finding entries the stability harness recorded across its four rounds (19 baseline, 9 round 1, 14 round 2, 15 round 3, two of them `None.` placeholders) were read in full, printed with their severity, property, and text by a `python3` pass over `ikuwowfiles/pr-selfcheck-stability/*/findings.jsonl`. None rests on the moved rule. The one finding reporting that a changed code path carries no verification, baseline run 5, was already filed under `Grounded`. The harness stays untracked under this repository's measurement-data policy, which is why the reading is recorded here
- CI runs two jobs (`.github/workflows/ci.yml`): shellcheck over the repository's shell scripts, and a doctest pass over `claude/hooks/*.py`. This change is Markdown only and reaches neither, so a green run is not evidence for it
