### PR TITLE
Bound a PR body by what the diff cannot carry, and make density answerable

### DIFF
--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -6,9 +6,15 @@ and when self-reviewing your own PR.
 A PR body is a summary that helps a reviewer decide, not a complete
 record of the change: everything else lives in the diff, the issue, or
 a linked source. It serves two audiences — the reviewer deciding now,
-and the future reader who reaches this PR from `git log` or blame. Both
-need why the change was made and the shape of the decision behind it;
-neither needs what the diff already shows.
+and the future reader who reaches this PR from `git log` or blame.
+
+The diff is the default carrier. A reviewer opens it, reads the changed
+lines, and derives from them most of what the change is. The body adds
+what the diff cannot state and what a reader would not derive from it.
+No rule below is a requirement to write a section, and none is
+discharged by writing more: each names something the body carries when
+the diff does not carry it, and asks nothing when the diff does. The
+shortest body that leaves a reviewer able to decide is the correct one.
 
 A body is ready when it holds all five properties below. Every rule in
 the five property sections belongs to exactly one of them, and within a
@@ -27,19 +33,22 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   survives the link going dead
 - Scoped — the diff read against the body carries only what the stated
   intent needs and nothing the body did not lead the reader to expect,
-  and the body conveys the change as a whole: its boundary, and what it
-  leaves to the parent issue
+  and the body conveys the change as a whole: a boundary the reader
+  would not assume, and what it leaves to the parent issue
 - Conformant — the body renders and behaves as intended on GitHub
 
 ## Decidable
 
-- State what changed, and what prompted it now — the incident, the
-  investigation that could not conclude, the request, the obligation
-  that came due
-  - Purpose and impact come from the body; the changed lines
-    themselves are the diff's to show
-- Give the shape of the decision: the approach taken vs. the approaches
-  rejected, and risks or things a reviewer should watch out for
+- Name the change in one sentence, and add what prompted it now where
+  the diff does not show it — the incident, the investigation that
+  could not conclude, the request, the obligation that came due
+  - The changed lines are the diff's to show, so the body names the
+    change rather than describing it
+- Where a design decision was weighed, the body carries its shape: the
+  approach taken against the approaches rejected, and risks or things a
+  reviewer should watch out for
+  - A change with one obvious approach carries none of this, and
+    inventing an alternative to name is itself a defect
   - "Approaches rejected" covers design alternatives weighed for the
     delivered design
   - Where the diff changes something other code reaches — a function
@@ -51,6 +60,13 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - Progressive disclosure — surface only what a reviewer needs to decide
   - Implementation details and full alternatives narrative move behind
     a link or to a "Notes" / "Background" section at the end
+- The body's structure comes from the decisions the change carries, not
+  from the shape of the diff. A heading, section, or top-level bullet
+  standing for one hunk, one file, or one edited section of a document
+  is a defect, and a change carrying a single decision takes one
+  paragraph and no headings
+  - A structure a reader could reconstruct from the diff's file list or
+    hunk boundaries alone conveys nothing the diff does not
 - In a bulleted section, the top level carries the change or claim
   itself, so the section reads from its top-level lines alone
   - Supporting material — rationale, evidence, the behavior this change
@@ -59,7 +75,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   it belongs beneath that one rather than beside it, in whichever
   section that one sits, unless another rule here places it in a
   section of its own
-  - A long flat list is usually a hierarchy that was never encoded
+  - A long flat list is usually diff paraphrase; where it survives
+    Necessary, it is usually a hierarchy that was never encoded
   - A section this empties loses its heading with it
 - Future work, out-of-scope follow-ups, and "next PR" notes belong at
   the end of the body (e.g., in a "Follow-up" / "Notes" section)
@@ -195,21 +212,28 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Anything past that shortest summary is duplication
 - When the diff is self-explanatory — documentation or config edits
   whose changed lines a reviewer can read directly, especially in the
-  team's own language — keep the body to what the diff cannot convey
-  (rationale, scope boundary)
+  team's own language — the body keeps to what the diff cannot convey,
+  and Decidable and Scoped ask nothing further of it
   - When nothing remains to add, one line such as "realigned stale
     wording with the actual code/config" is a complete description
+  - Apply this rule before any other rule in this section, so what it
+    leaves is what the rest of the walk reads
 - A section heading grants no exemption
   - "diff から読み取れない設計判断", "補足", or "詳細" does not excuse its
     contents from this property — each paragraph under it still has to
     be needed for the decision
-- A body that is long because every part of it is needed is correct as
-  it is, and length itself is never a finding
+- Length is not itself a finding, and a body long because every part of
+  it is needed is correct as it is
+  - A main description section that outweighs the diff it describes is
+    not a finding either, but it mandates the walk that opens this
+    section be run strictly: each claim answered separately, and the
+    self-explanatory-diff rule applied first
 
 ## Scoped
 
-- Describe the boundary of the change and call out anything
-  intentionally left out of scope
+- Where the change stops short of what its intent would lead a reader
+  to expect, the body says so; a boundary the reader would assume needs
+  no statement
 - Edits, reformats, renames, and "while I'm here" cleanups that fall
   outside the PR's stated scope should not appear in the diff
   - The PR diff itself is a deliverable, and out-of-scope hunks force
@@ -221,7 +245,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   parts a reader needs in order to hold that intent, with the rest left
   to the diff
   - A reader who finishes the body and then opens the diff finds what
-    the body led them to expect
+    the body led them to expect. The expectation is of the change's
+    intent, not of an inventory of where the diff touches — naming the
+    edited files, sections, or hunks does not discharge this
   - Where they do not, the body and the diff disagree, and the author
     chooses which of the two moves
 - Keep the PR self-contained: verification items, acceptance criteria,
@@ -261,6 +287,25 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Plain Markdown files (READMEs, ADRs, this guidelines file itself,
     and any other in-repo documentation) follow standard Markdown
     rendering and may be hard-wrapped for file-side readability
+
+## Worked example: a self-explanatory diff
+
+A design document gains a retry on one forwarding hop, and the sending
+side's request spec is gathered into a new prerequisites section. One
+Markdown file, 15 lines added and 7 removed, in the team's own
+language. The whole main description section:
+
+```
+転送失敗時のリトライを設計として追加しました。
+合わせて、「前提: 送信仕様」節を新設するなど文章の整理をしました。
+```
+
+The first sentence names the change and the second names the
+reorganization that came with it. What each added table row says, which
+bullets were merged, and how the sections were rearranged are the
+diff's. A heading per edited section would carry the diff's shape
+rather than the change's decisions, and a paragraph justifying each
+edit would be rationale the changed lines already carry.
 
 ## PR Body Template (fallback)
 

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -162,6 +162,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - A line the walk lands on is a finding whether or not a rule below
     names it, and the rules below reach lines answering `nowhere` that
     the walk does not
+  - After that pass, take each paragraph and ask whether a list would
+    carry the same content in fewer words, then take each list item and
+    count its sentences
 - Do not paraphrase the diff
   - Keep out file lists, line counts, percentage of lines removed,
     per-file summaries, and enumerations of added rules, linters,
@@ -204,6 +207,15 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     are one fact stated twice
 - Each bullet conveys a distinct decision or outcome, not an individual
   code change
+- One sentence per list item
+  - A second sentence becomes a sub-bullet under the first, or it was
+    not needed
+  - An item that takes three sentences to land is usually two items
+- A paragraph that enumerates parallel items is a finding; the items
+  belong in a list, one per line
+  - Parallel means the same kind: reasons, rejected alternatives,
+    caveats, affected files, options
+  - A single claim carrying its own qualifier stays prose
 - Rationale, background, or requirements that live elsewhere (issue,
   design doc, ADR, prior PR, official spec) are summarized under a
   link, not copied
@@ -222,12 +234,16 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - "diff から読み取れない設計判断", "補足", or "詳細" does not excuse its
     contents from this property — each paragraph under it still has to
     be needed for the decision
-- Length is not itself a finding, and a body long because every part of
-  it is needed is correct as it is
-  - A main description section that outweighs the diff it describes is
-    not a finding either, but it mandates the walk that opens this
-    section be run strictly: each claim answered separately, and the
-    self-explanatory-diff rule applied first
+- A body long because every part of it is needed, each part at its
+  tightest expression, is correct as it is
+  - Raw length, and the ratio of body size to diff size, are never
+    findings on their own
+  - Content that survives the walk above still answers for how densely
+    it is written
+  - A main description section that outweighs the diff it describes
+    mandates the walk that opens this section be run strictly: each
+    claim answered separately, and the self-explanatory-diff rule
+    applied first
 
 ## Scoped
 

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -57,8 +57,14 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - A reviewer reading only the first few lines can tell what kind of
     PR this is and where to focus
 - Progressive disclosure — surface only what a reviewer needs to decide
-  - Implementation details and full alternatives narrative move behind
-    a link or to a "Notes" / "Background" section at the end
+  - Material a reviewer would ask for rather than need in order to
+    decide — implementation detail, a derivation, a measurement, the
+    full alternatives narrative — moves behind a link, into a "Notes" /
+    "Background" section at the end, or into the review thread when the
+    question comes
+  - A decision a linked source delegates to this PR is stated as the
+    value and what bounds it, the derivation being material of that
+    kind
 - The body's structure comes from the decisions the change carries, not
   from the shape of the diff. A subheading or top-level bullet standing
   for one hunk, one file, or one edited section of a document is a
@@ -243,6 +249,10 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - Where the change stops short of what its intent would lead a reader
   to expect, the body says so; a boundary the reader would assume needs
   no statement
+  - The space outside a change is unbounded, so a list of what the
+    change is not conveys nothing on its own, and an out-of-scope item
+    earns its place only where the stated intent would lead a reader to
+    look for it in this diff
 - Edits, reformats, renames, and "while I'm here" cleanups that fall
   outside the PR's stated scope should not appear in the diff
   - The PR diff itself is a deliverable, and out-of-scope hunks force

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -8,13 +8,11 @@ record of the change: everything else lives in the diff, the issue, or
 a linked source. It serves two audiences — the reviewer deciding now,
 and the future reader who reaches this PR from `git log` or blame.
 
-The diff is the default carrier. A reviewer opens it, reads the changed
-lines, and derives from them most of what the change is. The body adds
-what the diff cannot state and what a reader would not derive from it.
-No rule below is a requirement to write a section, and none is
-discharged by writing more: each names something the body carries when
-the diff does not carry it, and asks nothing when the diff does. The
-shortest body that leaves a reviewer able to decide is the correct one.
+The diff is the default carrier: the body adds what the diff cannot
+state and what a reader would not derive from it. No rule under
+Decidable or Scoped is discharged by writing more, and none asks for a
+section the diff's own content would fill. The shortest body that
+leaves a reviewer able to decide is the correct one.
 
 A body is ready when it holds all five properties below. Every rule in
 the five property sections belongs to exactly one of them, and within a
@@ -29,8 +27,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - Necessary — read each line of the body for where else its content
   already lives, and the body carries nothing the diff, its commits,
   the Checks panel or an automation's output carry, states each thing
-  once, and takes from a linked source no more than the summary that
-  survives the link going dead
+  once, takes from a linked source no more than the summary that
+  survives the link going dead, and writes what remains at its tightest
+  expression
 - Scoped — the diff read against the body carries only what the stated
   intent needs and nothing the body did not lead the reader to expect,
   and the body conveys the change as a whole: a boundary the reader
@@ -51,9 +50,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     inventing an alternative to name is itself a defect
   - "Approaches rejected" covers design alternatives weighed for the
     delivered design
-  - Where the diff changes something other code reaches — a function
-    signature, a config key, an exit code, a file another script reads
-    — name the invariant it still holds
+- Where the diff changes something other code reaches — a function
+  signature, a config key, an exit code, a file another script reads —
+  name the invariant it still holds
 - Inverted pyramid — place the most important information first
   - A reviewer reading only the first few lines can tell what kind of
     PR this is and where to focus
@@ -61,12 +60,13 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Implementation details and full alternatives narrative move behind
     a link or to a "Notes" / "Background" section at the end
 - The body's structure comes from the decisions the change carries, not
-  from the shape of the diff. A heading, section, or top-level bullet
-  standing for one hunk, one file, or one edited section of a document
-  is a defect, and a change carrying a single decision takes one
-  paragraph and no headings
+  from the shape of the diff. A subheading or top-level bullet standing
+  for one hunk, one file, or one edited section of a document is a
+  defect, and a change carrying a single decision is described in one
+  paragraph under whichever section the template puts it in
   - A structure a reader could reconstruct from the diff's file list or
-    hunk boundaries alone conveys nothing the diff does not
+    hunk boundaries alone tells the reviewer nothing about where their
+    attention belongs
 - In a bulleted section, the top level carries the change or claim
   itself, so the section reads from its top-level lines alone
   - Supporting material — rationale, evidence, the behavior this change
@@ -162,9 +162,15 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - A line the walk lands on is a finding whether or not a rule below
     names it, and the rules below reach lines answering `nowhere` that
     the walk does not
-  - After that pass, take each paragraph and ask whether a list would
-    carry the same content in fewer words, then take each list item and
-    count its sentences
+- After that pass, walk the body again for how densely what survived is
+  written
+  - One sentence per list item: a second sentence becomes a sub-bullet
+    under the first, or it was not needed, and an item taking three
+    sentences to land is usually two items
+  - A paragraph enumerating three or more parallel items of the same
+    kind — reasons, rejected alternatives, caveats, options — is a
+    finding, and the items belong in a list, one per line
+  - A single claim carrying its own qualifier stays prose
 - Do not paraphrase the diff
   - Keep out file lists, line counts, percentage of lines removed,
     per-file summaries, and enumerations of added rules, linters,
@@ -207,15 +213,6 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     are one fact stated twice
 - Each bullet conveys a distinct decision or outcome, not an individual
   code change
-- One sentence per list item
-  - A second sentence becomes a sub-bullet under the first, or it was
-    not needed
-  - An item that takes three sentences to land is usually two items
-- A paragraph that enumerates parallel items is a finding; the items
-  belong in a list, one per line
-  - Parallel means the same kind: reasons, rejected alternatives,
-    caveats, affected files, options
-  - A single claim carrying its own qualifier stays prose
 - Rationale, background, or requirements that live elsewhere (issue,
   design doc, ADR, prior PR, official spec) are summarized under a
   link, not copied
@@ -225,11 +222,12 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - When the diff is self-explanatory — documentation or config edits
   whose changed lines a reviewer can read directly, especially in the
   team's own language — the body keeps to what the diff cannot convey,
-  and Decidable and Scoped ask nothing further of it
+  and neither Decidable nor Scoped asks for a rationale or boundary
+  beyond that
   - When nothing remains to add, one line such as "realigned stale
     wording with the actual code/config" is a complete description
-  - Apply this rule before any other rule in this section, so what it
-    leaves is what the rest of the walk reads
+  - Apply this rule before the others in this section, so what it
+    leaves is what they read
 - A section heading grants no exemption
   - "diff から読み取れない設計判断", "補足", or "詳細" does not excuse its
     contents from this property — each paragraph under it still has to
@@ -238,12 +236,6 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   tightest expression, is correct as it is
   - Raw length, and the ratio of body size to diff size, are never
     findings on their own
-  - Content that survives the walk above still answers for how densely
-    it is written
-  - A main description section that outweighs the diff it describes
-    mandates the walk that opens this section be run strictly: each
-    claim answered separately, and the self-explanatory-diff rule
-    applied first
 
 ## Scoped
 
@@ -304,24 +296,24 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     and any other in-repo documentation) follow standard Markdown
     rendering and may be hard-wrapped for file-side readability
 
-## Worked example: a self-explanatory diff
+## Worked example: a minimal body
 
 A design document gains a retry on one forwarding hop, and the sending
-side's request spec is gathered into a new prerequisites section. One
-Markdown file, 15 lines added and 7 removed, in the team's own
-language. The whole main description section:
+side's request spec, until then split across two places, is gathered
+into a new prerequisites section. One Markdown file, 15 lines added and
+7 removed, in the team's own language. The body's whole account of the
+change, under whichever heading the repository's template gives it:
 
 ```
 転送失敗時のリトライを設計として追加しました。
+
 合わせて、「前提: 送信仕様」節を新設するなど文章の整理をしました。
 ```
 
-The first sentence names the change and the second names the
-reorganization that came with it. What each added table row says, which
-bullets were merged, and how the sections were rearranged are the
-diff's. A heading per edited section would carry the diff's shape
-rather than the change's decisions, and a paragraph justifying each
-edit would be rationale the changed lines already carry.
+The first sentence names the decision and the second names the
+reorganization. Creating that section is the change; which lines moved
+into it, and how the surrounding text was rewritten to point at it, are
+the edits carrying it out, and the reviewer reads those in the diff.
 
 ## PR Body Template (fallback)
 

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -20,16 +20,16 @@ section the top-level line is the rule while the lines beneath it
 qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 
 - Decidable — reading top-down, a reviewer arrives at the diff knowing
-  what the change is for and where their attention belongs
+  what the change is for and where their attention belongs, each item
+  carrying one claim at the shortest length that lands it
 - Grounded — every claim is checkable on the evidence the body itself
   carries, and the body names a verification mechanism for the code
   paths the diff changes
 - Necessary — read each line of the body for where else its content
   already lives, and the body carries nothing the diff, its commits,
   the Checks panel or an automation's output carry, states each thing
-  once, takes from a linked source no more than the summary that
-  survives the link going dead, and writes what remains at its tightest
-  expression
+  once, and takes from a linked source no more than the summary that
+  survives the link going dead
 - Scoped — the diff read against the body carries only what the stated
   intent needs and nothing the body did not lead the reader to expect,
   and the body conveys the change as a whole: a boundary the reader
@@ -78,6 +78,16 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - A long flat list is usually diff paraphrase; where it survives
     Necessary, it is usually a hierarchy that was never encoded
   - A section this empties loses its heading with it
+- Each item carries one claim at the shortest length that lands it
+  - A list item carrying two or more sentences is a finding: the second
+    becomes a sub-bullet under the first, or it was not needed, and an
+    item taking three sentences to land is usually two items
+    - A verification item's evidence is exempt, since Grounded requires
+      the item to carry it
+  - A paragraph enumerating three or more parallel items of the same
+    kind — reasons, rejected alternatives, caveats, options — is a
+    finding, and the items belong in a list, one per line
+    - A single claim carrying its own qualifier stays prose
 - Future work, out-of-scope follow-ups, and "next PR" notes belong at
   the end of the body (e.g., in a "Follow-up" / "Notes" section)
   - Do not surface them in the opening sections (purpose, scope,
@@ -162,17 +172,6 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - A line the walk lands on is a finding whether or not a rule below
     names it, and the rules below reach lines answering `nowhere` that
     the walk does not
-- After that pass, walk the body again for how densely what survived is
-  written
-  - A list item carrying two or more sentences is a finding: the second
-    becomes a sub-bullet under the first, or it was not needed, and an
-    item taking three sentences to land is usually two items
-    - A verification item's evidence is exempt, since Grounded requires
-      the item to carry it
-  - A paragraph enumerating three or more parallel items of the same
-    kind — reasons, rejected alternatives, caveats, options — is a
-    finding, and the items belong in a list, one per line
-    - A single claim carrying its own qualifier stays prose
 - Do not paraphrase the diff
   - Keep out file lists, line counts, percentage of lines removed,
     per-file summaries, and enumerations of added rules, linters,
@@ -234,8 +233,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - "diff から読み取れない設計判断", "補足", or "詳細" does not excuse its
     contents from this property — each paragraph under it still has to
     be needed for the decision
-- A body long because every part of it is needed, each part at its
-  tightest expression, is correct as it is
+- A body long because every part of it is needed, each item at the
+  length Decidable asks of it, is correct as it is
   - Raw length, and the ratio of body size to diff size, are never
     findings on their own
 

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -164,13 +164,15 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     the walk does not
 - After that pass, walk the body again for how densely what survived is
   written
-  - One sentence per list item: a second sentence becomes a sub-bullet
-    under the first, or it was not needed, and an item taking three
-    sentences to land is usually two items
+  - A list item carrying two or more sentences is a finding: the second
+    becomes a sub-bullet under the first, or it was not needed, and an
+    item taking three sentences to land is usually two items
+    - A verification item's evidence is exempt, since Grounded requires
+      the item to carry it
   - A paragraph enumerating three or more parallel items of the same
     kind — reasons, rejected alternatives, caveats, options — is a
     finding, and the items belong in a list, one per line
-  - A single claim carrying its own qualifier stays prose
+    - A single claim carrying its own qualifier stays prose
 - Do not paraphrase the diff
   - Keep out file lists, line counts, percentage of lines removed,
     per-file summaries, and enumerations of added rules, linters,

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -88,8 +88,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - A list item carrying two or more sentences is a finding: the second
     becomes a sub-bullet under the first, or it was not needed, and an
     item taking three sentences to land is usually two items
-    - A verification item's evidence is exempt, since Grounded requires
-      the item to carry it
+    - Evidence the item quotes, and a verification item's evidence, are
+      exempt, since Grounded requires the item to carry them
   - A paragraph enumerating three or more parallel items of the same
     kind — reasons, rejected alternatives, caveats, options — is a
     finding, and the items belong in a list, one per line

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -54,6 +54,9 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 1. Walk the five properties one at a time, in the order
    `pr-guidelines.md` states them, judging the PR against that
    property's rules and the severity table below
+1. Run the density pass described below over the body's list items and
+   paragraphs. It is a count, not a judgement, and it does not depend
+   on the body's language
 1. Output the result in the format described below, reporting a line
    for every property including those with no finding
 
@@ -86,6 +89,32 @@ Excluded from detection to avoid false positives:
 - GFM tables in either form: rows whose first and last non-whitespace characters are `|`, or pipeless rows recognized by the `---|---` divider line directly below the header row
 - HTML comments (`<!-- ... -->`)
 - Blockquotes (lines starting with `> `)
+
+## Density pass
+
+Necessary's walk ends with a pass over how densely the surviving content
+is written. Apply the count below rather than judging density by eye.
+Each violation it finds is a Fix.
+
+A sentence terminator is `.`, `。`, `!`, `?`, `！`, or `？`. Ignore one
+that falls inside inline code, a fenced block, a URL, a version string,
+or a decimal number, and ignore a trailing terminator, so a one-sentence
+item counts zero.
+
+Violation:
+
+- A list item whose own text carries one or more sentence terminators after ignoring the trailing one — that is, two or more sentences
+
+Excluded from detection:
+
+- A `- [x]` or `- [ ]` item, whose extra sentences are the evidence Grounded requires it to carry
+- Sub-bullets, which are counted as their own items rather than as part of the parent
+- Fenced code blocks, GFM table rows, HTML comments, and blockquotes
+
+The companion rule — a paragraph enumerating three or more parallel
+items of the same kind belongs in a list — takes judgement rather than a
+count, so weigh it against the severity table instead of reporting it
+from this pass.
 
 ## Output Format
 

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -96,10 +96,18 @@ Decidable asks each item to carry one claim at the shortest length that
 lands it. Apply the count below rather than judging length by eye. Each
 violation it finds is a Fix.
 
-A sentence terminator is `.`, `。`, `!`, `?`, `！`, or `？`. Ignore one
-that falls inside inline code, a fenced block, a URL, a version string,
-or a decimal number, and ignore a trailing terminator, so a one-sentence
-item counts zero.
+Enumerate every list item in the body, top-level and nested alike, and
+count each one. Sampling reports a clean pass on a body full of
+violations, which is the failure this section exists to prevent. Start
+from the mechanical over-count below and remove the items the exclusions
+cover — do not start from the items that catch your eye.
+
+```
+grep -nE '^ *[-*+] ' <body file> | grep -cE '[.。!?！？].'
+```
+
+A sentence terminator is `.`, `。`, `!`, `?`, `！`, or `？`. A trailing
+terminator does not count, so a one-sentence item counts zero.
 
 Violation:
 
@@ -107,9 +115,13 @@ Violation:
 
 Excluded from detection:
 
+- A terminator inside inline code, a fenced block, a URL, a version string, a decimal number, or material the item quotes as its evidence
 - A `- [x]` or `- [ ]` item, whose extra sentences are the evidence Grounded requires it to carry
 - Sub-bullets, which are counted as their own items rather than as part of the parent
 - Fenced code blocks, GFM table rows, HTML comments, and blockquotes
+
+Report the enumerated count alongside the findings, so a reader can see
+the pass covered the whole body rather than a sample.
 
 The companion rule — a paragraph enumerating three or more parallel
 items of the same kind belongs in a list — takes judgement rather than a

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -92,9 +92,9 @@ Excluded from detection to avoid false positives:
 
 ## Density pass
 
-Necessary's walk ends with a pass over how densely the surviving content
-is written. Apply the count below rather than judging density by eye.
-Each violation it finds is a Fix.
+Decidable asks each item to carry one claim at the shortest length that
+lands it. Apply the count below rather than judging length by eye. Each
+violation it finds is a Fix.
 
 A sentence terminator is `.`, `。`, `!`, `?`, `！`, or `？`. Ignore one
 that falls inside inline code, a fenced block, a URL, a version string,


### PR DESCRIPTION
## Purpose

Two failures, measured on separate PRs, both of which `pr-guidelines.md` licenses as written.

The first: a documentation-only PR in a private work repository — one Markdown design doc, 15 lines added and 7 removed — carried a 992-character main description split into three `###` subsections, one per diff hunk. `/pr-selfcheck` returned PASS with no Fix, and its property walk gave that hunk-shaped structure as the reason it passed:

- Decidable — 「3点構成で…reviewer は差分を開く前に着眼点を把握できる」
- Scoped — 「diffも3箇所に閉じている」
- Conformant — a Note that the body was missing a template section, which pushes it longer still

The body was written against `pr-guidelines.md` and checked against it, so this is the file's own output rather than a lapse. Every rule in Decidable and Scoped was stated as an obligation the body owes regardless of what the diff shows. On a diff whose changed lines a reviewer reads directly, discharging those obligations means restating the changed lines, and Decidable's hierarchy rules ("A long flat list is usually a hierarchy that was never encoded") then reward giving that restatement a heading per edited section.

The second: two bodies for one PR, carrying the same claims and the same evidence at 4063 and 2083 characters, each returned PASS with no Fix and no Note. Necessary reaches content by where else it already lives, so a claim stated once in four sentences and the same claim stated once in one sentence both survive its walk.

Two other shapes were weighed. Restoring `#366`'s line-based budget fails on its own terms, since Conformant now makes one line one paragraph. Strengthening detection alone — leaving the rules and raising the checker's effort — leaves the rules rewarding the structure, so a checker enforcing them faithfully still passes the first body and still pushes a two-sentence one longer.

## Key changes

- Decidable and Scoped owe nothing the diff already carries, and the self-explanatory-diff rule settles what they ask of such a body
- A body's structure comes from the decisions the change carries, not from the diff's hunks or edited sections
- Decidable asks each item to carry one claim at the shortest length that lands it, and names a two-sentence list item a finding
  - Necessary decides a line by where else its content lives, which both of two bodies carrying the same claims at twice the words survive
  - The remedy is Decidable's own operation, since a second sentence becomes a sub-bullet under the first
- `pr-selfcheck` runs that count as a step with its own section, the way it already runs hard-wrap detection
- Raw length and the body-to-diff ratio stay out of findings, which the density pass no longer needs them to be
- The file gets its first worked example of a minimal body

## Evidence

- `#366` removed a length budget — main description ≈10 lines, body ≤30 lines, overrun reported as Should Fix — and replaced it with "length itself is never a finding"
  - Its commit message says an overrun "only prompts a closer pass against Necessary and Scoped"
  - `grep -niE 'length|size|escalat|character|line count' claude/skills/pr-selfcheck/SKILL.md` returns one unrelated hit, so that closer pass has never existed
  - The budget is not restorable verbatim, since Conformant forbids hard-wrapping GitHub-posted markdown and one line is therefore one paragraph
- Two `/pr-selfcheck` runs on the first PR, two days apart, reached opposite verdicts on the self-explanatory-diff rule
  - The earlier pair raised it as Fix: "the diff is a self-explanatory Japanese documentation edit a reviewer can read directly, so this body section adds no information the diff doesn't already carry and should be dropped"
  - The later run did not raise it at all
  - `git log -1 --date=iso -- claude/skills/git-workflow/pr-guidelines.md` puts the file's last commit before both runs, so the text was identical across them
  - This PR therefore moves the obligations rather than relying on that rule firing
- Retro notes record the defect recurring across repositories, quoted here because the notes are untracked under this repository's Measurement Data policy
  - 「PR本文の「実装内容」節に原因分析・設定の根拠・スコープ外運用を詰め込み、実際の変更内容が埋もれた」
  - 「PR本文を63行（実装内容セクション単独で43行）で作成し、pr-selfcheck から長さ超過を Must Fix として指摘され、約40行に圧縮し直した」

- A third PR self-checked three times after the density rule landed and returned no Fix and no Note, against a body carrying twelve list items of two or more sentences
  - Four subagent transcripts from those runs carry the rule's text verbatim, so the rule was in the checker's context and produced nothing
  - The deployed path and the repository file share an inode, so there is no deployment lag between the two
  - Counting non-checkbox list items carrying a second sentence separates the two measured bodies: 12 of 24 in that PR, 2 of 4 in the documentation PR after its own revision

All three measured cases sit in a private work repository, and the `/pr-selfcheck` runs behind them sit in untracked local session transcripts. The quotes above are the whole of what a reader of this PR can check.

## Out of scope

- A size trigger keyed on the diff, such as any `###` inside a repository template's main section, which would catch a body every list item of which the density pass reads as tight but whose diff warrants none of them
- A budget on supporting material, which nothing bounds today
  - One measured body carries ten second-level bullets under fifteen top-level ones, each of them rationale, which answers `nowhere` to the walk and so always survives
  - Two of those are already prohibited — a rejected alternative at implementation-attempt granularity, and self-paraphrase of a deleted function — making this partly the same detection problem
  - A decidable test for the rest is not yet written, which is why it is not in this PR
- Re-running `/pr-selfcheck` after a body edit made outside the git-workflow phases, which is a `git-workflow` gap and secondary here, since the check ran afterwards and still passed
- Grounded's verification-mechanism rule, still unconditional, which contributed to neither failure
- The remaining crossings of the file's own statement that each rule belongs to exactly one property
  - Necessary's self-explanatory-diff rule names what Decidable and Scoped ask of such a body
  - Necessary's length rule reaches Decidable for the shortest-length condition, so a verbose body is not correct under one property and defective under the other

This state is deliberately not final. A follow-up pass reorganizes the file as a whole.

## Verification

- [x] The worked example carries no identifiers from the private repository the case came from — it names a forwarding hop, a retry, and a prerequisites section, and nothing else
- [ ] The acceptance pair is unrun: the two-sentence example should pass all five properties, and the 992-character body should fail with named Fix items — both need `/pr-selfcheck` against this branch's `pr-guidelines.md`, which is loadable only once this merges or the checker is pointed at the branch copy
