### PR TITLE
Keep review attribution out, and name a Necessary finding location

### DIFF
--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -27,9 +27,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   paths the diff changes
 - Necessary — read each line of the body for where else its content
   already lives, and the body carries nothing the diff, its commits,
-  the Checks panel, this PR's review threads or an automation's output
-  carry, states each thing once, and takes from a linked source no more
-  than the summary that survives the link going dead
+  the Checks panel or an automation's output carry, states each thing
+  once, and takes from a linked source no more than the summary that
+  survives the link going dead
 - Scoped — the diff read against the body carries only what the stated
   intent needs and nothing the body did not lead the reader to expect,
   and the body conveys the change as a whole: a boundary the reader
@@ -164,13 +164,11 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 
 - Take the body a line at a time and name where else that line's content
   lives — the diff, the branch's commits, the Checks panel, a linked
-  source, this PR's own review threads, another line of this body, or
-  nowhere
+  source, another line of this body, or nowhere
   - What the answer forfeits is the part it already carries: detail the
-    diff or the commits show, output the Checks panel holds, the
-    attribution of a point to the review thread that raised it and not
-    the point itself, a fact another line of the body states, and
-    anything past the shortest summary a linked source needs
+    diff or the commits show, output the Checks panel holds, a fact
+    another line of the body states, and anything past the shortest
+    summary a linked source needs
   - A heading is a line the walk takes, and answers for its own text
     rather than for the lines beneath it
   - A table row is a line of the walk, read with the caption or lead-in
@@ -209,8 +207,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Keep out chronological narration of implementation attempts ("first
     tried X, it failed, so Y") and records of direction changes made
     mid-implementation
-  - Keep out references to the session, to plan-mode phases, or to
-    individual commits within the branch
+  - Keep out references to the session, to plan-mode phases, to
+    individual commits within the branch, or to the review that raised
+    a point ("raised in review", "per feedback")
   - Keep out rejected alternatives described at implementation-attempt
     granularity, and alternatives a reviewer would not arrive at and
     ask about

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -164,11 +164,13 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 
 - Take the body a line at a time and name where else that line's content
   lives — the diff, the branch's commits, the Checks panel, a linked
-  source, another line of this body, or nowhere
+  source, this PR's own review threads, another line of this body, or
+  nowhere
   - What the answer forfeits is the part it already carries: detail the
-    diff or the commits show, output the Checks panel holds, a fact
-    another line of the body states, and anything past the shortest
-    summary a linked source needs
+    diff or the commits show, output the Checks panel holds, the
+    attribution of a point to the review that raised it, a fact another
+    line of the body states, and anything past the shortest summary a
+    linked source needs
   - A heading is a line the walk takes, and answers for its own text
     rather than for the lines beneath it
   - A table row is a line of the walk, read with the caption or lead-in

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -27,9 +27,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   paths the diff changes
 - Necessary — read each line of the body for where else its content
   already lives, and the body carries nothing the diff, its commits,
-  the Checks panel or an automation's output carry, states each thing
-  once, and takes from a linked source no more than the summary that
-  survives the link going dead
+  the Checks panel, this PR's review threads or an automation's output
+  carry, states each thing once, and takes from a linked source no more
+  than the summary that survives the link going dead
 - Scoped — the diff read against the body carries only what the stated
   intent needs and nothing the body did not lead the reader to expect,
   and the body conveys the change as a whole: a boundary the reader
@@ -168,9 +168,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   nowhere
   - What the answer forfeits is the part it already carries: detail the
     diff or the commits show, output the Checks panel holds, the
-    attribution of a point to the review that raised it, a fact another
-    line of the body states, and anything past the shortest summary a
-    linked source needs
+    attribution of a point to the review thread that raised it and not
+    the point itself, a fact another line of the body states, and
+    anything past the shortest summary a linked source needs
   - A heading is a line the walk takes, and answers for its own text
     rather than for the lines beneath it
   - A table row is a line of the walk, read with the caption or lead-in

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -51,6 +51,14 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    or a login page), a 429 or 5xx, and a domain `WebFetch` is denied
    all land here. A Fix only when fetched content contradicts the
    citation
+1. When the body makes a claim about this PR's own history — that a
+   point came up in review, that a revision answered feedback, that an
+   item was raised and deferred — read the record it rests on with
+   `gh pr view <number> --json comments,reviews` and
+   `gh pr-review threads list <number>`. A record that contradicts the
+   claim is a Fix, and an empty record under a claim of review activity
+   is such a contradiction. A command that errors leaves the claim
+   unverifiable
 1. Walk the five properties one at a time, in the order
    `pr-guidelines.md` states them, judging the PR against that
    property's rules and the severity table below
@@ -66,7 +74,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 | --- | --- |
 | Fix | Acting on it is required before the PR is ready: a reviewer acting on the body would be misled about what the change does, would find in the diff a change the body did not prepare them for, or would treat a claim the change rests on as settled when the body does not carry what settles it |
 | Note | Surfaced for the reader's judgement, and the reader decides whether to act: a blemish that changes nothing for the reviewer, or a finding the checker is not confident about, stated with the reason for the doubt |
-| Unverifiable | A check that produced nothing comparable against the claim (the `FETCH_HEAD` and URL steps above). Reported as unverifiable, never Fix |
+| Unverifiable | A check that produced nothing comparable against the claim (the `FETCH_HEAD`, URL, and PR-history steps above). Reported as unverifiable, never Fix |
 
 ## Hard-wrap detection (GitHub-posted markdown)
 
@@ -156,6 +164,12 @@ PASS | NEEDS_IMPROVEMENT
 Write "None." under any of the three finding headings that has no
 items, Unverifiable included. The verdict is NEEDS_IMPROVEMENT when any
 Fix item is present, PASS otherwise.
+
+A Necessary finding names where the content already lives — the diff, a
+commit, the Checks panel, the linked source, or the line of this body
+that already states it — so the finding reads as "X carries this"
+rather than as "this is redundant", which an author discharges by
+rewording.
 
 ## Important Notes
 

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -157,9 +157,10 @@ Write "None." under any of the three finding headings that has no
 items, Unverifiable included. The verdict is NEEDS_IMPROVEMENT when any
 Fix item is present, PASS otherwise.
 
-A Necessary finding carries the location the walk answered for that
-line, so the finding reads as "X carries this" rather than as "this is
-redundant", which an author discharges by rewording.
+A finding that Necessary's line-by-line walk produced carries the
+location it answered for that line, so the finding reads as "X carries
+this" rather than as "this is redundant", which an author discharges by
+rewording.
 
 ## Important Notes
 

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -157,10 +157,8 @@ Write "None." under any of the three finding headings that has no
 items, Unverifiable included. The verdict is NEEDS_IMPROVEMENT when any
 Fix item is present, PASS otherwise.
 
-A finding that Necessary's line-by-line walk produced carries the
-location it answered for that line, so the finding reads as "X carries
-this" rather than as "this is redundant", which an author discharges by
-rewording.
+A Necessary finding names the location the Necessary walk answered for
+the line.
 
 ## Important Notes
 

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -51,14 +51,6 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    or a login page), a 429 or 5xx, and a domain `WebFetch` is denied
    all land here. A Fix only when fetched content contradicts the
    citation
-1. When the body makes a claim about this PR's own history — that a
-   point came up in review, that a revision answered feedback, that an
-   item was raised and deferred — read the record it rests on with
-   `gh pr view <number> --json comments,reviews` and
-   `gh pr-review threads list <number>`. A record that contradicts the
-   claim is a Fix, and an empty record under a claim of review activity
-   is such a contradiction. A command that errors leaves the claim
-   unverifiable
 1. Walk the five properties one at a time, in the order
    `pr-guidelines.md` states them, judging the PR against that
    property's rules and the severity table below
@@ -74,7 +66,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 | --- | --- |
 | Fix | Acting on it is required before the PR is ready: a reviewer acting on the body would be misled about what the change does, would find in the diff a change the body did not prepare them for, or would treat a claim the change rests on as settled when the body does not carry what settles it |
 | Note | Surfaced for the reader's judgement, and the reader decides whether to act: a blemish that changes nothing for the reviewer, or a finding the checker is not confident about, stated with the reason for the doubt |
-| Unverifiable | A check that produced nothing comparable against the claim (the `FETCH_HEAD`, URL, and PR-history steps above). Reported as unverifiable, never Fix |
+| Unverifiable | A check that produced nothing comparable against the claim (the `FETCH_HEAD` and URL steps above). Reported as unverifiable, never Fix |
 
 ## Hard-wrap detection (GitHub-posted markdown)
 

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -153,12 +153,11 @@ from this pass.
 PASS | NEEDS_IMPROVEMENT
 ```
 
+A Necessary finding names where the line's content already lives.
+
 Write "None." under any of the three finding headings that has no
 items, Unverifiable included. The verdict is NEEDS_IMPROVEMENT when any
 Fix item is present, PASS otherwise.
-
-A Necessary finding names the location the Necessary walk answered for
-the line.
 
 ## Important Notes
 

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -157,11 +157,9 @@ Write "None." under any of the three finding headings that has no
 items, Unverifiable included. The verdict is NEEDS_IMPROVEMENT when any
 Fix item is present, PASS otherwise.
 
-A Necessary finding names where the content already lives — the diff, a
-commit, the Checks panel, the linked source, or the line of this body
-that already states it — so the finding reads as "X carries this"
-rather than as "this is redundant", which an author discharges by
-rewording.
+A Necessary finding carries the location the walk answered for that
+line, so the finding reads as "X carries this" rather than as "this is
+redundant", which an author discharges by rewording.
 
 ## Important Notes
 


### PR DESCRIPTION
## Purpose

A body that credits a point to the review that raised it records provenance the reviewer does not act on. Necessary already keeps the path to the delivered design out of the body, but the bullet listing provenance references named only the session, plan-mode phases, and the branch's own commits, so a line attributing itself to review answered to no rule and stayed. A body that introduced its deferred items that way passed the check on a PR that had received no review.

Separately, `/pr-selfcheck`'s Output Format never asked a Necessary finding to carry the location the walk already answers for the line, so a finding could land as "this line is redundant" and be discharged by rewording.

## Key changes

- Review attribution joins the provenance references the body keeps out, with the deferred item it introduces staying as content
  - Checking the attribution against the review record is the alternative, and it fails on the true case: a point that really was raised in review still belongs in the thread rather than the body
- A Necessary finding names the location the walk answered, which the Output Format template did not ask for

## Verification

- [x] Both additions were live for a `/pr-selfcheck` run and produced no finding against this body — `~/.claude/skills/git-workflow` and `~/.claude/skills/pr-selfcheck` are symlinks into this working tree, so the checker loaded the branch's copies

No automated check covers the behavior of either file; both are skill prose.

## Notes

Two further changes to the same checker are left for separate PRs: giving Necessary's linked-source summary bound a decision procedure the way the density pass gave one to Decidable, and letting Grounded prescribe returning an unsupported claim to its source rather than only adding a citation.
