### PR TITLE
Name what a linked-source summary carries

### DIFF
--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -225,8 +225,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   design doc, ADR, prior PR, official spec) are summarized under a
   link, not copied
   - A bare link is itself a defect: write the shortest summary that
-    survives the link going dead, naming the value, constraint, or
-    decision this change rests on from that source
+    survives the link going dead, naming what this change rests on
+    from that source
   - Anything past that shortest summary is duplication
 - When the diff is self-explanatory — documentation or config edits
   whose changed lines a reviewer can read directly, especially in the

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -225,7 +225,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   design doc, ADR, prior PR, official spec) are summarized under a
   link, not copied
   - A bare link is itself a defect: write the shortest summary that
-    survives the link going dead
+    survives the link going dead, naming the value, constraint, or
+    decision this change rests on from that source
   - Anything past that shortest summary is duplication
 - When the diff is self-explanatory — documentation or config edits
   whose changed lines a reviewer can read directly, especially in the


### PR DESCRIPTION
## Purpose

Necessary bounds what a PR body may take from a linked source at "the shortest summary that survives the link going dead". That is a magnitude with no measure: a checker asking whether a given block is short enough has nothing to answer with, so a block reproducing a linked document's own account of a premise reads as within the bound. A body that summarized a design document's prerequisites section under its link that way passed `/pr-selfcheck` across repeated runs, and human review cut all of it.

That body is in a private repository and the checker runs behind it sit in untracked local session material, so a reader of this PR can open neither. The account above is the whole of what this PR offers on the case.

## Key changes

- The bound gains a criterion a line can be judged against, in place of a magnitude a checker cannot measure
  - A countable bound is the alternative — a per-link budget, or forbidding sub-bullets under a linked-source summary — and it is a threshold a correct body can violate, which Necessary already rules out where it says raw length is never a finding
- The criterion goes to the bullet that defines the bound and not to the rules that refer to it, so one definition stays authoritative

## Verification

- [x] Read that body against the rewritten rule: of the four lines under its design-doc link, three sit past the shortest summary — one carries where in the source a premise sits alongside naming it, one restates that premise as the source frames it, one states the source's own state on its main branch. The fourth names what the source delegates to the PR, which Decidable separately reduces to the values the PR set

No automated check covers this file's behavior; it is skill prose.
