### PR TITLE
Keep the excuse-phrase hook fail-open on two crashing inputs

### DIFF
--- a/claude/hooks/block_excuse_phrases.py
+++ b/claude/hooks/block_excuse_phrases.py
@@ -262,7 +262,17 @@ def main():
     try:
         data = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError) as e:
-        print(f"block_excuse_phrases: stdin parse failed: {e}", file=sys.stderr)
+        print(f"block_excuse_phrases: stdin parse failed: {e!r}", file=sys.stderr)
+        sys.exit(0)
+
+    # json.load accepts null, arrays, and scalars, none of which carry
+    # the payload's fields, so the parse guard alone would let them
+    # reach the first attribute access.
+    if not isinstance(data, dict):
+        print(
+            f"block_excuse_phrases: stdin was not a JSON object: {data!r}",
+            file=sys.stderr,
+        )
         sys.exit(0)
 
     if data.get("stop_hook_active"):
@@ -276,8 +286,8 @@ def main():
     try:
         with open(transcript_path, encoding="utf-8") as f:
             events = [json.loads(line) for line in f if line.strip()]
-    except (OSError, json.JSONDecodeError) as e:
-        print(f"block_excuse_phrases: transcript read failed: {e}", file=sys.stderr)
+    except (OSError, ValueError) as e:
+        print(f"block_excuse_phrases: transcript read failed: {e!r}", file=sys.stderr)
         sys.exit(0)
 
     blocks = collect_current_turn_assistant_text(events)
@@ -290,7 +300,7 @@ def main():
             try:
                 with open(transcript_path, encoding="utf-8") as f:
                     events = [json.loads(line) for line in f if line.strip()]
-            except (OSError, json.JSONDecodeError) as e:
+            except (OSError, ValueError) as e:
                 last_err = e
                 continue
             blocks = collect_current_turn_assistant_text(events)


### PR DESCRIPTION
## Purpose

A Stop hook that exits non-zero outside a deliberate block renders a hook error notice in the transcript, so the excuse-phrase hook treats every unusable input as an exit 0 with a stderr breadcrumb. Two inputs escaped that and produced a traceback and exit 1 instead.

Both surfaced while building a second Stop hook that started from this one's structure, and neither is reachable from that hook's own change, so they are separated out here.

## Key changes

- The transcript-read handlers catch `ValueError` rather than `json.JSONDecodeError`, so a read landing mid-flush on a partial multi-byte character no longer escapes them
  - `UnicodeDecodeError` subclasses `ValueError`, not `OSError` or `JSONDecodeError`, and the hook races the transcript writer by design — the poll loop exists for that race
- A stdin payload that parses as valid JSON but is not an object exits with a breadcrumb instead of reaching the first attribute access
- Breadcrumbs render the exception with `{e!r}`, since `str()` on some exceptions is empty and prints a bare colon

## Verification

Both reproductions were run against this file's state on `main` and then against the branch.

- [x] a transcript whose last line ends mid-UTF-8-sequence: `UnicodeDecodeError` and exit 1 on `main`, and on the branch `block_excuse_phrases: transcript read failed: UnicodeDecodeError('utf-8', b'\xe6', 0, 1, 'unexpected end of data')` with exit 0
- [x] a stdin payload of `null`: `AttributeError: 'NoneType' object has no attribute 'get'` and exit 1 on `main`, and on the branch `block_excuse_phrases: stdin was not a JSON object: None` with exit 0
- [x] the repository's doctest sweep over `claude/hooks/*.py` passes, including this file's existing examples
