### PR TITLE
Walk diagrams and added comments, and settle every Note

### DIFF
--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -94,7 +94,9 @@ Launch all three in a single assistant message so they execute concurrently:
   `run_in_background: true`
 
 If any of the three fails:
-- Fix self-review "Fix" items, and the "Note" items worth acting on
+- Fix every self-review "Fix" item. Each "Note" is either acted on too,
+  or declined in the assistant message with the reason — a Note passed
+  over in silence leaves the user unable to see the call was made
 - Move anything the sweep escalated into the PR body
 - Fix CI failures (`gh run view --log-failed`), or hand them back to
   the implementer when one is dispatched

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -173,6 +173,12 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     rather than for the lines beneath it
   - A table row is a line of the walk, read with the caption or lead-in
     that says what the table shows
+  - A diagram or a code block is a line of the walk, answered whole for
+    what it depicts. One that traces the control flow, structure, or
+    call order of code in the diff answers `the diff`
+  - The diff carries the comments and docstrings it adds, so a design
+    decision the changed code already explains in prose is content the
+    body forfeits
   - A line carrying more than one claim is answered a claim at a time,
     and each claim forfeits what its own answer names
   - A line the walk lands on is a finding whether or not a rule below

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -65,7 +65,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 | Severity | Condition |
 | --- | --- |
 | Fix | Acting on it is required before the PR is ready: a reviewer acting on the body would be misled about what the change does, would find in the diff a change the body did not prepare them for, or would treat a claim the change rests on as settled when the body does not carry what settles it |
-| Note | Surfaced for the reader's judgement, and the reader decides whether to act: a blemish that changes nothing for the reviewer, or a finding the checker is not confident about, stated with the reason for the doubt |
+| Note | Surfaced for the reader's judgement, and the reader decides whether to act: a blemish that changes nothing for the reviewer, or a finding the checker is not confident about, stated with the reason for the doubt. Carry the finding and that reason alone — a Note that also argues for or against acting on it answers the question it exists to hand over |
 | Unverifiable | A check that produced nothing comparable against the claim (the `FETCH_HEAD` and URL steps above). Reported as unverifiable, never Fix |
 
 ## Hard-wrap detection (GitHub-posted markdown)


### PR DESCRIPTION
## Purpose

Three gaps surfaced while writing and self-checking #397, where the body reached roughly twice the length it needed and four `/pr-selfcheck` runs did not close it.

## Key changes

- The Necessary walk reads a diagram or code block as one line of the walk, and one tracing the diff's control flow answers `the diff`
  - #397's body carried a flowchart of a linear early-return ladder that the script states in the same order; no run of the walk landed on it, because a diagram does not decompose into the lines the walk takes
- The diff carries the comments and docstrings it adds, so rationale the changed code already explains in prose is content the body forfeits
  - #397 gained code comments through review while the body gained matching bullets, and the walk cleared each bullet as absent from the diff because the diff was being read as changed code
- A Note states its finding and the reason for the doubt, and stops there
- Each Note is acted on or declined in the open, rather than passed over in silence

## Verification

- [x] the Necessary walk's own sub-bullet list is where the two new entries sit, alongside the existing heading and table-row entries, so a checker following the walk in order reaches them
- [x] `git grep -n '"Note"\|| Note |\|### Note' -- claude/skills/` returns three lines: the severity table row, the workflow step consuming it, and the output-format heading, so the two edited places are where Note handling is stated
- [ ] whether the walk now catches the two cases needs a `/pr-selfcheck` run against a body carrying them, which this PR's own body does not
