### PR TITLE
Enumerate same-decision statements before proposing a rule edit

### DIFF
--- a/claude/skills/retro-review/SKILL.md
+++ b/claude/skills/retro-review/SKILL.md
@@ -106,9 +106,17 @@ session context and cross-rule judgment.
    cluster's action. Weigh cost of failure: cheap self-correcting
    failures lean accept; failures that reach persisted artifacts,
    infrastructure, or user-facing claims lean structural fixes.
+1. For each cluster whose disposition is rule-edit, enumerate every
+   statement across `AIRULES.md` and `claude/rules/` that decides the
+   same question as the proposed edit, and record for each whether it
+   agrees with the edit, contradicts it, or already states it. Run
+   this before Step 6 so the user arbitrates a contradiction while the
+   action is still a proposal, rather than after both statements are
+   in force.
 1. Write `report.md` to the workdir: cluster table (counts, severity
    mix, diagnosis, disposition), effect-measurement results, key
-   observations, and proposed actions in priority order.
+   observations, the same-decision enumeration behind each rule-edit
+   action, and proposed actions in priority order.
 
 ## Step 6: Checkpoint with the user
 

--- a/claude/skills/retro-review/SKILL.md
+++ b/claude/skills/retro-review/SKILL.md
@@ -120,7 +120,8 @@ session context and cross-rule judgment.
 
 ## Step 6: Checkpoint with the user
 
-Present the report summary and the proposed action list. Creating PRs
+Present `report.md`'s summary, its same-decision enumeration for every
+rule-edit action, and the proposed action list. Creating PRs
 and editing rules are external mutations — proceed only with the
 actions the user approves. Record deferred or declined proposals as
 planned/accept entries in Step 8.

--- a/claude/skills/retro-review/SKILL.md
+++ b/claude/skills/retro-review/SKILL.md
@@ -107,12 +107,17 @@ session context and cross-rule judgment.
    failures lean accept; failures that reach persisted artifacts,
    infrastructure, or user-facing claims lean structural fixes.
 1. For each cluster whose disposition is rule-edit, enumerate every
-   statement across `AIRULES.md` and `claude/rules/` that decides the
-   same question as the proposed edit, and record for each whether it
-   agrees with the edit, contradicts it, or already states it. Run
-   this before Step 6 so the user arbitrates a contradiction while the
-   action is still a proposal, rather than after both statements are
-   in force.
+   statement that decides the same question as the proposed edit, and
+   record for each whether it agrees with the edit, contradicts it, or
+   already states it. The search space is `AIRULES.md` and
+   `claude/rules/`, plus the target project's own rule files when the
+   edit targets a project asset. A contradiction found here reaches
+   the user while the action is still a proposal, rather than after
+   both statements are in force.
+1. When an enumerated statement already states the proposed edit,
+   record the cluster's diagnosis as rule-not-followed and revisit the
+   disposition that followed from it, since restating a rule already
+   in force does not make it more binding.
 1. Write `report.md` to the workdir: cluster table (counts, severity
    mix, diagnosis, disposition), effect-measurement results, key
    observations, the same-decision enumeration behind each rule-edit
@@ -132,7 +137,9 @@ One action = one PR. For each approved action, invoke the git-workflow
 skill (branch, edit, draft PR, CI and review phases). Rule edits follow
 `rule-authoring.md` (integrate into the affected instruction) and the
 output-format rules in AIRULES.md (positive form, one sentence per
-bullet). Record which
+bullet). Its enumeration requirement runs here against the edit as
+actually worded, which the checkpoint may have moved away from the
+proposal Step 5 covered. Record which
 review findings were adopted or declined, and why, in `report.md`.
 
 ## Step 8: Persist lifecycle


### PR DESCRIPTION
## Purpose

Phase 3 of #404. #400 found conflicting rule pairs that per-diff review cannot catch by construction: a diff answers whether a line is good, not whether it contradicts a line in a file the diff does not touch. Those pairs entered the rule set one retro-review action at a time, each correct in isolation. This closes that intake while an action is still a proposal.

## Key changes

- A cluster diagnosed as rule-edit carries an enumeration of every statement deciding the same question, and the Step 6 checkpoint presents it, so the user arbitrates a contradiction before the edit is written
- A statement that already states the edit sends the cluster back to diagnosis as rule-not-followed, since finding one is evidence the disposition was wrong rather than context to file alongside it

## Notes

`claude/rules/rule-authoring.md` already requires this enumeration when a rule-editing PR is written, which #404 records as the other half of the requirement. That one runs at execution time inside Step 7, against the edit as finally worded; this one runs at diagnosis time, before the user is asked to approve the action at all.

A CI job checking rule-set consistency automatically stays out of scope, on the grounds #400's Caveats records.

## Verification

- [x] The new steps land on values and files the skill already has: rule-not-followed is one of Step 5's three diagnoses, `report.md` is written by the step that follows them, and Step 3's canonical targets admit the project assets the widened search space reaches
- [x] Result read against `claude/rules/rule-authoring.md`, which #404 Phase 0 fixed as the acceptance criterion for rule-set changes
