### PR TITLE
Delete broken symlinks in agent CLI deploy targets

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -57,31 +57,36 @@ if [[ -d "$ICLOUD_DIR" ]]; then
   ln -fvns "$ICLOUD_DIR" "$HOME/iCloudDrive"
 fi
 
+# Agent CLIs. Every auto-discovered directory below prunes broken symlinks
+# before relinking, so a source file deleted from the repo leaves nothing
+# behind in the deploy target.
+
 # Claude Code: explicit files + skills auto-discovered
 link claude/.mcp.json              "$HOME/.claude/.mcp.json"
 link claude/settings.json          "$HOME/.claude/settings.json"
 link claude/statusline-command.sh  "$HOME/.claude/statusline-command.sh"
 link AIRULES.md           "$HOME/.claude/CLAUDE.md"
 mkdir -p "$HOME/.claude/skills"
-find "$HOME/.claude/skills/" -maxdepth 1 -type l ! -exec test -e {} \; -print
+find "$HOME/.claude/skills/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/skills" -maxdepth 1 -mindepth 1 -type d -exec ln -fvns {} "$HOME/.claude/skills/" \;
 mkdir -p "$HOME/.claude/hooks"
-find "$HOME/.claude/hooks/" -maxdepth 1 -type l ! -exec test -e {} \; -print
+find "$HOME/.claude/hooks/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/hooks" -maxdepth 1 -mindepth 1 -type f ! -name 'test_*' -exec ln -fvns {} "$HOME/.claude/hooks/" \;
 mkdir -p "$HOME/.claude/agents"
-find "$HOME/.claude/agents/" -maxdepth 1 -type l ! -exec test -e {} \; -print
+find "$HOME/.claude/agents/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/agents" -maxdepth 1 -mindepth 1 -type f -name '*.md' -exec ln -fvns {} "$HOME/.claude/agents/" \;
 mkdir -p "$HOME/.claude/rules"
-find "$HOME/.claude/rules/" -maxdepth 1 -type l ! -exec test -e {} \; -print
+find "$HOME/.claude/rules/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/rules" -maxdepth 1 -mindepth 1 -type f -name '*.md' -exec ln -fvns {} "$HOME/.claude/rules/" \;
 
 # Codex CLI
 link AIRULES.md  "$HOME/.codex/AGENTS.md"
 mkdir -p "$HOME/.codex/rules"
+find "$HOME/.codex/rules/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/codex/rules" -maxdepth 1 -mindepth 1 -type f -name '*.rules' -exec ln -fvns {} "$HOME/.codex/rules/" \;
 
 # Junie CLI (JetBrains)
 link AIRULES.md  "$HOME/.junie/AGENTS.md"
 mkdir -p "$HOME/.junie/skills"
-find "$HOME/.junie/skills/" -maxdepth 1 -type l ! -exec test -e {} \; -print
+find "$HOME/.junie/skills/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/skills" -maxdepth 1 -mindepth 1 -type d -exec ln -fvns {} "$HOME/.junie/skills/" \;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -57,9 +57,11 @@ if [[ -d "$ICLOUD_DIR" ]]; then
   ln -fvns "$ICLOUD_DIR" "$HOME/iCloudDrive"
 fi
 
-# Agent CLIs. Every auto-discovered directory below prunes broken symlinks
-# before relinking, so a source file deleted from the repo leaves nothing
-# behind in the deploy target.
+# Agent CLIs (Claude Code, Codex, Junie). Each auto-discovered directory
+# below relinks first and prunes broken symlinks second, so a missing or
+# partial source tree aborts under `set -e` before anything is deleted.
+# Only broken symlinks go: real files stay, and so do the entries deployed
+# by link(), which warns and skips when its source is gone.
 
 # Claude Code: explicit files + skills auto-discovered
 link claude/.mcp.json              "$HOME/.claude/.mcp.json"
@@ -67,26 +69,26 @@ link claude/settings.json          "$HOME/.claude/settings.json"
 link claude/statusline-command.sh  "$HOME/.claude/statusline-command.sh"
 link AIRULES.md           "$HOME/.claude/CLAUDE.md"
 mkdir -p "$HOME/.claude/skills"
-find "$HOME/.claude/skills/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/skills" -maxdepth 1 -mindepth 1 -type d -exec ln -fvns {} "$HOME/.claude/skills/" \;
+find "$HOME/.claude/skills/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 mkdir -p "$HOME/.claude/hooks"
-find "$HOME/.claude/hooks/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/hooks" -maxdepth 1 -mindepth 1 -type f ! -name 'test_*' -exec ln -fvns {} "$HOME/.claude/hooks/" \;
+find "$HOME/.claude/hooks/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 mkdir -p "$HOME/.claude/agents"
-find "$HOME/.claude/agents/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/agents" -maxdepth 1 -mindepth 1 -type f -name '*.md' -exec ln -fvns {} "$HOME/.claude/agents/" \;
+find "$HOME/.claude/agents/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 mkdir -p "$HOME/.claude/rules"
-find "$HOME/.claude/rules/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/rules" -maxdepth 1 -mindepth 1 -type f -name '*.md' -exec ln -fvns {} "$HOME/.claude/rules/" \;
+find "$HOME/.claude/rules/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 
 # Codex CLI
 link AIRULES.md  "$HOME/.codex/AGENTS.md"
 mkdir -p "$HOME/.codex/rules"
-find "$HOME/.codex/rules/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/codex/rules" -maxdepth 1 -mindepth 1 -type f -name '*.rules' -exec ln -fvns {} "$HOME/.codex/rules/" \;
+find "$HOME/.codex/rules/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 
 # Junie CLI (JetBrains)
 link AIRULES.md  "$HOME/.junie/AGENTS.md"
 mkdir -p "$HOME/.junie/skills"
-find "$HOME/.junie/skills/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete
 find "$DOTPATH/claude/skills" -maxdepth 1 -mindepth 1 -type d -exec ln -fvns {} "$HOME/.junie/skills/" \;
+find "$HOME/.junie/skills/" -maxdepth 1 -type l ! -exec test -e {} \; -print -delete

--- a/scripts/verify_deploy.sh
+++ b/scripts/verify_deploy.sh
@@ -33,8 +33,9 @@ check_dir() {
 # Drift checks below are warnings, not failures: the live host's symlink
 # state is ambient, human-owned state (a stray dangling symlink might be
 # something intentionally left for manual review), not a repo-consistency
-# fact this script can safely gate a commit on. deploy.sh never
-# auto-deletes for the same reason. See check_symlink/check_dir above for
+# fact this script can safely gate a commit on. deploy.sh prunes the
+# dangling symlinks in the directories it owns, so a warning here names one
+# that appeared outside a deploy run. See check_symlink/check_dir above for
 # the deterministic, repo-driven checks that DO fail the build.
 
 check_no_dangling_symlinks() {
@@ -44,7 +45,7 @@ check_no_dangling_symlinks() {
   if [ -z "$dangling" ]; then
     echo "OK: $dir has no dangling symlinks"
   else
-    echo "WARN: $dir has dangling symlinks (review and remove manually if stale):"
+    echo "WARN: $dir has dangling symlinks (re-run scripts/deploy.sh to prune):"
     echo "$dangling"
     warnings=$((warnings + 1))
   fi


### PR DESCRIPTION
## Purpose

Deleting a rule, skill, agent, or hook file from this repository left a dangling symlink in the deploy target, because the auto-discovered directories under `~/.claude`, `~/.codex`, and `~/.junie` only reported broken symlinks. Follow-up from #404, where `implementation-delegation.md` and `external-tool-claims.md` each left one behind after #405 and #406.

## Key changes

- The agent CLI deploy targets prune dangling symlinks with `find ... -print -delete`, the expression the `~/bin` branch already uses
- `~/.codex/rules` gains a prune step, having had none
- Each block relinks before it prunes, for the reason the comment at `deploy.sh:60-64` gives
- `verify_deploy.sh`'s drift-check rationale and WARN text are realigned with the prune
- #404 named `~/.claude/rules`; the identical gap existed in every auto-discovered agent CLI target, so this covers all of them rather than that one directory

## Verification

- [x] Against a target holding all six entry kinds a deploy directory can carry, the prune removes the two dangling symlinks and nothing else. Real files, real directories, resolving symlinks, and every symlink target survive, on both `find` implementations this repo can hit:

```
== /usr/bin/find ==
before: link-to-gone-dir link-to-gone-file link-to-live-dir link-to-live-file realdir realfile
after:  link-to-live-dir link-to-live-file realdir realfile
src intact: livedir livefile
== findutils/libexec/gnubin/find ==
before: link-to-gone-dir link-to-gone-file link-to-live-dir link-to-live-file realdir realfile
after:  link-to-live-dir link-to-live-file realdir realfile
src intact: livedir livefile
```

- [x] Relink-then-prune against a missing source tree exits 1 from the relink and deletes nothing, so `set -e` aborts with the target intact:

```
$ ( set -eu; block "$BASE/missing" )
find: '.../ordertest/missing': No such file or directory
block exit: 1
$ ls -1 "$BASE/dst"
gone.md
live.md
```

- [x] That exit code holds on the fresh-Mac bootstrap path too, where `bootstrap/main.sh` runs `deploy.sh` (line 19) before `brew bundle` (line 66) and `find` is therefore BSD:

```
$ /usr/bin/find /nonexistent-xyz -maxdepth 1 -mindepth 1 -type f -print
find: /nonexistent-xyz: No such file or directory
BSD find exit: 1
```

## Notes

The prune's scope is every dangling symlink in the target directory, not only the ones this repository created, so a link another installer left behind goes too once its target is missing. That is the trade `deploy.sh:51` has carried for `~/bin` since before this PR.

Rejected alternatives, both against that same precedent:

- Replacing `-delete` with `-exec rm -f {} +` for a nonzero exit on a failed deletion, where the two `find` builds disagree against a broken symlink in a read-only parent and the fresh-Mac bootstrap path gets the one that hides it:

```
== /usr/bin/find ==
find: -delete: unlink(.../dst/gone): Permission denied
exit: 0
== findutils/libexec/gnubin/find ==
find: cannot delete '.../dst/gone': Permission denied
exit: 1
```

- Labelling the printed path with a `prune broken symlink:` prefix, which would give these six lines an idiom line 51 does not share

Out of scope, left as a follow-up: the XDG auto-discovery at `deploy.sh:39` links `xdg-config/*` into `~/.config/` with no prune step, so it has the same gap.
