### PR TITLE
Deny EnterWorktree outright and drop what git-essentials restated

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -62,3 +62,11 @@ hooks have no such prefix.
 Each subagent's model is chosen per invocation through the Agent tool's
 `model` parameter. The `CLAUDE_CODE_SUBAGENT_MODEL` environment variable
 overrides that parameter for every subagent at once, so it stays unset.
+
+## Worktrees
+
+`permissions.deny` carries `EnterWorktree`, which removes the tool from
+Claude's context entirely, and the CLI's own `--worktree` flag is left
+unused for the same reason: both have known bugs. Worktrees for a task
+are created with `git-worktree-create` instead, in projects that allow
+them.

--- a/claude/hooks/guard_default_branch_edits.py
+++ b/claude/hooks/guard_default_branch_edits.py
@@ -3,8 +3,9 @@
 
 Branching before the first edit is a git-workflow precondition the
 model is expected to enforce on its own, but retrospectives found edits
-landing on main before a branch existed. Some repos (this dotfiles repo included) also have sessions
-where the user genuinely wants direct default-branch work, so a
+landing on main before a branch existed. Some repos (this dotfiles
+repo included) also have sessions where the user genuinely wants
+direct default-branch work, so a
 permission prompt on every Write/Edit is the wrong shape — it would
 either interrupt the legitimate case repeatedly or train the user to
 reflexively approve it.

--- a/claude/hooks/guard_default_branch_edits.py
+++ b/claude/hooks/guard_default_branch_edits.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """Deny once per session, then allow: guard default-branch edits.
 
-git-essentials.md ("Never create or edit files on the default branch")
-is a git-workflow precondition the model is expected to enforce on its
-own, but retrospectives found edits landing on main before a branch
-existed. Some repos (this dotfiles repo included) also have sessions
+Branching before the first edit is a git-workflow precondition the
+model is expected to enforce on its own, but retrospectives found edits
+landing on main before a branch existed. Some repos (this dotfiles repo included) also have sessions
 where the user genuinely wants direct default-branch work, so a
 permission prompt on every Write/Edit is the wrong shape — it would
 either interrupt the legitimate case repeatedly or train the user to
@@ -190,8 +189,8 @@ def main():
             "permissionDecision": "deny",
             "permissionDecisionReason": (
                 f"Write/Edit targets a non-ignored path on the default "
-                f"branch '{current}' of {repo_root}. git-essentials "
-                f"prohibits editing files on the default branch — branch "
+                f"branch '{current}' of {repo_root}. Files are created "
+                f"and edited on a feature branch — branch "
                 f"first (invoke the git-workflow skill). Only when the "
                 f"user has explicitly asked for work directly on the "
                 f"default branch, retry this edit: retries in this "

--- a/claude/rules/git-essentials.md
+++ b/claude/rules/git-essentials.md
@@ -25,12 +25,6 @@ NOT restate the detailed procedures from the skill.
 - Step 4: CI wait and review (Phases 1-5)
 - Step 6: cleanup after merge (`git cleanup`)
 
-## Branch
-
-- Claude Code's `--worktree` flag and the EnterWorktree tool must
-  never be used (known bugs)
-- Never create or edit files on the default branch — branch first
-
 ## Commit
 
 - Append a blank line and exactly one Claude trailer block:
@@ -39,17 +33,14 @@ NOT restate the detailed procedures from the skill.
   rules prescribe a different trailer format, that format replaces
   this one (harness wins over project rules) — never stack a second
   trailer block.
-- Never modify commits that have already been pushed
 
 ## Push
 
 - First push: `git push -u origin HEAD`; afterwards `git push`
-- Force push variants (`--force`, `-f`, `--force-with-lease`) are
-  absolutely prohibited unless the user explicitly instructs
-  otherwise. If a chosen path would require one, or `git reset
-  --hard` on a published branch, back out to a merge-based path:
-  `gh pr update-branch <N>`, merge the default branch into the
-  feature branch, or a fresh commit on top.
+- When a path would need a force push, or `git reset --hard` on a
+  published branch, back out to a merge-based one: `gh pr
+  update-branch <N>`, merge the default branch into the feature
+  branch, or a fresh commit on top.
 
 ## PR / issue body edits
 

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -233,6 +233,7 @@
       "Bash(git push --force-with-lease *)",
       "Bash(git push * --force-with-lease)",
       "Bash(git push * --force-with-lease *)",
+      "EnterWorktree",
       "Bash(git worktree remove --force *)",
       "Bash(git worktree remove * --force *)",
       "Bash(git worktree remove -f *)",

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -222,6 +222,8 @@
       "Bash(git push -f *)",
       "Bash(git push * --force *)",
       "Bash(git push * -f *)",
+      "Bash(git push * -f)",
+      "Bash(git push * --force)",
       "Bash(git push *--force*)",
       "Bash(git push --delete *)",
       "Bash(git push * --delete *)",


### PR DESCRIPTION
Turns the worktree ban into a settings-level denial and removes three `git-essentials.md` lines a mechanism already carries. Second of the PRs that started at #416.

## The worktree ban becomes enforcement

`permissions.deny` now carries the bare tool name `EnterWorktree`. Per [permissions.md](https://code.claude.com/docs/en/permissions), "a bare tool name like `Bash` removes the tool from Claude's context entirely, so Claude never sees it" — stronger than a rule asking Claude to decline.

It cannot break the worktree flow: `git-worktree-create` is a shell script reached through the `Bash(git-worktree-create *)` allow entry, which is a different mechanism from the tool, and nothing under `claude/` names `EnterWorktree` as part of a flow.

The CLI's `--worktree` flag has no such enforcement point, since a person types it rather than Claude calling it. That half moves to `claude/README.md`, where the reader of the configuration finds it.

## Lines removed

| Line | Ground |
| --- | --- |
| never create or edit files on the default branch | `git-workflow/SKILL.md` states it verbatim, and `guard_default_branch_edits.py` gates it |
| never modify commits that have already been pushed | `git-workflow/SKILL.md` verbatim, `implementer.md` and `narrative-sweeper.md`, with `git commit --amend` denied and `git rebase` / `git reset` behind an ask rule |
| the force-push flag enumeration | `permissions.deny` covers `--force`, `-f`, `--force-with-lease`, `--delete`, `--mirror`, and `refspec:` deletion |

The force-push entry keeps its second half — back out to `gh pr update-branch <N>`, a merge of the default branch, or a fresh commit on top. A deny rule blocks a command without saying what to do instead, so that route exists nowhere else.

`guard_default_branch_edits.py` justified itself by quoting the rule line this PR removes, in both its docstring and its runtime deny message. Both now state the constraint directly, so the message a denied edit shows no longer points at a rule that does not say it.

## A hole in the force-push denial, closed

Reviewing the deletion above surfaced that the deny entries did not cover what they were credited with. Every one either put the flag directly after `push` or required text after it, so `git push origin main -f` matched none of them: per the docs, a trailing `* ` matches the bare command only when it is the rule's only wildcard, which `Bash(git push * -f *)` is not. `Bash(git push * -f)` and `Bash(git push * --force)` are now denied too, the shape `--force-with-lease` already had. Sixteen `git push` deny entries now cover the six flag families.

## The workflow checklist stays

This file requires every plan-mode Final Plan to embed the checklist as a section, so it has to be readable while the plan is being written, which is before Step 0 invokes the git-workflow skill. The copy in the skill is the procedure to follow; the copy here is what a plan quotes.

## Verification

- [x] `jq -e '.permissions.deny | index("EnterWorktree")' claude/settings.json` — present, and the JSON parses
- [x] `python3 -m doctest claude/hooks/guard_default_branch_edits.py` — passes after the docstring and message rewrite
- [x] `git grep -n 'git-essentials'` at the PR head — zero matches anywhere in the tree
- [x] `bash scripts/check_rule_budget.sh` — 51/100 lines for this file, and the pre-commit hook runs the same script
- [x] `jq -r '.permissions.deny[] | select(startswith("Bash(git push"))'` — sixteen entries, including the two trailing-flag forms added here
