### PR TITLE
Match a fetch invocation rather than a co-occurrence of two words

### DIFF
--- a/claude/hooks/block_raw_github_fetch.py
+++ b/claude/hooks/block_raw_github_fetch.py
@@ -7,13 +7,20 @@ constraint: a Bash command that reaches for ``curl``/``wget`` against
 that domain is denied and pointed at the ``gh api`` equivalent instead,
 with the "ask the user" fallback for the case where ``gh`` cannot run.
 
-The predicate asks for an invocation, not a mention. A command is
-denied when ``curl`` or ``wget`` stands at the head of a segment
-(splitting on ``&&``, ``||``, ``;``, newline, and ``|`` outside quotes)
-and the domain appears in that same segment. A commit message, a grep
-pattern, or a comment naming both the tool and the domain therefore
-passes, and so does a fetch of some other host piped into a command
-that mentions this one.
+The predicate asks for an invocation, not a mention. Line continuations
+are joined, the command is split on ``&&``, ``||``, ``;``, newline, and
+``|`` outside quotes, and each segment is denied when it names the
+domain and puts a fetch tool in command position — at the head of the
+segment, after a leading environment assignment or a wrapper such as
+``sudo`` or ``timeout``, or opening a substitution or subshell. A path
+qualifier such as ``/usr/bin/`` is accepted on the tool name.
+
+So a commit message, a grep pattern, or a comment naming both the tool
+and the domain passes, and so does a fetch of some other host piped
+into a command that mentions this one. Two shapes still match without
+fetching the domain: a heredoc body, whose lines are read as commands,
+and a fetch of another host that carries the domain elsewhere on the
+same segment, such as in a header value or an output filename.
 
 Spec: https://code.claude.com/docs/en/hooks
 """
@@ -21,11 +28,12 @@ import json
 import re
 import sys
 
+_CONTINUATION_RE = re.compile(r"\\\n")
 _SEPARATOR_RE = re.compile(r"&&|\|\||;|\n|\|")
 _DOMAIN_RE = re.compile(r"raw\.githubusercontent\.com")
-_FETCH_HEAD_RE = re.compile(r"(curl|wget)(\s|$)")
-_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=\S*\s+")
-_COMMAND_PREFIX_RE = re.compile(r"^(sudo|env|command|nohup|time)\s+")
+_FETCH_COMMAND_RE = re.compile(r"(?:^|[(`]|\$\()\s*(?:\S*/)?(?:curl|wget)(\s|$)")
+_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=[^\s$]*\s+")
+_WRAPPER_RE = re.compile(r"^(?:sudo|env|command|nohup|time)\s+|^timeout\s+\S+\s+")
 
 REASON = (
     'Use gh instead: gh api repos/<owner>/<repo>/contents/<path> '
@@ -90,27 +98,38 @@ def _split_outside_quotes(command: str) -> list[str]:
 
 
 def _strip_leading_prefixes(segment: str) -> str:
-    """Drop env assignments and wrappers that precede the real command.
+    """Drop env assignments and the wrappers named in ``_WRAPPER_RE``.
+
+    Each pass removes a prefix of at least two characters, so the loop
+    ends on every input.
 
     >>> _strip_leading_prefixes("HTTPS_PROXY=http://p curl x")
     'curl x'
     >>> _strip_leading_prefixes("sudo curl x")
     'curl x'
+    >>> _strip_leading_prefixes("timeout 10 curl x")
+    'curl x'
     >>> _strip_leading_prefixes("A=1 B=2 env curl x")
     'curl x'
     >>> _strip_leading_prefixes("curl x")
     'curl x'
+
+    An assignment whose value opens a substitution is left alone, so the
+    tool inside it stays visible:
+
+    >>> _strip_leading_prefixes("content=$(curl x)")
+    'content=$(curl x)'
     """
     previous = None
     while previous != segment:
         previous = segment
         segment = _ENV_ASSIGN_RE.sub("", segment)
-        segment = _COMMAND_PREFIX_RE.sub("", segment)
+        segment = _WRAPPER_RE.sub("", segment)
     return segment
 
 
 def is_raw_github_fetch(command: str) -> bool:
-    """Return True if a segment invokes curl/wget against the domain.
+    """Return True if a segment names the domain and invokes curl/wget.
 
     >>> is_raw_github_fetch("curl -sL https://raw.githubusercontent.com/a/b/main/x")
     True
@@ -118,15 +137,33 @@ def is_raw_github_fetch(command: str) -> bool:
     True
     >>> is_raw_github_fetch("cat urls | curl -K - https://raw.githubusercontent.com/a")
     True
+
+    Command position survives an assignment, a wrapper, a path
+    qualifier, a substitution, and a line continuation:
+
     >>> is_raw_github_fetch("HTTPS_PROXY=http://p curl https://raw.githubusercontent.com/a")
     True
+    >>> is_raw_github_fetch("timeout 10 curl https://raw.githubusercontent.com/a")
+    True
+    >>> is_raw_github_fetch("/usr/bin/curl -sL https://raw.githubusercontent.com/a")
+    True
+    >>> is_raw_github_fetch('bash -c "$(curl -fsSL https://raw.githubusercontent.com/a)"')
+    True
+    >>> is_raw_github_fetch("body=$(curl -sL https://raw.githubusercontent.com/a)")
+    True
+    >>> is_raw_github_fetch("curl -sL \\\\\\n  https://raw.githubusercontent.com/a")
+    True
 
-    Naming the tool and the domain without invoking one is not a fetch:
+    Naming the tool and the domain without putting the tool in command
+    position is not a fetch:
 
     >>> is_raw_github_fetch("git commit -m 'switch from curl to gh for raw.githubusercontent.com'")
     False
     >>> is_raw_github_fetch("git grep -n 'curl .*raw.githubusercontent.com'")
     False
+
+    Neither is a fetch whose domain sits in another segment, or none:
+
     >>> is_raw_github_fetch("curl -sL https://example.com | grep raw.githubusercontent.com")
     False
     >>> is_raw_github_fetch("curl -sL https://example.com/a/b")
@@ -134,9 +171,10 @@ def is_raw_github_fetch(command: str) -> bool:
     >>> is_raw_github_fetch("")
     False
     """
+    command = _CONTINUATION_RE.sub(" ", command)
     for segment in _split_outside_quotes(command):
         segment = _strip_leading_prefixes(segment.strip())
-        if _FETCH_HEAD_RE.match(segment) and _DOMAIN_RE.search(segment):
+        if _DOMAIN_RE.search(segment) and _FETCH_COMMAND_RE.search(segment):
             return True
     return False
 

--- a/claude/hooks/block_raw_github_fetch.py
+++ b/claude/hooks/block_raw_github_fetch.py
@@ -6,11 +6,14 @@ Fetching raw.githubusercontent.com directly is only warranted when
 constraint: a Bash command that reaches for ``curl``/``wget`` against
 that domain is denied and pointed at the ``gh api`` equivalent instead,
 with the "ask the user" fallback for the case where ``gh`` cannot run.
-The predicate asks for the domain and the word ``curl`` or ``wget``
-anywhere in the command, without relating their positions. A command
-that only names the domain passes; one that names it alongside either
-word is denied even when it fetches nothing, which covers a commit
-message or a grep pattern carrying both.
+
+The predicate asks for an invocation, not a mention. A command is
+denied when ``curl`` or ``wget`` stands at the head of a segment
+(splitting on ``&&``, ``||``, ``;``, newline, and ``|`` outside quotes)
+and the domain appears in that same segment. A commit message, a grep
+pattern, or a comment naming both the tool and the domain therefore
+passes, and so does a fetch of some other host piped into a command
+that mentions this one.
 
 Spec: https://code.claude.com/docs/en/hooks
 """
@@ -18,8 +21,11 @@ import json
 import re
 import sys
 
+_SEPARATOR_RE = re.compile(r"&&|\|\||;|\n|\|")
 _DOMAIN_RE = re.compile(r"raw\.githubusercontent\.com")
-_FETCH_TOOL_RE = re.compile(r"\b(curl|wget)\b")
+_FETCH_HEAD_RE = re.compile(r"(curl|wget)(\s|$)")
+_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=\S*\s+")
+_COMMAND_PREFIX_RE = re.compile(r"^(sudo|env|command|nohup|time)\s+")
 
 REASON = (
     'Use gh instead: gh api repos/<owner>/<repo>/contents/<path> '
@@ -29,26 +35,110 @@ REASON = (
 )
 
 
+def _split_outside_quotes(command: str) -> list[str]:
+    """Split command by shell separators, ignoring separators inside quotes.
+
+    >>> _split_outside_quotes("curl a | grep b")
+    ['curl a ', ' grep b']
+    >>> _split_outside_quotes("echo 'curl a | grep b'")
+    ["echo 'curl a | grep b'"]
+    >>> _split_outside_quotes("a && b || c ; d")
+    ['a ', ' b ', ' c ', ' d']
+    >>> _split_outside_quotes("a\\ncurl x")
+    ['a', 'curl x']
+    >>> _split_outside_quotes('echo "pipe | inside double"')
+    ['echo "pipe | inside double"']
+    """
+    segments = []
+    current = []
+    in_single = False
+    in_double = False
+    i = 0
+    while i < len(command):
+        ch = command[i]
+
+        if ch == "\\" and in_double and i + 1 < len(command):
+            current.append(ch)
+            current.append(command[i + 1])
+            i += 2
+            continue
+
+        if ch == "'" and not in_double:
+            in_single = not in_single
+            current.append(ch)
+            i += 1
+            continue
+        if ch == '"' and not in_single:
+            in_double = not in_double
+            current.append(ch)
+            i += 1
+            continue
+
+        if not in_single and not in_double:
+            match = _SEPARATOR_RE.match(command, i)
+            if match:
+                segments.append("".join(current))
+                current = []
+                i = match.end()
+                continue
+
+        current.append(ch)
+        i += 1
+
+    segments.append("".join(current))
+    return segments
+
+
+def _strip_leading_prefixes(segment: str) -> str:
+    """Drop env assignments and wrappers that precede the real command.
+
+    >>> _strip_leading_prefixes("HTTPS_PROXY=http://p curl x")
+    'curl x'
+    >>> _strip_leading_prefixes("sudo curl x")
+    'curl x'
+    >>> _strip_leading_prefixes("A=1 B=2 env curl x")
+    'curl x'
+    >>> _strip_leading_prefixes("curl x")
+    'curl x'
+    """
+    previous = None
+    while previous != segment:
+        previous = segment
+        segment = _ENV_ASSIGN_RE.sub("", segment)
+        segment = _COMMAND_PREFIX_RE.sub("", segment)
+    return segment
+
+
 def is_raw_github_fetch(command: str) -> bool:
-    """Return True if raw.githubusercontent.com and curl/wget both appear.
+    """Return True if a segment invokes curl/wget against the domain.
 
     >>> is_raw_github_fetch("curl -sL https://raw.githubusercontent.com/a/b/main/x")
     True
     >>> is_raw_github_fetch("wget https://raw.githubusercontent.com/a/b/main/x")
     True
-    >>> is_raw_github_fetch("git commit -m 'mentions raw.githubusercontent.com'")
-    False
-
-    Both words in one command are enough, whatever their positions:
-
-    >>> is_raw_github_fetch("git grep -n 'curl .*raw.githubusercontent.com'")
+    >>> is_raw_github_fetch("cat urls | curl -K - https://raw.githubusercontent.com/a")
     True
+    >>> is_raw_github_fetch("HTTPS_PROXY=http://p curl https://raw.githubusercontent.com/a")
+    True
+
+    Naming the tool and the domain without invoking one is not a fetch:
+
+    >>> is_raw_github_fetch("git commit -m 'switch from curl to gh for raw.githubusercontent.com'")
+    False
+    >>> is_raw_github_fetch("git grep -n 'curl .*raw.githubusercontent.com'")
+    False
+    >>> is_raw_github_fetch("curl -sL https://example.com | grep raw.githubusercontent.com")
+    False
     >>> is_raw_github_fetch("curl -sL https://example.com/a/b")
     False
     >>> is_raw_github_fetch("")
     False
     """
-    return bool(_DOMAIN_RE.search(command) and _FETCH_TOOL_RE.search(command))
+    for segment in _split_outside_quotes(command):
+        segment = _strip_leading_prefixes(segment.strip())
+        if _FETCH_HEAD_RE.match(segment) and _DOMAIN_RE.search(segment):
+            return True
+    return False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`block_raw_github_fetch.py` denied commands that named a fetch tool and the domain without fetching anything. It now matches an invocation. The module docstring carries the predicate; this body carries why it changed and what the review moved.

## The defect

The predicate was `_DOMAIN_RE.search(command) and _FETCH_TOOL_RE.search(command)` — two independent searches over the whole command string, with no relation between where each matched. Any command carrying both words was denied.

Three cases hit during #416 and this branch, none of them a fetch:

- `git grep -n 'curl .*raw.githubusercontent.com'`
- the commit message that documented the behavior, which named both words, so `git commit` was denied and the message had to go through a file
- the shell command that built this PR's own test payloads

#416 corrected the docstring to describe the conjunction rather than fix it, and kept the `raw.githubusercontent.com` rule clause it had nominated for removal, since this hook covers only the `gh`-unavailable case and only Bash. This PR fixes the hook.

## What the review moved

The first commit required the tool at a segment head. Two ordinary shapes escaped that, both confirmed against the hook on stdin rather than in doctests alone:

| Shape | Why it escaped |
| --- | --- |
| a multi-line `curl` split by a backslash continuation | the newline separated the tool from the domain into different segments, and neither segment had both |
| `bash -c "$(curl -fsSL <url>)"`, the installer idiom this hook exists for | the tool opened a substitution rather than standing at a head, and for `body=$(curl …)` the assignment stripper consumed the tool itself |

Wrappers outside the stripped list were raised too. `/usr/bin/curl` and `timeout N curl` are now handled — a path-qualified tool is plainly a fetch, and this repository's `CLAUDE.md` tells agents to assume `timeout` is on PATH. `sh -c '…'`, `env -i`, `sudo -u`, and `xargs` are left alone: reaching them means parsing a quoted command body, which is a shell-parser rewrite this hook does not warrant.

## Two false positives remain

- a heredoc body still matches, because its lines are split on newline and read as commands
    - this repository's README.md carries such a line, so writing it from Bash trips the guard
    - pre-existing, and mitigated because a file like that is normally written with Write or Edit, which this hook never sees
- a fetch of another host that carries the domain elsewhere in the same segment still matches

The docstring names both, so it no longer claims that every mention passes.

## Verification

- [x] `python3 -m doctest claude/hooks/block_raw_github_fetch.py` — 25 tests pass, covering the invocation shapes in both directions
- [x] Fed the hook real PreToolUse payloads on stdin: `bash -c "$(curl -fsSL <raw url>)"` and a continuation-split `curl` both emit the deny JSON, while `git grep -n 'curl .*<domain>'` emits nothing
- [x] The deny message is unchanged, so the `gh api` replacement and the "ask the user" fallback a denied command sees are the same

## Not in this PR

`_split_outside_quotes` now exists in four hooks — this one, `block_aws_logs_start_query.py`, `block_cd_chaining.py`, and `warn_scripting_oneliners.py` — each with its own doctests. Hoisting it into `hook_utils.py` would touch three hooks this change has no other reason to open, and `hook_utils.py` currently scopes itself to PermissionRequest hooks while all four of these are PreToolUse.
