### PR TITLE
Name the Read for each git-workflow supporting file at its step

### DIFF
--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -94,7 +94,6 @@ and the section 5 procedure.
    directory using the Write tool (new filename per revision — a new
    file needs no prior Read step)
    - Follow the repository's PR template if one exists
-   - Follow `pr-guidelines.md`
 1. Create the PR as a draft:
    `gh pr create --draft --body-file <body file path>`
    - Never use `--body` for PR creation. The `#`-prefixed lines in the body
@@ -231,11 +230,8 @@ per actionable change; quiet periods stay silent.
      user.
 
 1. Read [pr-reaction.md](pr-reaction.md) on the first monitor event,
-   before any reply, resolve, or push, and react under it. On a
-   `NEW_COMMENT` the `[BOT|USER]` label describes one comment, so that
-   file's thread walk governs the mutation; on `NEW_TOP_COMMENT` and
-   `NEW_REVIEW` the label is the classification of record and wins over
-   any conflicting signal.
+   before any reply, resolve, or push, and react under it — it governs
+   what the `[BOT|USER]` label settles for each event type
 
 1. `CHECK`: `gh pr checks` links the failing check. For an Actions job,
    `gh run view --log-failed <databaseId>` from `gh run list` reaches the

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -12,6 +12,19 @@ structurally absent (e.g., no PR exists yet).
 Prerequisite: the `agynio/gh-pr-review` gh extension is installed
 (used by Phase 5 review-thread reactions).
 
+## Supporting files
+
+The step that needs one of these names when to read it.
+
+- [pr-guidelines.md](pr-guidelines.md) — the properties a PR title and
+  body are judged against, and what belongs in the body versus the diff
+- [pr-reaction.md](pr-reaction.md) — bot-versus-human targeting for PR
+  events, reply-channel routing, thread resolve, and the cap on
+  autonomous fix pushes
+- [implementer-dispatch.md](implementer-dispatch.md) — branch setup,
+  brief contents, isolation, and handback bounds for the `implementer`
+  subagent
+
 ## Principles
 
 - All steps within a single workflow run are pre-authorized by the user
@@ -44,17 +57,19 @@ Prerequisite: the `agynio/gh-pr-review` gh extension is installed
 1. If the project rules explicitly prohibit worktrees, create a branch only:
    `git checkout -b <branch-name>`
 
-When the approved plan is several independent PRs, branch once per PR
-and dispatch them in parallel per `implementer-dispatch.md`, which
-decides the isolation each one needs before any of them starts.
+When the approved plan is several independent PRs, read
+[implementer-dispatch.md](implementer-dispatch.md), then branch once per
+PR and dispatch them in parallel under it — it decides the isolation
+each one needs before any of them starts.
 
 Note: `.worktrees/` is covered by the global gitignore.
 
 ## 2. Implement, commit, push
 
 The implementation work for this branch happens here. When it is
-delegated to the `implementer` subagent, follow
-`implementer-dispatch.md`.
+delegated to the `implementer` subagent, read
+[implementer-dispatch.md](implementer-dispatch.md) before writing the
+brief, and follow it for the rest of the dispatch.
 
 When the commit message or PR body will claim an exhaustive
 replacement or update ("replaced all X with Y"), run
@@ -63,6 +78,9 @@ remaining matches — `replace_all` misses occurrences that differ in
 formatting or indentation.
 
 ## 3. Create a PR
+
+Read [pr-guidelines.md](pr-guidelines.md) before writing or editing a
+title or body anywhere in this step.
 
 1. If the branch already has a PR (`gh pr view --json number,url`),
    skip creation. Bring its title and body into conformance with
@@ -210,10 +228,10 @@ per actionable change; quiet periods stay silent.
    - Skip the push if either check fails; surface the conflict to the
      user.
 
-1. React per `pr-reaction.md` (bot check, reply-channel routing,
-   thread resolve, cap for autonomous fix pushes). A `[BOT|USER]` label
-   on an event line is a routing hint; the rule's thread walk still
-   governs mutations.
+1. Read [pr-reaction.md](pr-reaction.md) on the first event of the run,
+   before any reply, resolve, or push, and react under it. A
+   `[BOT|USER]` label on an event line is a routing hint; that file's
+   thread walk still governs mutations.
 
 1. `CHECK`: `gh pr checks` links the failing check. For an Actions job,
    `gh run view --log-failed <databaseId>` from `gh run list` reaches the

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -47,6 +47,11 @@ Prerequisite: the `agynio/gh-pr-review` gh extension is installed
 
 ## 1. Start Work
 
+When the approved plan is several independent PRs, read
+[implementer-dispatch.md](implementer-dispatch.md) before the steps
+below — it decides whether they run in parallel or sequentially, and the
+isolation each one needs.
+
 1. From the main clone, not a worktree, switch to the default branch and
    pull: `git home`
 1. Create a worktree and branch (defaults to branching from origin's default branch):
@@ -56,11 +61,6 @@ Prerequisite: the `agynio/gh-pr-review` gh extension is installed
 1. Follow the command shown in the script output to move into the worktree
 1. If the project rules explicitly prohibit worktrees, create a branch only:
    `git checkout -b <branch-name>`
-
-When the approved plan is several independent PRs, read
-[implementer-dispatch.md](implementer-dispatch.md) before branching — it
-decides whether they run in parallel or sequentially, and the isolation
-each one needs.
 
 Note: `.worktrees/` is covered by the global gitignore.
 

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -89,7 +89,7 @@ and the section 5 procedure.
    proceed to CI wait (step 4).
    - For a PR the implementer opened, read
      [implementer-dispatch.md](implementer-dispatch.md) and apply its
-     When it returns steps before that conformance pass
+     `When it returns` steps before that conformance pass
 1. Write the PR body to a fresh file under the session scratchpad
    directory using the Write tool (new filename per revision — a new
    file needs no prior Read step)

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -14,15 +14,15 @@ Prerequisite: the `agynio/gh-pr-review` gh extension is installed
 
 ## Supporting files
 
-The step that needs one of these names when to read it.
-
 - [pr-guidelines.md](pr-guidelines.md) — the properties a PR title and
   body are judged against, and what belongs in the body versus the diff
 - [pr-reaction.md](pr-reaction.md) — bot-versus-human targeting for PR
-  events, reply-channel routing, thread resolve, and the cap on
-  autonomous fix pushes
+  events, whether an event is answered by a reply or a fix push, which
+  channel a reply goes to, thread resolve, and the cap on autonomous
+  fix pushes
 - [implementer-dispatch.md](implementer-dispatch.md) — branch setup,
-  brief contents, isolation, and handback bounds for the `implementer`
+  brief contents, what a dispatch does by default, what to do when it
+  returns, isolation, and handback bounds for the `implementer`
   subagent
 
 ## Principles
@@ -58,9 +58,9 @@ The step that needs one of these names when to read it.
    `git checkout -b <branch-name>`
 
 When the approved plan is several independent PRs, read
-[implementer-dispatch.md](implementer-dispatch.md), then branch once per
-PR and dispatch them in parallel under it — it decides the isolation
-each one needs before any of them starts.
+[implementer-dispatch.md](implementer-dispatch.md) before branching — it
+decides whether they run in parallel or sequentially, and the isolation
+each one needs.
 
 Note: `.worktrees/` is covered by the global gitignore.
 
@@ -69,7 +69,7 @@ Note: `.worktrees/` is covered by the global gitignore.
 The implementation work for this branch happens here. When it is
 delegated to the `implementer` subagent, read
 [implementer-dispatch.md](implementer-dispatch.md) before writing the
-brief, and follow it for the rest of the dispatch.
+brief, and follow it through the Phase 1 handback bound.
 
 When the commit message or PR body will claim an exhaustive
 replacement or update ("replaced all X with Y"), run
@@ -79,14 +79,16 @@ formatting or indentation.
 
 ## 3. Create a PR
 
-Read [pr-guidelines.md](pr-guidelines.md) before writing or editing a
-title or body anywhere in this step.
+Read [pr-guidelines.md](pr-guidelines.md) before writing or editing a PR
+title or body anywhere in this workflow, including the Phase 4 updates
+and the section 5 procedure.
 
 1. If the branch already has a PR (`gh pr view --json number,url`),
    skip creation. Bring its title and body into conformance with
    `pr-guidelines.md` using the section 5 procedure, display the PR URL to the user, then
    proceed to CI wait (step 4).
-   - For a PR the implementer opened, apply `implementer-dispatch.md`'s
+   - For a PR the implementer opened, read
+     [implementer-dispatch.md](implementer-dispatch.md) and apply its
      When it returns steps before that conformance pass
 1. Write the PR body to a fresh file under the session scratchpad
    directory using the Write tool (new filename per revision — a new
@@ -228,10 +230,12 @@ per actionable change; quiet periods stay silent.
    - Skip the push if either check fails; surface the conflict to the
      user.
 
-1. Read [pr-reaction.md](pr-reaction.md) on the first event of the run,
-   before any reply, resolve, or push, and react under it. A
-   `[BOT|USER]` label on an event line is a routing hint; that file's
-   thread walk still governs mutations.
+1. Read [pr-reaction.md](pr-reaction.md) on the first monitor event,
+   before any reply, resolve, or push, and react under it. On a
+   `NEW_COMMENT` the `[BOT|USER]` label describes one comment, so that
+   file's thread walk governs the mutation; on `NEW_TOP_COMMENT` and
+   `NEW_REVIEW` the label is the classification of record and wins over
+   any conflicting signal.
 
 1. `CHECK`: `gh pr checks` links the failing check. For an Actions job,
    `gh run view --log-failed <databaseId>` from `gh run list` reaches the


### PR DESCRIPTION
## Purpose

A skill directory's supporting files reach context only when the agent reads them, so a reference that names a file without asking for it can be walked past. `git-workflow` reached Phase 5 with `pr-reaction.md` named at the reaction step and never opened, and the reaction ran without the targeting policy that file holds.

## Key changes

- Each supporting file is read on an imperative at the site that needs it, scoped to the work it governs rather than to the step the pointer sits in, so a body written in Phase 4 and an implementer PR picked up by a run that dispatched no implementer both still pass through the file that governs them
- A pointer names what its file decides and stops there: the multi-PR line no longer presupposes parallel dispatch, which `implementer-dispatch.md` grants only to projects allowing worktrees, and the Phase 5 line defers the `[BOT|USER]` label's meaning to `pr-reaction.md` instead of carrying a second copy of the per-event-type rule
- The list of the three files and the relative links throughout follow the form the Claude Code docs prescribe for a skill directory, which also resolves identically through the repository path and the `~/.claude/skills` symlink

## Notes

`claude/skills/pr-selfcheck/SKILL.md:43` reaches `pr-guidelines.md` across a skill boundary and names it as bundled with the `git-workflow` skill, a form no relative link can express.

A structural review of the skill surfaced redundancies and section-ordering problems that predate this change — a duplicated `gh pr-review review view` invocation across the SKILL.md/`pr-reaction.md` boundary, the workflow-wide "armed event source" invariant nested under Phase 3, and the section 5 subroutine numbered as if it were a sequential step. Those are a separate concern from pointer form and are left to their own change.

## Verification

- [x] The navigation form matches its source: [Add supporting files](https://code.claude.com/docs/en/skills#add-supporting-files) reads "Reference supporting files from `SKILL.md` so Claude knows what each file contains and when to load it", and gives the relative-link example this section follows
- [x] Relative links resolve through the deploy path: `ls -l ~/.claude/skills/git-workflow/pr-reaction.md ...` lists all three files, because `scripts/deploy.sh:78` symlinks whole skill directories (`find "$DOTPATH/claude/skills" -maxdepth 1 -mindepth 1 -type d -exec ln -fvns {} "$HOME/.claude/skills/" \;`) rather than individual files
- [x] The runtime base directory a relative link resolves against is the deploy path: invoking a skill in this session injected `Base directory for this skill: /Users/ikuwow/.claude/skills/git-workflow`
- [x] Deferring the label's meaning loses no gate: `pr-reaction.md:15-17` and `:44-45` settle it per event type, and `:101` keeps "Skipping the bot check before any mutation" a forbidden shortcut, which the pointer's "before any reply, resolve, or push" preserves
- [x] The multi-PR line matches its source: `implementer-dispatch.md:77-79` requires one worktree per parallel implementer, and `:83-84` sends worktree-prohibiting projects down a sequential path, so parallel dispatch is that file's call and not a precondition this file can state
- [x] No existing instruction covers when to read a skill's supporting files: `grep -Rn "supporting file\|Supporting file\|skill.*Read\|SKILL.md" ~/.claude/rules/ AIRULES.md CLAUDE.md` returns no matches
- [x] Checked against `claude/skills/rule-edit/criteria.md` and the `AIRULES.md` output-format rules by a subagent given the criteria and the full `origin/main...HEAD` diff but not the editing intent: no non-compliance found in the lines the diff touches
