### PR TITLE
Give each workflow rule one site and number sections by execution order

### DIFF
--- a/claude/rules/git-essentials.md
+++ b/claude/rules/git-essentials.md
@@ -23,7 +23,7 @@ NOT restate the detailed procedures from the skill.
 - Step 2: implement, commit, push
 - Step 3: create a draft PR (`gh pr create --draft --body-file`)
 - Step 4: CI wait and review (Phases 1-5)
-- Step 6: cleanup after merge (`git cleanup`)
+- Step 5: cleanup after merge (`git cleanup`)
 
 ## Commit
 

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -30,7 +30,7 @@ Prerequisite: the `agynio/gh-pr-review` gh extension is installed
   who initiated the task. Do not pause between steps to ask for
   confirmation unless blocked by an error or ambiguity. Execute the
   full flow continuously and report results at the end.
-- Phase 2 code review and Phase 5 Monitor arming fall under that
+- Phase 2 code review and Phase 4 Monitor arming fall under that
   pre-authorization. The only user decision point in the flow is
   flipping the PR from draft to ready for review.
 - Signals like a small diff or personal-project scope affect how you
@@ -43,9 +43,11 @@ Prerequisite: the `agynio/gh-pr-review` gh extension is installed
   worktree (or feature branch) first. Creating files before branching
   leads to redundant copy-and-delete work.
 - Never modify commits that have already been pushed
-- Stop autonomous fix pushes after 3 fix commits for this PR in this
-  session, counting the fixes made in every phase. Switch to reply-only
-  and notify the user.
+- Stop autonomous fix pushes after 3 for this PR in this session,
+  counting the pushes made in every phase, since past that the fixes
+  are no longer converging on their own. Surface the state and wait for
+  a user instruction — in Phase 5 that means answering further events
+  with replies and no push.
 - Never end a turn that claims ongoing waiting (delegated fix push,
   CI run, CI rerun, external state change) without an armed event
   source — a Monitor on the branch head, or
@@ -202,7 +204,8 @@ edits.
 ### Phase 5: Watch PR activity until merge
 
 The Monitor armed in Phase 4 polls every 60s and emits one stdout line
-per actionable change; quiet periods stay silent.
+per actionable change; quiet periods stay silent. Arm it here when the
+run entered the workflow at this phase.
 
 1. Each event line is `<EVENT>` or `<EVENT>: <details>`, carrying
    GitHub's own field values. The steps below cover the events with a

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -18,8 +18,7 @@ Prerequisite: the `agynio/gh-pr-review` gh extension is installed
   body are judged against, and what belongs in the body versus the diff
 - [pr-reaction.md](pr-reaction.md) — bot-versus-human targeting for PR
   events, whether an event is answered by a reply or a fix push, which
-  channel a reply goes to, thread resolve, and the cap on autonomous
-  fix pushes
+  channel a reply goes to, and thread resolve
 - [implementer-dispatch.md](implementer-dispatch.md) — branch setup,
   brief contents, what a dispatch does by default, what to do when it
   returns, isolation, and handback bounds for the `implementer`
@@ -31,9 +30,9 @@ Prerequisite: the `agynio/gh-pr-review` gh extension is installed
   who initiated the task. Do not pause between steps to ask for
   confirmation unless blocked by an error or ambiguity. Execute the
   full flow continuously and report results at the end.
-- Phase 2 code review and Phase 5 Monitor arming are pre-authorized —
-  run them without pausing for confirmation. The only user decision
-  point in the flow is flipping the PR from draft to ready for review.
+- Phase 2 code review and Phase 5 Monitor arming fall under that
+  pre-authorization. The only user decision point in the flow is
+  flipping the PR from draft to ready for review.
 - Signals like a small diff or personal-project scope affect how you
   weigh findings within a phase, never whether to run it. The only
   override to the pre-authorization above is an explicit user
@@ -44,6 +43,16 @@ Prerequisite: the `agynio/gh-pr-review` gh extension is installed
   worktree (or feature branch) first. Creating files before branching
   leads to redundant copy-and-delete work.
 - Never modify commits that have already been pushed
+- Stop autonomous fix pushes after 3 fix commits for this PR in this
+  session, counting the fixes made in every phase. Switch to reply-only
+  and notify the user.
+- Never end a turn that claims ongoing waiting (delegated fix push,
+  CI run, CI rerun, external state change) without an armed event
+  source — a Monitor on the branch head, or
+  `gh pr checks --watch --fail-fast` with `run_in_background: true`.
+  After every `gh run rerun` or other re-kick, re-arm the watch before
+  yielding. State what is being awaited in the final message before
+  going idle.
 
 ## 1. Start Work
 
@@ -81,29 +90,28 @@ formatting or indentation.
 
 Read [pr-guidelines.md](pr-guidelines.md) before writing or editing a PR
 title or body anywhere in this workflow, including the Phase 4 updates
-and the section 5 procedure.
+and the Update a PR / issue procedure.
 
 1. If the branch already has a PR (`gh pr view --json number,url`),
    skip creation. Bring its title and body into conformance with
-   `pr-guidelines.md` using the section 5 procedure, display the PR URL to the user, then
-   proceed to CI wait (step 4).
+   `pr-guidelines.md` using the Update a PR / issue procedure,
+   display the PR URL to the user, then proceed to step 4.
    - For a PR the implementer opened, read
      [implementer-dispatch.md](implementer-dispatch.md) and apply its
      `When it returns` steps before that conformance pass
 1. Write the PR body to a fresh file under the session scratchpad
-   directory using the Write tool (new filename per revision — a new
-   file needs no prior Read step)
+   directory using the Write tool (new filename per revision — no
+   temp-file generation, no Read of an empty file)
    - Follow the repository's PR template if one exists
 1. Create the PR as a draft:
    `gh pr create --draft --body-file <body file path>`
-   - Never use `--body` for PR creation. The `#`-prefixed lines in the body
-     trigger Claude Code's security pre-check, which cannot be bypassed by
-     hooks. Always go through `--body-file`.
+   - Never use `--body` for PR creation, for the reason the Update a PR
+     / issue section gives
 1. After creating the PR, display the PR URL to the user:
    `gh pr view --json url --jq '.url'`
-1. Proceed to CI wait (step 4)
+1. Proceed to step 4
 
-## 4. CI Wait & Review
+## 4. Checks, review, and merge
 
 Five phases: pass all mechanical checks, run the code review,
 consolidate fixes, finalize the PR for review readiness, then watch
@@ -135,10 +143,6 @@ regardless of whether the three checks passed, then re-run all three
 until all pass. After any push, and after a watch exits with checks still
 pending, re-arm `gh pr checks --watch --fail-fast`.
 
-Note: `/pr-selfcheck` and the narrative sweep are mechanical checks, not
-a code review. Re-running them after fixes is expected. The
-"single-pass" policy applies only to the code review in Phase 2.
-
 ### Phase 2: Code review
 
 Once Phase 1 passes, launch:
@@ -165,17 +169,9 @@ The code review is single-pass — do not re-run after fixes.
 `/pr-selfcheck` and the narrative sweep run again in Phase 3 to catch
 inconsistencies introduced by review fix changes.
 
-Never end a turn that claims ongoing waiting (delegated fix push,
-CI run, CI rerun, external state change) without an armed event
-source — a Monitor on the branch head, or
-`gh pr checks --watch --fail-fast` with `run_in_background: true`. After
-every `gh run rerun` or other re-kick, re-arm the watch before yielding.
-State what is being awaited in the final message before going idle.
-
 ### Phase 4: Finalize PR for review readiness
 
-Bring the PR into a state where a human reviewer can act on it. This
-covers three things:
+Bring the PR into a state where a human reviewer can act on it:
 
 1. Reflect actual verification in the PR body. Update the body to
    describe what was confirmed, with evidence (HTTP status, Location
@@ -190,21 +186,22 @@ covers three things:
 1. Surface Phase 4 completion so the user can decide whether to mark
    the PR ready for review. `gh pr ready` is the user's call — do
    not run it unless explicitly instructed.
+1. Arm the persistent `Monitor` running `pr-monitor <PR number>` in
+   that same turn, before handing control back to the user and before
+   they flip the PR to ready. `READY_FOR_REVIEW` is itself a monitored
+   event, so an arm deferred until after the ready flip can never
+   observe it.
 
 Update incrementally as conditions are confirmed (e.g., after Phase 1
 CI passes, after apply / deploy succeeds, after post-deploy
 verification with `curl`, `aws logs tail`, etc.).
 
-Use the section 5 procedure (`gh pr edit --body-file`) for body
+Use the Update a PR / issue procedure (`gh pr edit --body-file`) for body
 edits.
 
 ### Phase 5: Watch PR activity until merge
 
-Arm the persistent `Monitor` running `pr-monitor <PR number>` in the
-same turn you surface Phase 4 completion — before handing control back
-to the user and before they flip the PR to ready. `READY_FOR_REVIEW`
-is itself a monitored event, so an arm deferred until after the ready
-flip can never observe it. It polls every 60s and emits one stdout line
+The Monitor armed in Phase 4 polls every 60s and emits one stdout line
 per actionable change; quiet periods stay silent.
 
 1. Each event line is `<EVENT>` or `<EVENT>: <details>`, carrying
@@ -214,11 +211,9 @@ per actionable change; quiet periods stay silent.
 
 1. Re-fetch detail on each event with:
    - `gh pr view <number> --json state,isDraft,reviewDecision,latestReviews,statusCheckRollup,comments,updatedAt,mergedAt,headRefName`
-   - `gh pr-review review view -R <owner>/<repo> <number>` — add
-     `--unresolved --not_outdated` for full-PR sweeps; drop them when
-     inspecting a specific `NEW_COMMENT` that may have been resolved
-     in the interim.
    - `gh run list --branch <headRefName> --json databaseId,name,status,conclusion,createdAt,headSha,workflowName --limit 20`
+   - review threads: the listing in `pr-reaction.md`'s Step 1, which
+     carries the flags each use needs
 
    The notification is not a user reply — keep working.
 
@@ -239,7 +234,7 @@ per actionable change; quiet periods stay silent.
    not have. Fix and push under the same pre-push checks.
 
 1. Exit conditions:
-   - `STATE: MERGED` → execute Step 6 (Cleanup).
+   - `STATE: MERGED` → execute step 5 (Cleanup).
    - `STATE: CLOSED` without merge → skip cleanup.
    - Session ends → Monitor terminates with the session (best-effort).
 
@@ -253,7 +248,7 @@ per actionable change; quiet periods stay silent.
 next (merge, or "needs human attention" after the fix cap). Skip
 routine CI / comment events.
 
-## 5. Update a PR / issue (title / body)
+## Update a PR / issue (title / body)
 
 - Update title:
   `gh pr edit <number> --title '...'`
@@ -275,7 +270,7 @@ Note: Always use `--body-file` for any body update. The `#`-prefixed lines
 in PR/issue bodies trigger Claude Code's security pre-check when passed
 via `--body`, which cannot be bypassed by hooks.
 
-## 6. Cleanup After Task Completion
+## 5. Cleanup After Task Completion
 
 After the PR is merged (or the task is fully done):
 

--- a/claude/skills/git-workflow/pr-reaction.md
+++ b/claude/skills/git-workflow/pr-reaction.md
@@ -55,7 +55,8 @@ kind, `NEW_COMMENT` is pre-filtered to unresolved / non-outdated).
 
 - Clear fix request (`CHANGES_REQUESTED`, or a `NEW_COMMENT` /
   `NEW_TOP_COMMENT` / `NEW_REVIEW` asking for a change): modify code
-  and push, subject to Phase 5's pre-push checks and the Step 5 cap.
+  and push, subject to Phase 5's pre-push checks and the fix-push cap
+  in the git-workflow skill's Principles.
   For a `NEW_COMMENT` whose thread is now `is_resolved` / `is_outdated`
   on re-fetch, skip it. For a `NEW_REVIEW`, re-fetch the body first.
 - Question / nit / ambiguous intent — reply, do not push. Bot author
@@ -94,12 +95,6 @@ top-level) and stop.
 
 If the user explicitly asks to reply, draft the text, wait for
 approval, then run the command. Resolution stays with the user.
-
-## Step 5: Cap for autonomous fix pushes
-
-Fix pushes made here count against the session-wide cap in the
-git-workflow skill's Principles, alongside the fixes its other phases
-push.
 
 ## Forbidden shortcuts
 

--- a/claude/skills/git-workflow/pr-reaction.md
+++ b/claude/skills/git-workflow/pr-reaction.md
@@ -30,6 +30,10 @@ gh pr-review review view -R <owner>/<repo> <number> \
   --unresolved --not_outdated --include-comment-node-id
 ```
 
+Drop `--unresolved --not_outdated` when inspecting one `NEW_COMMENT`,
+since a thread resolved or outdated in the interim is filtered out by
+them and Step 2 needs to see that state to skip the event.
+
 `gh api` is required here: the `gh pr-review` extension does not
 expose `user.type` on review comments (no equivalent flag), and no
 high-level `gh pr` subcommand returns per-line review comments.
@@ -93,8 +97,9 @@ approval, then run the command. Resolution stays with the user.
 
 ## Step 5: Cap for autonomous fix pushes
 
-Stop autonomous fix pushes after 3 fix commits for this PR in this
-session. Switch to reply-only and notify the user.
+Fix pushes made here count against the session-wide cap in the
+git-workflow skill's Principles, alongside the fixes its other phases
+push.
 
 ## Forbidden shortcuts
 


### PR DESCRIPTION
## Purpose

A structural review of the `git-workflow` skill found rules stated at two sites, a rule stated where the phase that must obey it cannot see it, and a section numbered as a stage when it is a called procedure. Each lets a reader act on a stale or absent copy.

## Key changes

- A rule that holds across phases now lives in Principles rather than inside one phase: the autonomous fix-push cap, which every phase spends against, and the armed-event-source requirement, which a Phase 1 background watch needs as much as Phase 5 does
- The fix-push cap counts pushes rather than commits, so a phase that pushes a round of sweep, self-review and CI fixes together spends one against it, and its remedy is stated for a caller with no thread to reply to
- Instructions sit in the phase whose turn executes them, so the Monitor arm is an item of Phase 4, the turn it must share, and Phase 5 arms it only for a run that entered the workflow there
- Where `SKILL.md` and a supporting file both carried a command or rule, the supporting file keeps it: the review-thread listing goes to `pr-reaction.md`, which owns thread handling and needs the comment node id for its author-type join
- Numbered sections carry only stages the reader passes through in order, so Update a PR / issue is named rather than numbered, Cleanup takes the freed number, and the section holding Phases 1-5 is named for the merge it now runs to rather than for the CI wait that is one of its phases

## Correspondence

Every line this change removes, and where its content now lives.

| Removed from | Content | Now at |
| --- | --- | --- |
| `SKILL.md` Phase 3 tail | armed event source before ending a waiting turn | Principles |
| `pr-reaction.md` Step 5 | the fix-push cap, and the section holding it | Principles, widened to every phase and recounted in pushes |
| `SKILL.md` Phase 5 opening | Monitor arm and its `READY_FOR_REVIEW` rationale | Phase 4, as its last item |
| `SKILL.md` Phase 5 re-fetch list | `gh pr-review review view` and its flag guidance | `pr-reaction.md` Step 1 |
| `SKILL.md` Phase 1 tail | the single-pass policy note | already stated at Phase 3's tail |
| `SKILL.md` step 3 | the `--body-file` security-pre-check rationale | already stated in Update a PR / issue |
| Principles bullet 2 | "run them without pausing for confirmation" | already stated in bullet 1 |
| `SKILL.md` Phase 4 lead-in | "This covers three things" | dropped, the list having gained a fourth |
| `SKILL.md` step 3 | "a new file needs no prior Read step" | replaced by the wording Update a PR / issue already gave the same convention |

## Notes

`claude/rules/git-essentials.md` names the cleanup step by number, so its checklist moves from Step 6 to Step 5 with the renumbering. Its other steps already matched.

The two body-file writing sites gave different parenthetical reasons for one convention; step 3 now carries the same reason as the procedure it parallels.

The fix cap's scope was not derivable from either file. It is settled here as every phase, counted in pushes so the per-round pushes of Phases 1 and 3 each spend one rather than three.

## Verification

- [x] No cross-reference outlives the renumbering or the removed section: `grep -rn "Step 5\|step 5\|section 5\|Step 6\|step 6\|fix cap\|fix-push cap" claude/skills/git-workflow/ claude/rules/git-essentials.md bin/pr-monitor` returns four lines — `execute step 5 (Cleanup)`, `after the fix cap`, `pr-reaction.md`'s pointer to the Principles cap, and git-essentials' `Step 5` entry — each naming a target that exists
- [x] Counting in pushes clears the collision the commit count created: `SKILL.md` Phase 1 reads "push them together with any self-review and CI fixes in one push … then re-run all three until all pass", so a round costs one against the cap where three commits would have spent it outright
- [x] The flag guidance moved to a site that needs it: `pr-reaction.md` Step 2 reads "For a `NEW_COMMENT` whose thread is now `is_resolved` / `is_outdated` on re-fetch, skip it", which the dropped `--unresolved --not_outdated` filters make visible
- [x] The listing moved to the site holding the join it feeds: `pr-reaction.md:26` reads "Run both, join on `comment_node_id` (extension) == `node_id` (REST)", and only its copy passes `--include-comment-node-id`
- [x] Every reader of the relocated cap still reaches it: `pr-reaction.md` is read only from `SKILL.md`, so Principles is loaded before it in every path, and `pr-reaction.md` Step 2 names the cap directly rather than through a section of its own
