### PR TITLE
Give each shared writing decision one owner and invoke the skill from the write paths

### DIFF
--- a/claude/rules/software-development.md
+++ b/claude/rules/software-development.md
@@ -31,8 +31,7 @@
 1. 編集 / 簡素化 / 整理タスクで、依頼されたスコープに含まれない既存の行・コメント・順序・命名・wordingは基本的に触らない
     - 明らかなtypo修正等で「ついで」が許容される場面もあるが、原則は別PRで提案する
 1. リポジトリへ永続化する出力（コミットメッセージ・PR本文・コード内コメント・docs等）の言語は、OSSはデフォルト英語、それ以外はプロジェクトのルール（`CLAUDE.md` / `AGENTS.md` 等）と既存資産（PR / commit history / docs）の言語に合わせる
-1. 1文を超える散文を永続化する前に `Skill(technical-writing)` を起動する（design doc、ADR、README、issue本文、issue / PRコメント、レビュー返信、commit messageの本文等）
-    - PR本文はgit-workflowの手順が起動するため対象外
+1. 1文を超える散文を永続化する前に `Skill(technical-writing)` を起動する
 
 ## ツール選択
 

--- a/claude/rules/software-development.md
+++ b/claude/rules/software-development.md
@@ -31,6 +31,8 @@
 1. 編集 / 簡素化 / 整理タスクで、依頼されたスコープに含まれない既存の行・コメント・順序・命名・wordingは基本的に触らない
     - 明らかなtypo修正等で「ついで」が許容される場面もあるが、原則は別PRで提案する
 1. リポジトリへ永続化する出力（コミットメッセージ・PR本文・コード内コメント・docs等）の言語は、OSSはデフォルト英語、それ以外はプロジェクトのルール（`CLAUDE.md` / `AGENTS.md` 等）と既存資産（PR / commit history / docs）の言語に合わせる
+1. design doc・ADR・README・issue本文など、1文を超える散文を書く前に `Skill(technical-writing)` を起動する
+    - PR本文はgit-workflowの手順が起動するため対象外
 
 ## ツール選択
 

--- a/claude/rules/software-development.md
+++ b/claude/rules/software-development.md
@@ -31,7 +31,7 @@
 1. 編集 / 簡素化 / 整理タスクで、依頼されたスコープに含まれない既存の行・コメント・順序・命名・wordingは基本的に触らない
     - 明らかなtypo修正等で「ついで」が許容される場面もあるが、原則は別PRで提案する
 1. リポジトリへ永続化する出力（コミットメッセージ・PR本文・コード内コメント・docs等）の言語は、OSSはデフォルト英語、それ以外はプロジェクトのルール（`CLAUDE.md` / `AGENTS.md` 等）と既存資産（PR / commit history / docs）の言語に合わせる
-1. design doc・ADR・README・issue本文など、1文を超える散文を書く前に `Skill(technical-writing)` を起動する
+1. 1文を超える散文を永続化する前に `Skill(technical-writing)` を起動する（design doc、ADR、README、issue本文、issue / PRコメント、レビュー返信、commit messageの本文等）
     - PR本文はgit-workflowの手順が起動するため対象外
 
 ## ツール選択

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -255,6 +255,10 @@ routine CI / comment events.
 
 ## Update a PR / issue (title / body)
 
+Read [pr-guidelines.md](pr-guidelines.md) and invoke the
+`technical-writing` skill before the steps below, which reach this
+section directly from `git-essentials.md` without passing section 3.
+
 - Update title:
   `gh pr edit <number> --title '...'`
 - Update body (always use `--body-file`, never `--body`):

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -256,8 +256,8 @@ routine CI / comment events.
 ## Update a PR / issue (title / body)
 
 Read [pr-guidelines.md](pr-guidelines.md) and invoke the
-`technical-writing` skill before the steps below, which reach this
-section directly from `git-essentials.md` without passing section 3.
+`technical-writing` skill before the steps below. `git-essentials.md`
+routes a body edit here directly, without passing section 3.
 
 - Update title:
   `gh pr edit <number> --title '...'`

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -90,9 +90,11 @@ formatting or indentation.
 
 ## 3. Create a PR
 
-Read [pr-guidelines.md](pr-guidelines.md) before writing or editing a PR
-title or body anywhere in this workflow, including the Phase 4 updates
-and the Update a PR / issue procedure.
+Read [pr-guidelines.md](pr-guidelines.md) and invoke the
+`technical-writing` skill before writing or editing a PR title or body
+anywhere in this workflow, including the Phase 4 updates and the Update
+a PR / issue procedure. The guidelines decide what the body carries, the
+skill decides how its prose is built.
 
 1. If the branch already has a PR (`gh pr view --json number,url`),
    skip creation. Bring its title and body into conformance with

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -3,7 +3,9 @@
 Quality criteria for pull requests. Follow these when writing a PR body
 and when self-reviewing your own PR.
 
-Invoke the `technical-writing` skill alongside this file.
+Before writing a PR body or judging one against the properties below,
+invoke the `technical-writing` skill. These properties decide what the
+body carries, and that skill decides how its prose is built.
 
 A PR body is a summary that helps a reviewer decide, not a complete
 record of the change: everything else lives in the diff, the issue, or

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -3,6 +3,9 @@
 Quality criteria for pull requests. Follow these when writing a PR body
 and when self-reviewing your own PR.
 
+These decide what the body carries. The `technical-writing` skill
+decides how its prose is built, and is invoked alongside this file.
+
 A PR body is a summary that helps a reviewer decide, not a complete
 record of the change: everything else lives in the diff, the issue, or
 a linked source. It serves two audiences — the reviewer deciding now,
@@ -73,10 +76,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - A structure a reader could reconstruct from the diff's file list or
     hunk boundaries alone tells the reviewer nothing about where their
     attention belongs
-- In a bulleted section, the top level carries the change or claim
-  itself, so the section reads from its top-level lines alone
-  - Supporting material — rationale, evidence, the behavior this change
-    replaces, and the like — does not displace it from the top level
+- In a bulleted section, the top level carries the change itself, and
+  rationale, evidence, and the behavior this change replaces do not
+  displace it from there
 - When one top-level item supports, qualifies, or follows from another,
   it belongs beneath that one rather than beside it, in whichever
   section that one sits, unless another rule here places it in a
@@ -84,12 +86,11 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - A long flat list is usually diff paraphrase; where it survives
     Necessary, it is usually a hierarchy that was never encoded
   - A section this empties loses its heading with it
-- Each item carries one claim at the shortest length that lands it
-  - A list item carrying two or more sentences is a finding: the second
-    becomes a sub-bullet under the first, or it was not needed, and an
-    item taking three sentences to land is usually two items
-    - Evidence the item quotes, and a verification item's evidence, are
-      exempt, since Grounded requires the item to carry them
+- Each item carries one claim at the shortest length that lands it, and
+  an item taking three sentences to land is usually two items
+  - Evidence the item quotes, and a verification item's evidence, are
+    exempt from the one-sentence-per-item rule in `AIRULES.md`'s
+    出力フォーマット, since Grounded requires the item to carry them
   - A paragraph enumerating three or more parallel items of the same
     kind — reasons, rejected alternatives, caveats, options — is a
     finding, and the items belong in a list, one per line
@@ -98,13 +99,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   the end of the body (e.g., in a "Follow-up" / "Notes" section)
   - Do not surface them in the opening sections (purpose, scope,
     summary), where they compete with the approve/reject decision
-- Tables must stand alone
-  - Give each table a caption or a one-line lead-in that tells the
-    reader what it shows (e.g., "Alert firings in the past 7 days")
-  - A reader who skips the surrounding prose still understands what the
-    table represents
-  - Avoid placing tables mid-sentence where their meaning depends on
-    parsing the prose around them
+- Keep a table out of the middle of a sentence, where its meaning
+  depends on parsing the prose around it
 
 ## Grounded
 
@@ -135,14 +131,10 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - The shown query covers the whole claim — a regex anchored to line
     start or end, a single literal where the claim covers a family of
     spellings, or a path filter narrower than the claim does not
-- Provide official documentation URLs or other authoritative sources
-  that justify configuration values, tool choices, or version
-  selections
-  - Especially important for dotfiles / infrastructure changes where
-    "why this value" matters
-- A claim about the behavior of a tool, service, or platform this diff
-  does not modify carries a link to or citation of a primary source (a
-  man page section or `--help` output counts)
+- A claim about a tool, service, or platform this diff does not modify,
+  and the configuration values, tool choices, and version selections the
+  diff introduces, carry their source in the body itself
+  (`AIRULES.md`'s 事実と確信度の管理 defines what counts as a primary source)
 - A causal claim asserting a mechanism a reader cannot check from the
   diff ("because X locks the table") carries evidence or a source
 - Naming an external tool or service in a step the reader is meant to
@@ -156,7 +148,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     change are outside this rule
 - Rationale attributed to a linked issue, PR, or document quotes the
   one sentence it rests on, or links to the section carrying it
-- All URLs and anchor links resolve to the expected content
+- Each URL and anchor link reaches the content the body cites it for
 - The title accurately reflects the change, and the body does not
   contradict the diff
 
@@ -209,13 +201,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - Focus on what changes from the user's or system's perspective —
   behavior changes, new capabilities, removed limitations — rather than
   on implementation details (resources added, files touched)
-- The body records the delivered design, not the path to it
-  - Keep out chronological narration of implementation attempts ("first
-    tried X, it failed, so Y") and records of direction changes made
-    mid-implementation
-  - Keep out references to the session, to plan-mode phases, to
-    individual commits within the branch, or to the review that raised
-    a point ("raised in review", "per feedback")
+- The body records the delivered design, not the path to it, under
+  `AIRULES.md`'s 出力フォーマット reader criterion
   - Keep out rejected alternatives described at implementation-attempt
     granularity, and alternatives a reviewer would not arrive at and
     ask about

--- a/claude/skills/git-workflow/pr-guidelines.md
+++ b/claude/skills/git-workflow/pr-guidelines.md
@@ -3,8 +3,7 @@
 Quality criteria for pull requests. Follow these when writing a PR body
 and when self-reviewing your own PR.
 
-These decide what the body carries. The `technical-writing` skill
-decides how its prose is built, and is invoked alongside this file.
+Invoke the `technical-writing` skill alongside this file.
 
 A PR body is a summary that helps a reviewer decide, not a complete
 record of the change: everything else lives in the diff, the issue, or
@@ -79,10 +78,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - In a bulleted section, the top level carries the change itself, and
   rationale, evidence, and the behavior this change replaces do not
   displace it from there
-- When one top-level item supports, qualifies, or follows from another,
-  it belongs beneath that one rather than beside it, in whichever
-  section that one sits, unless another rule here places it in a
-  section of its own
+  - A nested item stays in whichever section its parent sits, unless
+    another rule here places it in a section of its own
   - A long flat list is usually diff paraphrase; where it survives
     Necessary, it is usually a hierarchy that was never encoded
   - A section this empties loses its heading with it
@@ -164,7 +161,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - A heading is a line the walk takes, and answers for its own text
     rather than for the lines beneath it
   - A table row is a line of the walk, read with the caption or lead-in
-    that says what the table shows
+    that the `technical-writing` skill asks every table to carry
   - A diagram or a code block is a line of the walk, answered whole for
     what it depicts. One that traces the control flow, structure, or
     call order of code in the diff answers `the diff`
@@ -203,6 +200,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   on implementation details (resources added, files touched)
 - The body records the delivered design, not the path to it, under
   `AIRULES.md`'s 出力フォーマット reader criterion
+  - Keep out attribution to the review that raised a point ("raised in
+    review", "per feedback"). The thread is on this PR, so that reader
+    criterion passes it and only this rule reaches it
   - Keep out rejected alternatives described at implementation-attempt
     granularity, and alternatives a reviewer would not arrive at and
     ask about

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -42,6 +42,10 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    and a change already merged there reads as text the diff did not add
 1. Locate and read `pr-guidelines.md`, bundled with the `git-workflow`
    skill, to load the five properties the PR body is judged against
+1. Invoke the `technical-writing` skill, which carries the prose rules
+   Decidable rests on: a table's caption, and a list whose top level
+   reads alone. Findings against those rules are reported under
+   Decidable
 1. For each URL found in the PR body, fetch it with WebFetch and
    compare what comes back against what the body cites the URL for. A
    fetch that returns no comparable content makes the URL unverifiable

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -42,10 +42,9 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    and a change already merged there reads as text the diff did not add
 1. Locate and read `pr-guidelines.md`, bundled with the `git-workflow`
    skill, to load the five properties the PR body is judged against
-1. Invoke the `technical-writing` skill, which carries the prose rules
-   Decidable rests on: a table's caption, and a list whose top level
-   reads alone. Findings against those rules are reported under
-   Decidable
+1. Invoke the `technical-writing` skill, which carries the caption or
+   lead-in Decidable's table rules rest on. Report a finding against it
+   under Decidable
 1. For each URL found in the PR body, fetch it with WebFetch and
    compare what comes back against what the body cites the URL for. A
    fetch that returns no comparable content makes the URL unverifiable
@@ -96,9 +95,11 @@ Excluded from detection to avoid false positives:
 
 ## Density pass
 
-`AIRULES.md`'s 出力フォーマット asks each list item to carry one sentence,
-and Decidable asks it to carry one claim. Apply the count below rather
-than judging length by eye. Each violation it finds is a Fix.
+`AIRULES.md`'s 出力フォーマット asks each list item to carry one sentence
+as its default, and Decidable asks it to carry one claim. Apply the
+count below rather than judging length by eye, and read it against the
+exclusions further down, which carry the cases that default admits.
+Each violation left after those is a Fix.
 
 Enumerate every list item in the body, top-level and nested alike, and
 count each one. Sampling reports a clean pass on a body full of

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -92,9 +92,9 @@ Excluded from detection to avoid false positives:
 
 ## Density pass
 
-Decidable asks each item to carry one claim at the shortest length that
-lands it. Apply the count below rather than judging length by eye. Each
-violation it finds is a Fix.
+`AIRULES.md`'s 出力フォーマット asks each list item to carry one sentence,
+and Decidable asks it to carry one claim. Apply the count below rather
+than judging length by eye. Each violation it finds is a Fix.
 
 Enumerate every list item in the body, top-level and nested alike, and
 count each one. Sampling reports a clean pass on a body full of

--- a/claude/skills/technical-writing/SKILL.md
+++ b/claude/skills/technical-writing/SKILL.md
@@ -61,6 +61,9 @@ reader can follow the reasoning paragraph by paragraph.
   claim
 - Name the knowledge the document assumes its reader already has, since
   an author holding the whole problem leaves prerequisites unstated
+- In a list, put the claims at the top level and nest what supports or
+  qualifies a claim under it, so the list reads from its top-level lines
+  alone
 
 ## Rigor
 
@@ -115,6 +118,9 @@ text introduces has to be worth holding.
   specifics the argument needs
 - Keep the cells of one table column the same kind of thing, since a
   column the reader cannot predict has to be read row by row
+- Give each table a caption or a one-line lead-in saying what it shows,
+  so a reader who skips the surrounding prose still knows what they are
+  looking at
 
 ## Voice
 
@@ -156,8 +162,8 @@ use, not the vocabulary.
 ## Compression
 
 Compress until removing anything more would remove one of these: the
-mechanism behind a claim, the reason a negation holds, an uncertainty
-marker, or the bound on a claim's scope.
+mechanism behind a claim, the reason a negation holds, or the bound on a
+claim's scope.
 
 - Leave out the intermediate steps a reader supplies without help
 - Where several sentences of argument compress into one, or where naming

--- a/claude/skills/technical-writing/SKILL.md
+++ b/claude/skills/technical-writing/SKILL.md
@@ -162,8 +162,8 @@ use, not the vocabulary.
 ## Compression
 
 Compress until removing anything more would remove one of these: the
-mechanism behind a claim, the reason a negation holds, or the bound on a
-claim's scope.
+mechanism behind a claim, the reason a negation holds, the bound on a
+claim's scope, or a hedge on a judgment or a prediction.
 
 - Leave out the intermediate steps a reader supplies without help
 - Where several sentences of argument compress into one, or where naming


### PR DESCRIPTION
## Purpose

#424 added the `technical-writing` skill with nothing pointing at it, so it fired only when its description happened to match. It also arrived carrying rules `pr-guidelines.md` and `AIRULES.md` already state, which put a writer through the same check twice. Part 2 of #423 gives each shared decision one owner and puts the skill on the paths that write prose.

## Key changes

Five decisions were stated in two files at once. Each now sits in one, under the split that `AIRULES.md` owns markup and epistemic honesty, `pr-guidelines.md` owns what a PR body carries, and the skill owns how prose is built.

| Decision | Was in | Now decided by |
| --- | --- | --- |
| A list item holds one sentence, and a second becomes a sub-bullet | `AIRULES.md` and Decidable | `AIRULES.md`, with Decidable keeping the one-claim test and the evidence exemption |
| A persisted artifact does not reference a superseded state or the session | `AIRULES.md` and Necessary | `AIRULES.md`, with Necessary keeping the two PR-only cases |
| What counts as a primary source for a claim about an external tool | `AIRULES.md` and Grounded | `AIRULES.md`, with Grounded keeping that the citation lands in the body |
| Every URL is fetched before it ships | `AIRULES.md` and Conformant | `AIRULES.md`, with Conformant keeping that the URL reaches what the body cites it for |
| A hedge on a factual claim survives being carried into an artifact | `AIRULES.md` and the skill | `AIRULES.md`, with the skill keeping the case that rule does not reach |

Two rules only `pr-guidelines.md` stated, which a design doc or ADR needs just as much and which never load it, move to the skill in general form: a table carries a caption, and a list puts its claims at the top level. `pr-guidelines.md` keeps the PR-specific part of each.

Two sub-bullets of the delivered-design rule come out with no successor line, because a rule already in force reaches each. Naming a plan-mode phase fails `AIRULES.md`'s reader criterion, which asks whether the sentence means anything to a reader without the chat. Naming an individual commit within the branch is caught by the Necessary walk, which lists the branch's commits among the places a line's content already lives.

### Where the skill is invoked from

- `git-workflow/SKILL.md` § 3, next to the existing instruction to read `pr-guidelines.md`, which is the one imperative that fires before every body write in the workflow
- `git-workflow/SKILL.md` § Update a PR / issue, which `git-essentials.md` reaches directly without passing § 3
- `pr-guidelines.md`'s header, which `/pr-selfcheck` loads on the standalone path
- `claude/rules/software-development.md`, always loaded, for prose written outside any workflow

`/pr-selfcheck` now invokes the skill as its own step, since the caption rule Decidable's table rules rest on moved there and it would otherwise report Decidable clean on a body that rule fails.

## Verification

- [x] A separate-context agent, told nothing of the editing intent, walked every removed and reworded line for the case it decided and searched the post-change files for a line deciding it. It reported eleven cases covered and two lost
- [x] Both losses are fixed. Attribution to a review thread passes `AIRULES.md`'s reader criterion, since the thread sits on the PR the reader is looking at, so Necessary states it again with that reason attached
- [x] `AIRULES.md`'s hedge rule is scoped to 事実についての主張 carried into an artifact at the 要約・引用・永続化 stage, which leaves a hedge on a judgment or a prediction unprotected while tightening prose already written. The skill's compression floor names that case
- [x] The same agent found the list-nesting rule restated in both files after the move. `pr-guidelines.md` now keeps only what its own section structure adds
- [x] It traced four write paths for pointer coverage and found three uncovered: a body update entered from `git-essentials.md`, a standalone `/pr-selfcheck` followed by a rewrite, and the comments, review replies, and commit bodies the rule's list did not name. All three are covered
- [x] `scripts/check_rule_budget.sh`, run by the `check-rule-budget` pre-commit hook, reports `OK: claude/rules/software-development.md (70 / 100 lines)` and exits 0
- [x] Code review found the self-check step claiming the list-hierarchy rule had moved to the skill while `pr-guidelines.md` still carries its own. The step now claims only the table caption, which did move
- [x] It also found the always-loaded rule listing the artifacts the skill's description already lists, and carrying a PR-body carve-out that changed no behavior while reading as an instruction to skip invocation. Both are gone, so a body edit entered from `git-essentials.md` still reaches the skill
- [x] Two pointers were reworded: `pr-guidelines.md`'s named no moment and no reason, and the Update section's said the steps reach the section where it is `git-essentials.md` that routes there
- [x] `pr-guidelines.md` goes from 362 lines to 351, counted with `grep -c ''` on both revisions

## Notes

Two things this PR leaves open, both recorded on #423. `pr-guidelines.md` states a fact once in two places within itself, which the Necessary walk already reaches, and that is a within-document duplicate rather than one the split created. Separately, the rule that a bare link is a defect is needed by design docs and stated only for PR bodies, and its destination is not settled by the ownership split: it decides which content a document carries, which the skill disclaims, and it sits closest to `AIRULES.md`'s source-handling section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbPK1SW7Dahw4ENTLZw3BU
