### PR TITLE
Give the PR body rubric a skill of its own

### DIFF
--- a/claude/rules/git-essentials.md
+++ b/claude/rules/git-essentials.md
@@ -9,7 +9,7 @@ explicitly (e.g., "stop after Step 3, skip CI wait"). (Truly
 trivial fixes that don't warrant Plan Mode at all are a separate
 judgment call — see EnterPlanMode's own criteria.)
 
-The full procedure (worktree setup, PR body rules, CI phases,
+The full procedure (worktree setup, CI phases,
 monitoring, cleanup) lives in the git-workflow skill. Plans MUST
 NOT restate the detailed procedures from the skill.
 

--- a/claude/rules/git-essentials.md
+++ b/claude/rules/git-essentials.md
@@ -44,7 +44,6 @@ NOT restate the detailed procedures from the skill.
 
 ## PR / issue body edits
 
-- Before running `gh pr edit` / `gh issue edit` with `--body`,
-  `--body-file`, or `--title`, summarize the change in the assistant
-  message body — a short list of what is being added, removed, or
-  reworded, not the full before/after diff
+- Invoke `Skill(create-pull-request)` before writing or editing a PR or
+  issue title or body, including a `gh pr edit` / `gh issue edit` run
+  outside the git workflow

--- a/claude/skills/create-pull-request/SKILL.md
+++ b/claude/skills/create-pull-request/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: create-pull-request
+description: Write or edit the title and body of a pull request or an issue, and create a PR. Carries the five properties a PR body is judged against (Decidable, Grounded, Necessary, Scoped, Conformant), the body template, and the commands for creating a draft PR and for editing a PR or issue body safely. Invoke before writing a PR title or body, before editing one, before writing an issue body, and when bringing an existing PR into conformance. The git-workflow skill invokes this at its create-a-PR step and at its update procedure, and pr-selfcheck invokes it to load the properties it judges against.
+---
+
+# Create a Pull Request
+
+Writing a PR title or body, editing one, and writing an issue body all
+run through here.
+
+Read [properties.md](properties.md) for the five properties a body is
+judged against and the template to write into. Invoke the
+`technical-writing` skill for how the prose itself is built.
+
+## Create a PR
+
+1. If the branch already has a PR (`gh pr view --json number,url`),
+   skip creation and bring its title and body into conformance using
+   the update procedure below
+1. Write the body to a fresh file under the session scratchpad
+   directory using the Write tool, a new filename per revision
+   - Follow the repository's PR template when one exists
+1. Create the PR as a draft:
+   `gh pr create --draft --body-file <body file path>`
+1. Display the PR URL: `gh pr view --json url --jq '.url'`
+
+## Update a PR or issue title or body
+
+- Update a title: `gh pr edit <number> --title '...'`
+- Update a body:
+  1. Fetch the current one:
+     `gh pr view <number> --json body --jq .body`
+     (`gh issue view <number> --json body --jq .body` for an issue)
+  1. Summarize the change in the assistant message body, a short list
+     of what is being added, removed, or reworded rather than the full
+     before-and-after
+  1. Write the new body to a fresh file under the session scratchpad
+     directory using the Write tool, a new filename per revision
+  1. Execute the edit:
+     `gh pr edit <number> --body-file <body file path>`
+     (`gh issue edit <number> --body-file <body file path>` for an
+     issue)
+
+Pass a body through `--body-file` and never `--body`. The `#`-prefixed
+lines a body carries trigger Claude Code's security pre-check when
+passed via `--body`, which no hook can bypass.

--- a/claude/skills/create-pull-request/SKILL.md
+++ b/claude/skills/create-pull-request/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-pull-request
-description: Write or edit the title and body of a pull request or an issue, and create a PR. Carries the five properties a PR body is judged against (Decidable, Grounded, Necessary, Scoped, Conformant), the body template, and the commands for creating a draft PR and for editing a PR or issue body safely. Invoke before writing a PR title or body, before editing one, before writing an issue body, and when bringing an existing PR into conformance. The git-workflow skill invokes this at its create-a-PR step and at its update procedure, and pr-selfcheck invokes it to load the properties it judges against.
+description: Write or edit the title and body of a pull request or an issue, and create a PR. Carries the five properties a PR body is judged against (Decidable, Grounded, Necessary, Scoped, Conformant), the body template, and the commands for creating a draft PR and for editing a PR or issue body safely. Invoke before writing a PR title or body, before editing one, before writing an issue body, and when bringing an existing PR into conformance.
 ---
 
 # Create a Pull Request
@@ -12,35 +12,43 @@ Read [properties.md](properties.md) for the five properties a body is
 judged against and the template to write into. Invoke the
 `technical-writing` skill for how the prose itself is built.
 
+Pass a body through `--body-file` and never `--body`, on creation and on
+every edit after it. The `#`-prefixed lines a body carries trigger
+Claude Code's security pre-check when passed via `--body`, which no hook
+can bypass.
+
 ## Create a PR
 
+The branch exists, carries the commits, and is pushed before this runs.
+
 1. If the branch already has a PR (`gh pr view --json number,url`),
-   skip creation and bring its title and body into conformance using
-   the update procedure below
+   skip creation, bring its title and body into conformance using the
+   update procedure below, display the PR URL, and stop here
 1. Write the body to a fresh file under the session scratchpad
-   directory using the Write tool, a new filename per revision
+   directory using the Write tool, a new filename per revision. Do not
+   generate a temp filename, and do not Read a file that does not exist
+   yet
    - Follow the repository's PR template when one exists
 1. Create the PR as a draft:
    `gh pr create --draft --body-file <body file path>`
 1. Display the PR URL: `gh pr view --json url --jq '.url'`
 
-## Update a PR or issue title or body
+## Update an existing title or body
+
+Summarize the change in the assistant message body before either edit
+below, as a short list of what is being added, removed, or reworded
+rather than the full before-and-after.
 
 - Update a title: `gh pr edit <number> --title '...'`
 - Update a body:
   1. Fetch the current one:
      `gh pr view <number> --json body --jq .body`
      (`gh issue view <number> --json body --jq .body` for an issue)
-  1. Summarize the change in the assistant message body, a short list
-     of what is being added, removed, or reworded rather than the full
-     before-and-after
   1. Write the new body to a fresh file under the session scratchpad
-     directory using the Write tool, a new filename per revision
+     directory using the Write tool, a new filename per revision. Do
+     not generate a temp filename, and do not Read a file that does not
+     exist yet
   1. Execute the edit:
      `gh pr edit <number> --body-file <body file path>`
      (`gh issue edit <number> --body-file <body file path>` for an
      issue)
-
-Pass a body through `--body-file` and never `--body`. The `#`-prefixed
-lines a body carries trigger Claude Code's security pre-check when
-passed via `--body`, which no hook can bypass.

--- a/claude/skills/create-pull-request/properties.md
+++ b/claude/skills/create-pull-request/properties.md
@@ -311,7 +311,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - GitHub Flavored Markdown renders soft line breaks inside a
     paragraph as visible breaks only in these contexts
     ([basic writing and formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax))
-  - Plain Markdown files (READMEs, ADRs, this guidelines file itself,
+  - Plain Markdown files (READMEs, ADRs, this file itself,
     and any other in-repo documentation) follow standard Markdown
     rendering and may be hard-wrapped for file-side readability
 

--- a/claude/skills/create-pull-request/properties.md
+++ b/claude/skills/create-pull-request/properties.md
@@ -1,11 +1,7 @@
-# PR Guidelines
+# The properties a PR body holds
 
 Quality criteria for pull requests. Follow these when writing a PR body
 and when self-reviewing your own PR.
-
-Before writing a PR body or judging one against the properties below,
-invoke the `technical-writing` skill. These properties decide what the
-body carries, and that skill decides how its prose is built.
 
 A PR body is a summary that helps a reviewer decide, not a complete
 record of the change: everything else lives in the diff, the issue, or

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -15,8 +15,6 @@ threads), the `pr-review-toolkit` plugin (Phase 2), and `bin/pr-monitor`
 
 ## Supporting files
 
-- [pr-guidelines.md](pr-guidelines.md) — the properties a PR title and
-  body are judged against, and what belongs in the body versus the diff
 - [pr-reaction.md](pr-reaction.md) — bot-versus-human targeting for PR
   events, whether an event is answered by a reply or a fix push, which
   channel a reply goes to, and thread resolve
@@ -89,29 +87,15 @@ formatting or indentation.
 
 ## 3. Create a PR
 
-Read [pr-guidelines.md](pr-guidelines.md) and invoke the
-`technical-writing` skill before writing or editing a PR title or body
-anywhere in this workflow, including the Phase 4 updates and the Update
-a PR / issue procedure.
+Invoke the `create-pull-request` skill, which carries the properties a
+title and body are judged against and the commands that write them.
+This holds wherever the workflow writes or edits a title or body,
+including the Phase 4 updates.
 
-1. If the branch already has a PR (`gh pr view --json number,url`),
-   skip creation. Bring its title and body into conformance with
-   `pr-guidelines.md` using the Update a PR / issue procedure,
-   display the PR URL to the user, then proceed to step 4.
-   - For a PR the implementer opened, read
-     [implementer-dispatch.md](implementer-dispatch.md) and apply its
-     `When it returns` steps before that conformance pass
-1. Write the PR body to a fresh file under the session scratchpad
-   directory using the Write tool (new filename per revision — no
-   temp-file generation, no Read of an empty file)
-   - Follow the repository's PR template if one exists
-1. Create the PR as a draft:
-   `gh pr create --draft --body-file <body file path>`
-   - Never use `--body` for PR creation, for the reason the Update a PR
-     / issue section gives
-1. After creating the PR, display the PR URL to the user:
-   `gh pr view --json url --jq '.url'`
-1. Proceed to step 4
+- For a PR the implementer opened, read
+  [implementer-dispatch.md](implementer-dispatch.md) and apply its
+  `When it returns` steps before bringing the body into conformance
+- Proceed to step 4 once the PR exists and its URL is displayed
 
 ## 4. Checks, review, and merge
 
@@ -198,8 +182,7 @@ Update incrementally as conditions are confirmed (e.g., after Phase 1
 CI passes, after apply / deploy succeeds, after post-deploy
 verification with `curl`, `aws logs tail`, etc.).
 
-Use the Update a PR / issue procedure (`gh pr edit --body-file`) for body
-edits.
+Invoke the `create-pull-request` skill for body edits.
 
 ### Phase 5: Watch PR activity until merge
 
@@ -250,31 +233,6 @@ run entered the workflow at this phase.
 `PushNotification` only for events that change what the user would do
 next (merge, or "needs human attention" after the fix cap). Skip
 routine CI / comment events.
-
-## Update a PR / issue (title / body)
-
-Read [pr-guidelines.md](pr-guidelines.md) and invoke the
-`technical-writing` skill before the steps below.
-
-- Update title:
-  `gh pr edit <number> --title '...'`
-- Update body (always use `--body-file`, never `--body`):
-  1. Fetch the current body:
-     `gh pr view <number> --json body --jq .body`
-     (or `gh issue view <number> --json body --jq .body` for issues)
-  1. Summarize the change in the assistant message body — a short
-     list of what is being added, removed, or reworded, not the full
-     before/after diff
-  1. Write the new body to a fresh file under the session scratchpad
-     directory using the Write tool (new filename per revision — no
-     temp-file generation, no Read of an empty file)
-  1. Execute the edit:
-     `gh pr edit <number> --body-file <body file path>`
-     (or `gh issue edit <number> --body-file <body file path>`)
-
-Note: Always use `--body-file` for any body update. The `#`-prefixed lines
-in PR/issue bodies trigger Claude Code's security pre-check when passed
-via `--body`, which cannot be bypassed by hooks.
 
 ## 5. Cleanup After Task Completion
 

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -87,15 +87,16 @@ formatting or indentation.
 
 ## 3. Create a PR
 
-Invoke the `create-pull-request` skill, which carries the properties a
-title and body are judged against and the commands that write them.
-This holds wherever the workflow writes or edits a title or body,
-including the Phase 4 updates.
+For a PR the implementer opened, read
+[implementer-dispatch.md](implementer-dispatch.md) first and apply its
+`When it returns` steps, since the body it left is a placeholder.
 
-- For a PR the implementer opened, read
-  [implementer-dispatch.md](implementer-dispatch.md) and apply its
-  `When it returns` steps before bringing the body into conformance
-- Proceed to step 4 once the PR exists and its URL is displayed
+Then invoke the `create-pull-request` skill, which carries the
+properties a title and body are judged against and the commands that
+write them. This holds wherever the workflow writes or edits a title or
+body, including the Phase 4 updates.
+
+Proceed to step 4 once the PR exists and its URL is displayed.
 
 ## 4. Checks, review, and merge
 
@@ -182,7 +183,6 @@ Update incrementally as conditions are confirmed (e.g., after Phase 1
 CI passes, after apply / deploy succeeds, after post-deploy
 verification with `curl`, `aws logs tail`, etc.).
 
-Invoke the `create-pull-request` skill for body edits.
 
 ### Phase 5: Watch PR activity until merge
 

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -51,9 +51,9 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    or a login page), a 429 or 5xx, and a domain `WebFetch` is denied
    all land here. A Fix only when fetched content contradicts the
    citation
-1. Walk the five properties one at a time, in the order that skill
-   states them, judging the PR against that property's rules and the
-   severity table below
+1. Walk the five properties one at a time, in the order the
+   `create-pull-request` skill states them, judging the PR against that
+   property's rules and the severity table below
 1. Run the density pass described below over the body's list items and
    paragraphs. It is a count, not a judgement, and it does not depend
    on the body's language

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -40,8 +40,8 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    reading the head for every later check. The default branch is not
    that merge base once anything has landed since the branch was cut,
    and a change already merged there reads as text the diff did not add
-1. Locate and read `pr-guidelines.md`, bundled with the `git-workflow`
-   skill, to load the five properties the PR body is judged against
+1. Invoke the `create-pull-request` skill to load the five properties
+   the PR body is judged against
 1. For each URL found in the PR body, fetch it with WebFetch and
    compare what comes back against what the body cites the URL for. A
    fetch that returns no comparable content makes the URL unverifiable
@@ -51,9 +51,9 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    or a login page), a 429 or 5xx, and a domain `WebFetch` is denied
    all land here. A Fix only when fetched content contradicts the
    citation
-1. Walk the five properties one at a time, in the order
-   `pr-guidelines.md` states them, judging the PR against that
-   property's rules and the severity table below
+1. Walk the five properties one at a time, in the order that skill
+   states them, judging the PR against that property's rules and the
+   severity table below
 1. Run the density pass described below over the body's list items and
    paragraphs. It is a count, not a judgement, and it does not depend
    on the body's language


### PR DESCRIPTION
## Purpose

`pr-selfcheck` judged every PR body against a rubric that lived in the `git-workflow` skill's directory, reached by filename across a skill boundary. A rename of that file would have left the self-check emitting a five-property walk against rules it never loaded, and the rubric it depends on entirely belonged to a skill with no claim on it. Last of the three items #426 left in its Notes.

## Key changes

The rubric becomes the `create-pull-request` skill, and both callers reach it by name. A name that stops resolving fails the invocation loudly, which is the property the filename reference did not have.

The skill carries the commands as well as the properties, because writing a body, creating the draft, and editing a body afterwards are one job. `git-workflow` held two copies of the scratchpad-file and `--body-file` steps to cover the create path and the update path separately, and both are now stated once.

`git-essentials.md` points at the skill instead of restating the summarize-before-editing step, so that step has one home too. Its rule now covers a `gh pr edit` run outside the workflow, which the old wording left to a procedure the reader had to find on their own.

## Verification

- [x] `git grep -n 'pr-guidelines' -- claude/ AGENTS.md` returns nothing at the branch head
- [x] `scripts/deploy.sh` symlinks each directory under `claude/skills/` by a `find` over the parent, so the new one is picked up with no deploy change
- [x] `git-workflow/SKILL.md` drops from 285 lines to 243, and `scripts/check_rule_budget.sh` reports `claude/rules/git-essentials.md` at 49 of 100
- [x] `git diff main...HEAD -M --numstat` reports the rubric as a rename with two insertions and six deletions: a reworded heading, a phrase that called it a guidelines file, and the removal of the paragraph telling the reader to invoke `technical-writing`, which the new `SKILL.md` now says once for every path into it

## Notes

`pr-selfcheck` now reaches both of the skills it depends on by name: `technical-writing` for prose, and `create-pull-request` for the rubric. The vocabulary mismatch between `retrospective` and `retro-review` is the one item #426 raised that no PR has taken, and it still wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbPK1SW7Dahw4ENTLZw3BU
