### PR TITLE
Make the PR page a carrier the Necessary walk names

### DIFF
--- a/claude/skills/create-pull-request/properties.md
+++ b/claude/skills/create-pull-request/properties.md
@@ -27,9 +27,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   paths the diff changes
 - Necessary — read each line of the body for where else its content
   already lives, and the body carries nothing the diff, its commits,
-  the Checks panel or an automation's output carry, states each thing
-  once, and takes from a linked source no more than the summary that
-  survives the link going dead
+  the PR page or an automation's output carry, states each thing once,
+  and takes from a linked source no more than the summary that survives
+  the link going dead
 - Scoped — the diff read against the body carries only what the stated
   intent needs and nothing the body did not lead the reader to expect,
   and the body conveys the change as a whole: a boundary the reader
@@ -163,12 +163,15 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 ## Necessary
 
 - Take the body a line at a time and name where else that line's content
-  lives — the diff, the branch's commits, the Checks panel, a linked
-  source, another line of this body, or nowhere
+  lives — the diff, the branch's commits, the PR page around the body, a
+  linked source, another line of this body, or nowhere
+  - The PR page carries the diff's own statistics, the file and commit
+    counts, the branch name, the labels, and the Checks panel, so a line
+    stating any of them answers `the PR page`
   - What the answer forfeits is the part it already carries: detail the
-    diff or the commits show, output the Checks panel holds, a fact
-    another line of the body states, and anything past the shortest
-    summary a linked source needs
+    diff or the commits show, anything the PR page displays on its own,
+    a fact another line of the body states, and anything past the
+    shortest summary a linked source needs
   - A heading is a line the walk takes, and answers for its own text
     rather than for the lines beneath it
   - A table row is a line of the walk, read with the caption or lead-in
@@ -185,9 +188,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     names it, and the rules below reach lines answering `nowhere` that
     the walk does not
 - Do not paraphrase the diff
-  - Keep out file lists, line counts, percentage of lines removed,
-    per-file summaries, and enumerations of added rules, linters,
-    settings, constants, or values
+  - Keep out file lists, per-file summaries, and enumerations of added
+    rules, linters, settings, constants, or values
   - Keep out self-paraphrase of own edits ("edited file X", "bumped
     value from A to B", "added N items", "raised timeout to M")
   - Keep out per-item rendering of a pre-flight checklist when every
@@ -351,8 +353,8 @@ what prompted it, intended outcome. Not a paraphrase of the diff.>
 ## Key changes
 
 <3-5 bullets, each a distinct decision or user-visible outcome. Do
-not enumerate files, line counts, or per-file summaries — the diff
-already shows those.>
+not enumerate files or per-file summaries, and do not state what the
+PR page already displays — the diff and the page show those.>
 
 ## Verification
 

--- a/claude/skills/create-pull-request/properties.md
+++ b/claude/skills/create-pull-request/properties.md
@@ -163,15 +163,16 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 ## Necessary
 
 - Take the body a line at a time and name where else that line's content
-  lives — the diff, the branch's commits, the PR page around the body, a
-  linked source, another line of this body, or nowhere
-  - The PR page carries the diff's own statistics, the file and commit
-    counts, the branch name, the labels, and the Checks panel, so a line
-    stating any of them answers `the PR page`
+  lives — the diff, the branch's commits, the PR page, a linked source,
+  another line of this body, or nowhere
+  - The PR page carries this PR's own insertion and deletion counts, its
+    file and commit counts, its head and base branch names, its title,
+    its labels, and the results in its Checks panel, so a line stating
+    any of them answers `the PR page`
   - What the answer forfeits is the part it already carries: detail the
-    diff or the commits show, anything the PR page displays on its own,
-    a fact another line of the body states, and anything past the
-    shortest summary a linked source needs
+    diff or the commits show, a value the PR page itself carries, a fact
+    another line of the body states, and anything past the shortest
+    summary a linked source needs
   - A heading is a line the walk takes, and answers for its own text
     rather than for the lines beneath it
   - A table row is a line of the walk, read with the caption or lead-in
@@ -188,8 +189,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     names it, and the rules below reach lines answering `nowhere` that
     the walk does not
 - Do not paraphrase the diff
-  - Keep out file lists, per-file summaries, and enumerations of added
-    rules, linters, settings, constants, or values
+  - Keep out file lists, per-file summaries, figures derived from the
+    diff's size such as the percentage of lines removed, and
+    enumerations of added rules, linters, settings, constants, or values
   - Keep out self-paraphrase of own edits ("edited file X", "bumped
     value from A to B", "added N items", "raised timeout to M")
   - Keep out per-item rendering of a pre-flight checklist when every
@@ -353,8 +355,8 @@ what prompted it, intended outcome. Not a paraphrase of the diff.>
 ## Key changes
 
 <3-5 bullets, each a distinct decision or user-visible outcome. Do
-not enumerate files or per-file summaries, and do not state what the
-PR page already displays — the diff and the page show those.>
+not enumerate files or per-file summaries, and do not state a value the
+PR page itself carries — the diff and the page hold those.>
 
 ## Verification
 

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -14,7 +14,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
 ## Steps
 
 1. Retrieve PR metadata:
-   `gh pr view <number> --json title,body,url,additions,deletions,files,baseRefName`
+   `gh pr view <number> --json title,body,url,additions,deletions,files,commits,labels,headRefName,baseRefName`
 1. Retrieve the diff:
    `gh pr diff <number>`
 1. When verifying a body claim needs file contents at the PR head,


### PR DESCRIPTION
## Purpose

The Necessary walk asks where else a line's content lives and lists the diff, the branch's commits, the Checks panel, and a linked source. The Checks panel is one part of the PR page, and the rest of that page went unnamed, so a body could state the diff's own statistics, the file and commit counts, the branch name, or the labels and answer that the content lives nowhere else. All of it sits on screen beside the body a reviewer is reading.

#427 carried a line count for two skill files through that gap, and its self-check caught the number as wrong twice, each time after a later commit changed one of them.

## Key changes

The walk now names the PR page as a carrier, with a line saying what the page displays on its own. The Checks panel becomes one entry in that list rather than the only one.

Line counts move out of the diff-paraphrase rule, which grouped them with file lists and per-file summaries. A line count is not diff detail a reader would open the diff to find; it is a number the page prints above the diff. That rule keeps the enumerations that are genuinely detail the diff shows.

## Verification

- [x] `git grep -n 'Checks panel' -- claude/` returns one line, the entry inside the new list, so nothing elsewhere still treats it as a carrier in its own right
- [x] The template's Key changes note pointed at the same content through a different phrase, and now points at the page, so a writer following the template reaches the same verdict as a checker running the walk
- [x] This body carries no count of its own, which the new rule is what asks for

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbPK1SW7Dahw4ENTLZw3BU
