### PR TITLE
Emit PR events from every author

### DIFF
--- a/bin/pr-monitor
+++ b/bin/pr-monitor
@@ -24,6 +24,12 @@
 #
 # CHECK covers every check on the head commit, Actions or not, settling
 # on anything but success.
+#
+# Comment and review events carry every author, the account the monitor
+# authenticates as included, so that a comment the operator posts reaches
+# the reader. A reply a reacting session posts from that same account
+# therefore returns once as an event; `pr-reaction.md` Step 4 covers
+# telling that echo apart from the operator acting.
 
 set -eu
 
@@ -56,11 +62,6 @@ fi
 owner_repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
 owner="${owner_repo%/*}"
 repo="${owner_repo#*/}"
-
-# The monitor's own account: exclude its own comments so that replies it
-# posts via `gh pr comment` (a step-4 reaction) do not re-emit as fresh
-# events on the next poll. Empty `me` (lookup failed) filters nothing.
-me="$(gh api user --jq .login 2>/dev/null || true)"
 
 prev_state=""
 prev_decision=""
@@ -245,10 +246,10 @@ while true; do
   else
     poll_ok "gh api graphql (threads)"
   fi
-  fresh_comments="$(echo "$threads_json" | jq -r --arg me "$me" '
+  fresh_comments="$(echo "$threads_json" | jq -r '
     .data.repository.pullRequest.reviewThreads.nodes[]
     | select(.isResolved == false and .isOutdated == false)
-    | .comments.nodes[] | select(.author.login != $me)
+    | .comments.nodes[]
     | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)\t\(.path // "?"):\(.line // "?")"' \
     2>/dev/null || true)"
   emit_new "$fresh_comments" "$seen_comments" "NEW_COMMENT"
@@ -265,16 +266,15 @@ while true; do
   else
     poll_ok "gh api graphql (reviews)"
   fi
-  fresh_top="$(echo "$reviews_json" | jq -r --arg me "$me" '
+  fresh_top="$(echo "$reviews_json" | jq -r '
     .data.repository.pullRequest.comments.nodes[]
-    | select(.author.login != $me)
     | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)"' \
     2>/dev/null || true)"
   emit_new "$fresh_top" "$seen_top_comments" "NEW_TOP_COMMENT"
 
-  fresh_reviews="$(echo "$reviews_json" | jq -r --arg me "$me" '
+  fresh_reviews="$(echo "$reviews_json" | jq -r '
     .data.repository.pullRequest.reviews.nodes[]
-    | select(.author.login != $me and .state != "PENDING" and (.body // "") != "")
+    | select(.state != "PENDING" and (.body // "") != "")
     | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)\t\(.state)"' \
     2>/dev/null || true)"
   emit_new "$fresh_reviews" "$seen_reviews" "NEW_REVIEW"

--- a/bin/pr-monitor
+++ b/bin/pr-monitor
@@ -25,8 +25,10 @@
 # CHECK covers every check on the head commit, Actions or not, settling
 # on anything but success.
 #
-# `[SELF]` marks the account the monitor authenticates as, which is also
-# the account a reacting session posts from.
+# `[SELF]` marks the account the monitor authenticates as, taken to be
+# the account a reacting session posts from. It is tested before `[BOT]`,
+# so an account GitHub types as a Bot still tags `[SELF]` on its own
+# events and a session never reads its own posts as a bot's.
 
 set -eu
 
@@ -61,8 +63,8 @@ owner="${owner_repo%/*}"
 repo="${owner_repo#*/}"
 
 # The login behind the `[SELF]` tag. An empty `me` (lookup failed) tags
-# nothing `[SELF]`, leaving those events `[USER]` — the path that
-# surfaces them to the user.
+# nothing `[SELF]`, so the session's own posts arrive as `[USER]`:
+# surfaced to the user rather than acted on autonomously.
 me="$(gh api user --jq .login 2>/dev/null || true)"
 
 prev_state=""
@@ -98,8 +100,9 @@ poll_ok() {
 }
 
 # `__typename` on each author is the authoritative Bot/User signal per
-# `pr-reaction.md`. It flows into the event line as a `[BOT]`, `[USER]`,
-# or `[SELF]` prefix on the author label so a reaction turn can classify
+# `pr-reaction.md`, and `author.login` against `me` splits off the
+# monitor's own account. Together they settle the `[SELF]`, `[BOT]`, or
+# `[USER]` prefix on the author label so a reaction turn can classify
 # without re-fetching. For review-thread comments this is a per-comment
 # hint only — the rule still requires walking every comment in the
 # thread before mutating it.
@@ -252,7 +255,7 @@ while true; do
     .data.repository.pullRequest.reviewThreads.nodes[]
     | select(.isResolved == false and .isOutdated == false)
     | .comments.nodes[]
-    | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" elif .author.login == $me then "[SELF]" else "[USER]" end) \(.author.login)\t\(.path // "?"):\(.line // "?")"' \
+    | "\(.id)\t\(if .author.login == $me then "[SELF]" elif .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)\t\(.path // "?"):\(.line // "?")"' \
     2>/dev/null || true)"
   emit_new "$fresh_comments" "$seen_comments" "NEW_COMMENT"
 
@@ -270,14 +273,14 @@ while true; do
   fi
   fresh_top="$(echo "$reviews_json" | jq -r --arg me "$me" '
     .data.repository.pullRequest.comments.nodes[]
-    | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" elif .author.login == $me then "[SELF]" else "[USER]" end) \(.author.login)"' \
+    | "\(.id)\t\(if .author.login == $me then "[SELF]" elif .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)"' \
     2>/dev/null || true)"
   emit_new "$fresh_top" "$seen_top_comments" "NEW_TOP_COMMENT"
 
   fresh_reviews="$(echo "$reviews_json" | jq -r --arg me "$me" '
     .data.repository.pullRequest.reviews.nodes[]
     | select(.state != "PENDING" and (.body // "") != "")
-    | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" elif .author.login == $me then "[SELF]" else "[USER]" end) \(.author.login)\t\(.state)"' \
+    | "\(.id)\t\(if .author.login == $me then "[SELF]" elif .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)\t\(.state)"' \
     2>/dev/null || true)"
   emit_new "$fresh_reviews" "$seen_reviews" "NEW_REVIEW"
 

--- a/bin/pr-monitor
+++ b/bin/pr-monitor
@@ -25,8 +25,9 @@
 # CHECK covers every check on the head commit, Actions or not, settling
 # on anything but success.
 #
-# Comment and review events carry every author, the account the monitor
-# authenticates as included.
+# Comment and review events carry every author, the one `gh`
+# authenticates as included; `pr-reaction.md` decides what a reacting
+# session does with those.
 
 set -eu
 

--- a/bin/pr-monitor
+++ b/bin/pr-monitor
@@ -16,20 +16,17 @@
 #   STATE: <state>
 #   REVIEW: <reviewDecision>
 #   READY_FOR_REVIEW
-#   NEW_COMMENT: [BOT|USER] <author> <path>:<line>
-#   NEW_TOP_COMMENT: [BOT|USER] <author>
-#   NEW_REVIEW: [BOT|USER] <author> <state>
+#   NEW_COMMENT: [BOT|USER|SELF] <author> <path>:<line>
+#   NEW_TOP_COMMENT: [BOT|USER|SELF] <author>
+#   NEW_REVIEW: [BOT|USER|SELF] <author> <state>
 #   CHECK: <check name> (<conclusion or state>)
 #   POLL_ERROR: <call that failed>
 #
 # CHECK covers every check on the head commit, Actions or not, settling
 # on anything but success.
 #
-# Comment and review events carry every author, the account the monitor
-# authenticates as included, so that a comment the operator posts reaches
-# the reader. A reply a reacting session posts from that same account
-# therefore returns once as an event; `pr-reaction.md` Step 4 covers
-# telling that echo apart from the operator acting.
+# `[SELF]` marks the account the monitor authenticates as, which is also
+# the account a reacting session posts from.
 
 set -eu
 
@@ -62,6 +59,11 @@ fi
 owner_repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
 owner="${owner_repo%/*}"
 repo="${owner_repo#*/}"
+
+# The login behind the `[SELF]` tag. An empty `me` (lookup failed) tags
+# nothing `[SELF]`, leaving those events `[USER]` — the path that
+# surfaces them to the user.
+me="$(gh api user --jq .login 2>/dev/null || true)"
 
 prev_state=""
 prev_decision=""
@@ -96,8 +98,8 @@ poll_ok() {
 }
 
 # `__typename` on each author is the authoritative Bot/User signal per
-# `pr-reaction.md`. It flows into the event line as a `[BOT]` or
-# `[USER]` prefix on the author label so a reaction turn can classify
+# `pr-reaction.md`. It flows into the event line as a `[BOT]`, `[USER]`,
+# or `[SELF]` prefix on the author label so a reaction turn can classify
 # without re-fetching. For review-thread comments this is a per-comment
 # hint only — the rule still requires walking every comment in the
 # thread before mutating it.
@@ -246,11 +248,11 @@ while true; do
   else
     poll_ok "gh api graphql (threads)"
   fi
-  fresh_comments="$(echo "$threads_json" | jq -r '
+  fresh_comments="$(echo "$threads_json" | jq -r --arg me "$me" '
     .data.repository.pullRequest.reviewThreads.nodes[]
     | select(.isResolved == false and .isOutdated == false)
     | .comments.nodes[]
-    | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)\t\(.path // "?"):\(.line // "?")"' \
+    | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" elif .author.login == $me then "[SELF]" else "[USER]" end) \(.author.login)\t\(.path // "?"):\(.line // "?")"' \
     2>/dev/null || true)"
   emit_new "$fresh_comments" "$seen_comments" "NEW_COMMENT"
 
@@ -266,16 +268,16 @@ while true; do
   else
     poll_ok "gh api graphql (reviews)"
   fi
-  fresh_top="$(echo "$reviews_json" | jq -r '
+  fresh_top="$(echo "$reviews_json" | jq -r --arg me "$me" '
     .data.repository.pullRequest.comments.nodes[]
-    | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)"' \
+    | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" elif .author.login == $me then "[SELF]" else "[USER]" end) \(.author.login)"' \
     2>/dev/null || true)"
   emit_new "$fresh_top" "$seen_top_comments" "NEW_TOP_COMMENT"
 
-  fresh_reviews="$(echo "$reviews_json" | jq -r '
+  fresh_reviews="$(echo "$reviews_json" | jq -r --arg me "$me" '
     .data.repository.pullRequest.reviews.nodes[]
     | select(.state != "PENDING" and (.body // "") != "")
-    | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)\t\(.state)"' \
+    | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" elif .author.login == $me then "[SELF]" else "[USER]" end) \(.author.login)\t\(.state)"' \
     2>/dev/null || true)"
   emit_new "$fresh_reviews" "$seen_reviews" "NEW_REVIEW"
 

--- a/bin/pr-monitor
+++ b/bin/pr-monitor
@@ -16,19 +16,17 @@
 #   STATE: <state>
 #   REVIEW: <reviewDecision>
 #   READY_FOR_REVIEW
-#   NEW_COMMENT: [BOT|USER|SELF] <author> <path>:<line>
-#   NEW_TOP_COMMENT: [BOT|USER|SELF] <author>
-#   NEW_REVIEW: [BOT|USER|SELF] <author> <state>
+#   NEW_COMMENT: [BOT|USER] <author> <path>:<line>
+#   NEW_TOP_COMMENT: [BOT|USER] <author>
+#   NEW_REVIEW: [BOT|USER] <author> <state>
 #   CHECK: <check name> (<conclusion or state>)
 #   POLL_ERROR: <call that failed>
 #
 # CHECK covers every check on the head commit, Actions or not, settling
 # on anything but success.
 #
-# `[SELF]` marks the account the monitor authenticates as, taken to be
-# the account a reacting session posts from. It is tested before `[BOT]`,
-# so an account GitHub types as a Bot still tags `[SELF]` on its own
-# events and a session never reads its own posts as a bot's.
+# Comment and review events carry every author, the account the monitor
+# authenticates as included.
 
 set -eu
 
@@ -61,11 +59,6 @@ fi
 owner_repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
 owner="${owner_repo%/*}"
 repo="${owner_repo#*/}"
-
-# The login behind the `[SELF]` tag. An empty `me` (lookup failed) tags
-# nothing `[SELF]`, so the session's own posts arrive as `[USER]`:
-# surfaced to the user rather than acted on autonomously.
-me="$(gh api user --jq .login 2>/dev/null || true)"
 
 prev_state=""
 prev_decision=""
@@ -100,8 +93,7 @@ poll_ok() {
 }
 
 # `__typename` on each author is the authoritative Bot/User signal per
-# `pr-reaction.md`, and `author.login` against `me` splits off the
-# monitor's own account. Together they settle the `[SELF]`, `[BOT]`, or
+# `pr-reaction.md`. It flows into the event line as a `[BOT]` or
 # `[USER]` prefix on the author label so a reaction turn can classify
 # without re-fetching. For review-thread comments this is a per-comment
 # hint only — the rule still requires walking every comment in the
@@ -251,11 +243,11 @@ while true; do
   else
     poll_ok "gh api graphql (threads)"
   fi
-  fresh_comments="$(echo "$threads_json" | jq -r --arg me "$me" '
+  fresh_comments="$(echo "$threads_json" | jq -r '
     .data.repository.pullRequest.reviewThreads.nodes[]
     | select(.isResolved == false and .isOutdated == false)
     | .comments.nodes[]
-    | "\(.id)\t\(if .author.login == $me then "[SELF]" elif .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)\t\(.path // "?"):\(.line // "?")"' \
+    | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)\t\(.path // "?"):\(.line // "?")"' \
     2>/dev/null || true)"
   emit_new "$fresh_comments" "$seen_comments" "NEW_COMMENT"
 
@@ -271,16 +263,16 @@ while true; do
   else
     poll_ok "gh api graphql (reviews)"
   fi
-  fresh_top="$(echo "$reviews_json" | jq -r --arg me "$me" '
+  fresh_top="$(echo "$reviews_json" | jq -r '
     .data.repository.pullRequest.comments.nodes[]
-    | "\(.id)\t\(if .author.login == $me then "[SELF]" elif .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)"' \
+    | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)"' \
     2>/dev/null || true)"
   emit_new "$fresh_top" "$seen_top_comments" "NEW_TOP_COMMENT"
 
-  fresh_reviews="$(echo "$reviews_json" | jq -r --arg me "$me" '
+  fresh_reviews="$(echo "$reviews_json" | jq -r '
     .data.repository.pullRequest.reviews.nodes[]
     | select(.state != "PENDING" and (.body // "") != "")
-    | "\(.id)\t\(if .author.login == $me then "[SELF]" elif .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)\t\(.state)"' \
+    | "\(.id)\t\(if .author.__typename == "Bot" then "[BOT]" else "[USER]" end) \(.author.login)\t\(.state)"' \
     2>/dev/null || true)"
   emit_new "$fresh_reviews" "$seen_reviews" "NEW_REVIEW"
 

--- a/bin/pr-monitor
+++ b/bin/pr-monitor
@@ -26,8 +26,7 @@
 # on anything but success.
 #
 # Comment and review events carry every author, the one `gh`
-# authenticates as included; `pr-reaction.md` decides what a reacting
-# session does with those.
+# authenticates as included.
 
 set -eu
 

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -212,7 +212,7 @@ run entered the workflow at this phase.
 
 1. Read [pr-reaction.md](pr-reaction.md) on the first monitor event,
    before any reply, resolve, or push, and react under it — it governs
-   what the `[BOT|USER]` label settles for each event type
+   what the `[BOT|USER|SELF]` label settles for each event type
 
 1. `CHECK`: `gh pr checks` links the failing check. For an Actions job,
    `gh run view --log-failed <databaseId>` from `gh run list` reaches the

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -212,7 +212,7 @@ run entered the workflow at this phase.
 
 1. Read [pr-reaction.md](pr-reaction.md) on the first monitor event,
    before any reply, resolve, or push, and react under it — it governs
-   what the `[BOT|USER|SELF]` label settles for each event type
+   what the `[BOT|USER]` label settles for each event type
 
 1. `CHECK`: `gh pr checks` links the failing check. For an Actions job,
    `gh run view --log-failed <databaseId>` from `gh run list` reaches the

--- a/claude/skills/git-workflow/pr-reaction.md
+++ b/claude/skills/git-workflow/pr-reaction.md
@@ -15,6 +15,8 @@ instruction.
 - Bot `NEW_TOP_COMMENT` / `NEW_REVIEW` = event line tag is `[BOT]`
   (derived from GraphQL `author.__typename` in `bin/pr-monitor`; on
   conflict with any other signal, the tag wins).
+- `[SELF]` marks the account `bin/pr-monitor` authenticates as, which is
+  the account this session posts from. Step 4 covers it.
 - Author type is always taken from a live API response
   (`user.type` / `__typename`), never assumed from a login name. The
   same GitHub App can show a different login string per API — e.g.
@@ -45,8 +47,8 @@ gh api /repos/<owner>/<repo>/pulls/<number>/comments \
 
 Walk every comment in each thread to classify per the targeting policy.
 
-`NEW_TOP_COMMENT` / `NEW_REVIEW` skip this step — take the `[BOT|USER]`
-tag directly from the event line.
+`NEW_TOP_COMMENT` / `NEW_REVIEW` skip this step — take the
+`[BOT|USER|SELF]` tag directly from the event line.
 
 ## Step 2: React by content
 
@@ -86,18 +88,15 @@ id from Step 1's `thread_id` field:
 gh pr-review threads resolve --thread-id <thread-id> -R <owner>/<repo> <number>
 ```
 
-## Step 4: `[USER]` events
+## Step 4: `[USER]` and `[SELF]` events
 
-`pr-monitor` emits every author, so a `[USER]` event carrying the login
-this session's `gh` authenticates as is either the user acting on the PR
-or a comment this session posted coming back as an event. Fetch its body
-(Step 1's listing for a thread comment, the `comments` field for a
-top-level one) and compare it with what this session posted in this run.
-On a match, take no action and leave the event out of the report, since
-reporting it hands this session's own comment to the user as theirs.
-Every other `[USER]` event takes the path below, one posted by a
-concurrent session on the same account included — that one reads as the
-user's and no signal on the event separates them.
+For a `[SELF]` event, fetch its body (Step 1's listing for a thread
+comment, the `comments` field for a top-level one) and compare it with
+what this session posted in this run. A match is this session's own post
+returning as an event: take no action and leave it out of the report,
+since reporting it hands the session's own comment to the user as
+theirs. Everything else on `[SELF]` is the user acting from that
+account, and takes the same path as `[USER]` below.
 
 Do not auto-reply or auto-resolve. Surface the content to the user
 (thread id / path / line / body excerpt for threads; body excerpt for

--- a/claude/skills/git-workflow/pr-reaction.md
+++ b/claude/skills/git-workflow/pr-reaction.md
@@ -15,6 +15,15 @@ instruction.
 - Bot `NEW_TOP_COMMENT` / `NEW_REVIEW` = event line tag is `[BOT]`
   (derived from GraphQL `author.__typename` in `bin/pr-monitor`; on
   conflict with any other signal, the tag wins).
+- `[SELF]` marks the account this session posts from, and wins over
+  `[BOT]`. An event on it whose body matches something this session
+  posted in this run is that post coming back: neither acted on nor
+  reported, since reporting presents the session's own post to the user
+  as incoming feedback.
+  - Match on the body, which no event line carries — take it from Step
+    1's listing, or re-fetch it for a top-level comment.
+  - Every other `[SELF]` event is the user acting, as is one the
+    session cannot match either way.
 - Author type is always taken from a live API response
   (`user.type` / `__typename`), never assumed from a login name. The
   same GitHub App can show a different login string per API — e.g.
@@ -92,10 +101,10 @@ Do not auto-reply or auto-resolve. Surface the content to the user
 (thread id / path / line / body excerpt for threads; body excerpt for
 top-level) and stop.
 
-A `[SELF]` event whose body matches something this session posted in
-this run is that post coming back, and is neither acted on nor
-reported — reporting it hands the session's own comment to the user as
-theirs.
+`[SELF]` marks the account this session posts from. An event on it whose
+body matches something this session posted in this run is that post
+coming back, and is neither acted on nor reported — reporting it hands
+the session's own comment to the user as theirs.
 
 If the user explicitly asks to reply, draft the text, wait for
 approval, then run the command. Resolution stays with the user.

--- a/claude/skills/git-workflow/pr-reaction.md
+++ b/claude/skills/git-workflow/pr-reaction.md
@@ -9,21 +9,23 @@ when the author is a bot. Never touch anything with a human author
 autonomously — summarize to the user and wait for an explicit
 instruction.
 
+- This session's own account is the login `gh api user --jq .login`
+  returns, read once on the first monitor event. An event authored by it
+  never takes the bot path, whatever its tag.
+  - Where its body matches something this session posted in this run, it
+    is that post coming back: neither acted on nor reported, since
+    reporting presents the session's own post to the user as incoming
+    feedback. Take the body from Step 1's listing, or re-fetch it for a
+    top-level comment; no event line carries it.
+  - Every other event on that login is the user acting, as is one the
+    session cannot match either way.
 - Bot thread = every comment in it has REST `user.type == "Bot"`. Any
   single `User`-type comment flips the thread to the human path — a
   bot can open a thread that a human later joins.
 - Bot `NEW_TOP_COMMENT` / `NEW_REVIEW` = event line tag is `[BOT]`
   (derived from GraphQL `author.__typename` in `bin/pr-monitor`; on
-  conflict with any other signal, the tag wins).
-- `[SELF]` marks the account this session posts from, and wins over
-  `[BOT]`. An event on it whose body matches something this session
-  posted in this run is that post coming back: neither acted on nor
-  reported, since reporting presents the session's own post to the user
-  as incoming feedback.
-  - Match on the body, which no event line carries — take it from Step
-    1's listing, or re-fetch it for a top-level comment.
-  - Every other `[SELF]` event is the user acting, as is one the
-    session cannot match either way.
+  conflict with any other signal, the tag wins), except on the account
+  above.
 - Author type is always taken from a live API response
   (`user.type` / `__typename`), never assumed from a login name. The
   same GitHub App can show a different login string per API — e.g.
@@ -54,8 +56,8 @@ gh api /repos/<owner>/<repo>/pulls/<number>/comments \
 
 Walk every comment in each thread to classify per the targeting policy.
 
-`NEW_TOP_COMMENT` / `NEW_REVIEW` skip this step — take the
-`[BOT|USER|SELF]` tag directly from the event line.
+`NEW_TOP_COMMENT` / `NEW_REVIEW` skip this step — take the `[BOT|USER]`
+tag directly from the event line.
 
 ## Step 2: React by content
 
@@ -95,7 +97,7 @@ id from Step 1's `thread_id` field:
 gh pr-review threads resolve --thread-id <thread-id> -R <owner>/<repo> <number>
 ```
 
-## Step 4: `[USER]` and `[SELF]` events
+## Step 4: Human-authored events
 
 Do not auto-reply or auto-resolve. Surface the content to the user
 (thread id / path / line / body excerpt for threads; body excerpt for

--- a/claude/skills/git-workflow/pr-reaction.md
+++ b/claude/skills/git-workflow/pr-reaction.md
@@ -101,11 +101,6 @@ Do not auto-reply or auto-resolve. Surface the content to the user
 (thread id / path / line / body excerpt for threads; body excerpt for
 top-level) and stop.
 
-`[SELF]` marks the account this session posts from. An event on it whose
-body matches something this session posted in this run is that post
-coming back, and is neither acted on nor reported — reporting it hands
-the session's own comment to the user as theirs.
-
 If the user explicitly asks to reply, draft the text, wait for
 approval, then run the command. Resolution stays with the user.
 

--- a/claude/skills/git-workflow/pr-reaction.md
+++ b/claude/skills/git-workflow/pr-reaction.md
@@ -7,24 +7,14 @@ How to react to PR events emitted by `bin/pr-monitor`.
 Reply / resolve threads and reply to top-level comments / reviews only
 when the author is a bot. Never touch anything with a human author
 autonomously — summarize to the user and wait for an explicit
-instruction, except the session's own echo below.
+instruction.
 
 - This session's own account is the login `gh api user --jq .login`
-  returns, read once on the first monitor event and compared against
-  `author.login` — an identity check, separate from the author-type
-  rules below. An event authored by it never takes the bot path,
-  whatever its tag.
-  - Where its body is one this session posted verbatim in this run, it
-    is that post coming back: neither acted on nor reported, since
-    reporting presents the session's own post to the user as incoming
-    feedback. The match runs on the body the step for that event type
-    fetches.
-  - Every other event on that login is the user acting, as is one the
-    session cannot match either way.
+  returns, read once on the first monitor event. Events on it are the
+  owner acting on the PR, and the session's own posts coming back.
 - Bot thread = every comment in it has REST `user.type == "Bot"`. Any
-  single `User`-type comment other than the account above flips the
-  thread to the human path — a bot can open a thread that a human later
-  joins.
+  single `User`-type comment flips the thread to the human path — a
+  bot can open a thread that a human later joins.
 - Bot `NEW_TOP_COMMENT` / `NEW_REVIEW` = event line tag is `[BOT]`
   (derived from GraphQL `author.__typename` in `bin/pr-monitor`; on
   conflict with any other signal, the tag wins).
@@ -59,8 +49,7 @@ gh api /repos/<owner>/<repo>/pulls/<number>/comments \
 Walk every comment in each thread to classify per the targeting policy.
 
 `NEW_TOP_COMMENT` / `NEW_REVIEW` skip this step — take the `[BOT|USER]`
-tag and the author login directly from the event line, the login being
-what the targeting policy's own-account check runs on.
+tag directly from the event line.
 
 ## Step 2: React by content
 
@@ -104,8 +93,7 @@ gh pr-review threads resolve --thread-id <thread-id> -R <owner>/<repo> <number>
 
 Do not auto-reply or auto-resolve. Surface the content to the user
 (thread id / path / line / body excerpt for threads; body excerpt for
-top-level) and stop, unless the targeting policy reads the event as this
-session's own echo, which is dropped unsurfaced.
+top-level) and stop.
 
 If the user explicitly asks to reply, draft the text, wait for
 approval, then run the command. Resolution stays with the user.

--- a/claude/skills/git-workflow/pr-reaction.md
+++ b/claude/skills/git-workflow/pr-reaction.md
@@ -86,7 +86,18 @@ id from Step 1's `thread_id` field:
 gh pr-review threads resolve --thread-id <thread-id> -R <owner>/<repo> <number>
 ```
 
-## Step 4: Human-authored events
+## Step 4: `[USER]` events
+
+`pr-monitor` emits every author, so a `[USER]` event carrying the login
+this session's `gh` authenticates as is either the user acting on the PR
+or a comment this session posted coming back as an event. Fetch its body
+(Step 1's listing for a thread comment, the `comments` field for a
+top-level one) and compare it with what this session posted in this run.
+On a match, take no action and leave the event out of the report, since
+reporting it hands this session's own comment to the user as theirs.
+Every other `[USER]` event takes the path below, one posted by a
+concurrent session on the same account included — that one reads as the
+user's and no signal on the event separates them.
 
 Do not auto-reply or auto-resolve. Surface the content to the user
 (thread id / path / line / body excerpt for threads; body excerpt for

--- a/claude/skills/git-workflow/pr-reaction.md
+++ b/claude/skills/git-workflow/pr-reaction.md
@@ -7,25 +7,27 @@ How to react to PR events emitted by `bin/pr-monitor`.
 Reply / resolve threads and reply to top-level comments / reviews only
 when the author is a bot. Never touch anything with a human author
 autonomously — summarize to the user and wait for an explicit
-instruction.
+instruction, except the session's own echo below.
 
 - This session's own account is the login `gh api user --jq .login`
-  returns, read once on the first monitor event. An event authored by it
-  never takes the bot path, whatever its tag.
-  - Where its body matches something this session posted in this run, it
+  returns, read once on the first monitor event and compared against
+  `author.login` — an identity check, separate from the author-type
+  rules below. An event authored by it never takes the bot path,
+  whatever its tag.
+  - Where its body is one this session posted verbatim in this run, it
     is that post coming back: neither acted on nor reported, since
     reporting presents the session's own post to the user as incoming
-    feedback. Take the body from Step 1's listing, or re-fetch it for a
-    top-level comment; no event line carries it.
+    feedback. The match runs on the body the step for that event type
+    fetches.
   - Every other event on that login is the user acting, as is one the
     session cannot match either way.
 - Bot thread = every comment in it has REST `user.type == "Bot"`. Any
-  single `User`-type comment flips the thread to the human path — a
-  bot can open a thread that a human later joins.
+  single `User`-type comment other than the account above flips the
+  thread to the human path — a bot can open a thread that a human later
+  joins.
 - Bot `NEW_TOP_COMMENT` / `NEW_REVIEW` = event line tag is `[BOT]`
   (derived from GraphQL `author.__typename` in `bin/pr-monitor`; on
-  conflict with any other signal, the tag wins), except on the account
-  above.
+  conflict with any other signal, the tag wins).
 - Author type is always taken from a live API response
   (`user.type` / `__typename`), never assumed from a login name. The
   same GitHub App can show a different login string per API — e.g.
@@ -57,7 +59,8 @@ gh api /repos/<owner>/<repo>/pulls/<number>/comments \
 Walk every comment in each thread to classify per the targeting policy.
 
 `NEW_TOP_COMMENT` / `NEW_REVIEW` skip this step — take the `[BOT|USER]`
-tag directly from the event line.
+tag and the author login directly from the event line, the login being
+what the targeting policy's own-account check runs on.
 
 ## Step 2: React by content
 
@@ -101,7 +104,8 @@ gh pr-review threads resolve --thread-id <thread-id> -R <owner>/<repo> <number>
 
 Do not auto-reply or auto-resolve. Surface the content to the user
 (thread id / path / line / body excerpt for threads; body excerpt for
-top-level) and stop.
+top-level) and stop, unless the targeting policy reads the event as this
+session's own echo, which is dropped unsurfaced.
 
 If the user explicitly asks to reply, draft the text, wait for
 approval, then run the command. Resolution stays with the user.
@@ -113,8 +117,8 @@ approval, then run the command. Resolution stays with the user.
   when later comments include a human.
 - Posting a top-level `gh pr comment` in place of a review-thread
   reply to bypass the bot-check.
-- Classifying an author from a remembered login string instead of a
-  live `user.type` / `__typename` lookup.
+- Classifying an author's type from a remembered login string instead
+  of a live `user.type` / `__typename` lookup.
 
 ## References
 

--- a/claude/skills/git-workflow/pr-reaction.md
+++ b/claude/skills/git-workflow/pr-reaction.md
@@ -15,8 +15,6 @@ instruction.
 - Bot `NEW_TOP_COMMENT` / `NEW_REVIEW` = event line tag is `[BOT]`
   (derived from GraphQL `author.__typename` in `bin/pr-monitor`; on
   conflict with any other signal, the tag wins).
-- `[SELF]` marks the account `bin/pr-monitor` authenticates as, which is
-  the account this session posts from. Step 4 covers it.
 - Author type is always taken from a live API response
   (`user.type` / `__typename`), never assumed from a login name. The
   same GitHub App can show a different login string per API — e.g.
@@ -90,17 +88,14 @@ gh pr-review threads resolve --thread-id <thread-id> -R <owner>/<repo> <number>
 
 ## Step 4: `[USER]` and `[SELF]` events
 
-For a `[SELF]` event, fetch its body (Step 1's listing for a thread
-comment, the `comments` field for a top-level one) and compare it with
-what this session posted in this run. A match is this session's own post
-returning as an event: take no action and leave it out of the report,
-since reporting it hands the session's own comment to the user as
-theirs. Everything else on `[SELF]` is the user acting from that
-account, and takes the same path as `[USER]` below.
-
 Do not auto-reply or auto-resolve. Surface the content to the user
 (thread id / path / line / body excerpt for threads; body excerpt for
 top-level) and stop.
+
+A `[SELF]` event whose body matches something this session posted in
+this run is that post coming back, and is neither acted on nor
+reported — reporting it hands the session's own comment to the user as
+theirs.
 
 If the user explicitly asks to reply, draft the text, wait for
 approval, then run the command. Resolution stays with the user.


### PR DESCRIPTION
## Purpose

`pr-monitor` decided which comments and reviews to emit by author, dropping everything posted by the account `gh` authenticates as. That account is the repository owner's own, so a comment, review, or thread reply the owner posted on a watched PR never reached the reader — the watching session stayed silent through an action it should have known about.

## Key changes

Every author reaches the reader, and the reaction rule names the login the reacting session posts from so it can tell the owner's account apart, rather than the monitor filtering on it.

## Notes

A reply the session itself posts under that account also comes back as an event, and the steps surface it to the user like any other human-authored one. Nothing suppresses it: the session holds its own posts in context and judges the case when it arrives, which is where this stops rather than growing a rule for the session to recognise its own text.

## Verification

- [x] `shellcheck bin/pr-monitor` → no output, exit 0
- [x] Each of the three jq programs run against a fixture holding the authenticated login, another user, and a bot emits a line for every one of them:

```
NEW_COMMENT: [USER] ikuwow bin/pr-monitor:63
NEW_COMMENT: [USER] octocat bin/pr-monitor:70
NEW_COMMENT: [BOT] devin-ai-integration bin/pr-monitor:80
NEW_TOP_COMMENT: [USER] ikuwow
NEW_TOP_COMMENT: [USER] octocat
NEW_REVIEW: [USER] ikuwow COMMENTED
NEW_REVIEW: [USER] octocat APPROVED
```

- [x] `gh api user --jq .login` → `ikuwow`, the lookup the rule names
- [ ] The Phase 5 Monitor on this PR runs `pr-monitor` through the `~/bin` symlink to this branch's file, so a comment posted on this PR exercises the change end to end — requires the PR to be watched while a comment lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEprXLVTxJP34oetKJ122n
