### PR TITLE
Rename create-pull-request to pr-issue-writing and give issues their own criteria

### DIFF
--- a/claude/rules/git-essentials.md
+++ b/claude/rules/git-essentials.md
@@ -44,6 +44,6 @@ NOT restate the detailed procedures from the skill.
 
 ## PR / issue body edits
 
-- Invoke `Skill(create-pull-request)` before writing or editing a PR or
+- Invoke `Skill(pr-issue-writing)` before writing or editing a PR or
   issue title or body, including a `gh pr edit` / `gh issue edit` run
   outside the git workflow

--- a/claude/skills/git-workflow/SKILL.md
+++ b/claude/skills/git-workflow/SKILL.md
@@ -91,7 +91,7 @@ For a PR the implementer opened, read
 [implementer-dispatch.md](implementer-dispatch.md) first and apply its
 `When it returns` steps, since the body it left is a placeholder.
 
-Then invoke the `create-pull-request` skill, which carries the
+Then invoke the `pr-issue-writing` skill, which carries the
 properties a title and body are judged against and the commands that
 write them. This holds wherever the workflow writes or edits a title or
 body, including the Phase 4 updates.

--- a/claude/skills/pr-issue-writing/SKILL.md
+++ b/claude/skills/pr-issue-writing/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: create-pull-request
-description: Write or edit the title and body of a pull request or an issue, and create a PR. Carries the five properties a PR body is judged against (Decidable, Grounded, Necessary, Scoped, Conformant), the body template, and the commands for creating a draft PR and for editing a PR or issue body safely. Invoke before writing a PR title or body, before editing one, before writing an issue body, and when bringing an existing PR into conformance.
+name: pr-issue-writing
+description: Write or edit the title and body of a pull request or an issue, and create either. Carries the five properties a body is judged against (Decidable, Grounded, Necessary, Scoped, Conformant) and which of them an issue body is held to, the PR body template, and the commands for creating a draft PR or an issue and for editing a title or body safely. Invoke before writing a PR or issue title or body, before editing one, and when bringing an existing PR into conformance.
 ---
 
-# Create a Pull Request
+# Write a Pull Request or Issue
 
-Writing a PR title or body, editing one, and writing an issue body all
-run through here.
+Writing or editing the title or body of a PR or an issue runs through
+here.
 
 Read [properties.md](properties.md) for the five properties a body is
 judged against and the template to write into. Invoke the
@@ -33,6 +33,17 @@ The branch exists, carries the commits, and is pushed before this runs.
    `gh pr create --draft --body-file <body file path>`
 1. Display the PR URL: `gh pr view --json url --jq '.url'`
 
+## Create an issue
+
+1. Write the body to a fresh file under the session scratchpad
+   directory using the Write tool, a new filename per revision. Do not
+   generate a temp filename, and do not Read a file that does not exist
+   yet
+   - Follow the repository's issue template when one exists
+1. Create the issue:
+   `gh issue create --title '...' --body-file <body file path>`
+1. Display the issue URL, which `gh issue create` prints to stdout
+
 ## Update an existing title or body
 
 Summarize the change in the assistant message body before either edit
@@ -40,6 +51,7 @@ below, as a short list of what is being added, removed, or reworded
 rather than the full before-and-after.
 
 - Update a title: `gh pr edit <number> --title '...'`
+  (`gh issue edit <number> --title '...'` for an issue)
 - Update a body:
   1. Fetch the current one:
      `gh pr view <number> --json body --jq .body`

--- a/claude/skills/pr-issue-writing/SKILL.md
+++ b/claude/skills/pr-issue-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-issue-writing
-description: Write or edit the title and body of a pull request or an issue, and create either. Carries the five properties a body is judged against (Decidable, Grounded, Necessary, Scoped, Conformant) and which of them an issue body is held to, the PR body template, and the commands for creating a draft PR or an issue and for editing a title or body safely. Invoke before writing a PR or issue title or body, before editing one, and when bringing an existing PR into conformance.
+description: Write or edit the title and body of a pull request or an issue, and create either. Carries the five properties a PR body is judged against (Decidable, Grounded, Necessary, Scoped, Conformant), the criteria an issue body is judged against, the PR body template, and the commands for creating a draft PR or an issue and for editing a title or body safely. Invoke before writing a PR or issue title or body, before editing one, and when bringing an existing PR into conformance.
 ---
 
 # Write a Pull Request or Issue
@@ -8,8 +8,9 @@ description: Write or edit the title and body of a pull request or an issue, and
 Writing or editing the title or body of a PR or an issue runs through
 here.
 
-Read [properties.md](properties.md) for the five properties a body is
-judged against and the template to write into. Invoke the
+For a PR, read [properties.md](properties.md) for the five properties
+its body is judged against and the template to write into. For an
+issue, read [issue-body.md](issue-body.md) instead. Invoke the
 `technical-writing` skill for how the prose itself is built.
 
 Pass a body through `--body-file` and never `--body`, on creation and on

--- a/claude/skills/pr-issue-writing/issue-body.md
+++ b/claude/skills/pr-issue-writing/issue-body.md
@@ -2,7 +2,9 @@
 
 Criteria for the title and body of a GitHub issue. An issue has no diff
 behind it, so its body is the whole record: a reader who opens it
-decides from the body alone whether and how to act on it.
+decides from the body alone whether and how to act on it. A security
+vulnerability goes through the repository's private reporting channel
+instead, since an issue may be public.
 
 The repository's issue template, when one exists, sets the sections and
 their order, and the content below goes into them. Otherwise a skill
@@ -24,7 +26,8 @@ body carries the content below in the order listed.
 - Quote the part of the evidence the issue rests on (an error message,
   a log line, a measurement) in the body, even when a link holds the
   rest, since the link may expire
-  - Remove credentials and other secrets from what is quoted
+- Keep credentials, personal data, and customer identifiers out of the
+  body, including what it quotes, since an issue may be public
 - List what closes the issue, where it is already known, as `- [ ]`
   items
 - Write every sentence so it reads without the chat session or the plan

--- a/claude/skills/pr-issue-writing/issue-body.md
+++ b/claude/skills/pr-issue-writing/issue-body.md
@@ -4,49 +4,53 @@ Criteria for the title and body of a GitHub issue. An issue has no diff
 behind it, so its body is the whole record: a reader who opens it
 decides from the body alone whether and how to act on it.
 
-The repository's issue template, when one exists, sets the sections.
-Otherwise a skill that prescribes the issue's format sets them, and
-failing both, the body follows the order of the first list below.
+The repository's issue template, when one exists, sets the sections and
+their order, and the content below goes into them. Otherwise a skill
+that prescribes the issue's format sets them, and failing both, the
+body carries the content below in the order listed.
 
 ## What the body carries
 
-- Open with the problem or the request in one or two sentences, so the
-  first lines tell a reader what the issue asks for
-- For a problem, give the symptom, the steps that reproduce it, and the
-  expected and actual behavior
-- For a request, give what is wanted and the need behind it
+- State the problem or the request in one or two sentences before the
+  detail that supports it
+- Give what a reader needs to act: what is wrong or wanted, and why it
+  matters
+  - Where the problem reproduces, include the steps and the expected and
+    actual behavior
 - Where the issue asks the reader to choose between approaches, lay out
   each option with its tradeoff
-- Keep the investigation that led to the issue: what was checked, what
+- Where an investigation led to the issue, keep what was checked, what
   it showed, and what remains open
-- Carry the evidence the issue rests on (an error message, a log
-  excerpt, a measurement, reproduction output) in the body, even when a
-  link also holds it, since the link may expire
-- List what closes the issue, its tasks or acceptance criteria, as
-  `- [ ]` items, and tick each one done as `- [x]`
-- Keep references to the chat session and to plan-mode phases out,
-  since a reader of the issue cannot see them
+- Quote the part of the evidence the issue rests on (an error message,
+  a log line, a measurement) in the body, even when a link holds the
+  rest, since the link may expire
+  - Remove credentials and other secrets from what is quoted
+- List what closes the issue, where it is already known, as `- [ ]`
+  items
+- Write every sentence so it reads without the chat session or the plan
+  that produced it, since a reader of the issue has seen neither
 
 ## Grounding
 
-- State a cause not yet established as a hypothesis, with the evidence
-  that points to it
-- Back a claim about how an external tool or service behaves with a
+- A claim about how an external tool or service behaves carries a
   primary source (official documentation, a man page section, `--help`
-  output) or with reproduction output that shows the behavior
+  output) or reproduction output that shows it
+  - Without either, and for any cause not yet established, state it as
+    a hypothesis with the evidence that points to it
 - Show the query and the scope behind a negative or absence claim ("no
   X remains")
-- Check that every URL resolves to the content it is cited for
-- Summarize background that lives elsewhere (another issue, a PR, a
-  design document) under its link, in the shortest form that survives
-  the link going dead
+- Check that every URL the writer can open resolves to the content it
+  is cited for
+- Summarize context that lives elsewhere (another issue, a PR, a design
+  document) under its link, in the shortest form that survives the link
+  going dead
 
 ## Form
 
 - The title is a one-line summary of the problem or request, and issue
   references and other detail go in the body
-- The language follows the target repository: its `CLAUDE.md` or
-  `AGENTS.md` first, otherwise its existing issues
+- The language follows the target repository's own rule when it states
+  one, otherwise its existing issues
 - Write each paragraph and each list item as a single line, with a
   blank line between paragraphs, since GitHub renders a line break
   inside an issue body as a visible break

--- a/claude/skills/pr-issue-writing/issue-body.md
+++ b/claude/skills/pr-issue-writing/issue-body.md
@@ -1,0 +1,55 @@
+# What an issue body holds
+
+Criteria for the title and body of a GitHub issue. An issue has no diff
+behind it, so its body is the whole record: a reader who opens it
+decides from the body alone whether and how to act on it.
+
+The repository's issue template, when one exists, sets the sections.
+Otherwise a skill that prescribes the issue's format sets them, and
+failing both, the body follows the order of the first list below.
+
+## What the body carries
+
+- Open with the problem or the request in one or two sentences, so the
+  first lines tell a reader what the issue asks for
+- For a problem, give the symptom, the steps that reproduce it, and the
+  expected and actual behavior
+- For a request, give what is wanted and the need behind it
+- Where the issue asks the reader to choose between approaches, lay out
+  each option with its tradeoff
+- Keep the investigation that led to the issue: what was checked, what
+  it showed, and what remains open
+- Carry the evidence the issue rests on (an error message, a log
+  excerpt, a measurement, reproduction output) in the body, even when a
+  link also holds it, since the link may expire
+- List what closes the issue, its tasks or acceptance criteria, as
+  `- [ ]` items, and tick each one done as `- [x]`
+- Keep references to the chat session and to plan-mode phases out,
+  since a reader of the issue cannot see them
+
+## Grounding
+
+- State a cause not yet established as a hypothesis, with the evidence
+  that points to it
+- Back a claim about how an external tool or service behaves with a
+  primary source (official documentation, a man page section, `--help`
+  output) or with reproduction output that shows the behavior
+- Show the query and the scope behind a negative or absence claim ("no
+  X remains")
+- Check that every URL resolves to the content it is cited for
+- Summarize background that lives elsewhere (another issue, a PR, a
+  design document) under its link, in the shortest form that survives
+  the link going dead
+
+## Form
+
+- The title is a one-line summary of the problem or request, and issue
+  references and other detail go in the body
+- The language follows the target repository: its `CLAUDE.md` or
+  `AGENTS.md` first, otherwise its existing issues
+- Write each paragraph and each list item as a single line, with a
+  blank line between paragraphs, since GitHub renders a line break
+  inside an issue body as a visible break
+- Put one claim in each list item, and nest what supports a claim under
+  it
+- Give each table a lead-in saying what it shows

--- a/claude/skills/pr-issue-writing/properties.md
+++ b/claude/skills/pr-issue-writing/properties.md
@@ -1,18 +1,26 @@
-# The properties a PR body holds
+# The properties a PR or issue body holds
 
-Quality criteria for pull requests. Follow these when writing a PR body
-and when self-reviewing your own PR.
+Quality criteria for pull request and issue bodies. Follow these when
+writing a PR or issue body and when self-reviewing your own PR.
 
 A PR body is a summary that helps a reviewer decide, not a complete
 record of the change: everything else lives in the diff, the issue, or
 a linked source. It serves two audiences — the reviewer deciding now,
 and the future reader who reaches this PR from `git log` or blame.
 
-The diff is the default carrier: the body adds what the diff cannot
-state and what a reader would not derive from it. No rule under
+In a PR, the diff is the default carrier: the body adds what the diff
+cannot state and what a reader would not derive from it. No rule under
 Decidable or Scoped is discharged by writing more, and none asks for a
 section the diff's own content would fill. The shortest body that
 leaves a reviewer able to decide is the correct one.
+
+An issue has no diff behind it, so its body is the record itself. Read
+the rules below for an issue with "the change" meaning the problem or
+request the issue raises, and "the reviewer" meaning the reader deciding
+whether and how to act on it. A rule marked `(PR only)` does not apply
+to an issue body. The issue's structure comes from the repository's
+issue template, or from the skill that prescribes the issue's format
+when one does.
 
 A body is ready when it holds all five properties below. Every rule in
 the five property sections belongs to exactly one of them, and within a
@@ -23,17 +31,17 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   what the change is for and where their attention belongs, each item
   carrying one claim at the shortest length that lands it
 - Grounded — every claim is checkable on the evidence the body itself
-  carries, and the body names a verification mechanism for the code
+  carries, and a PR body names a verification mechanism for the code
   paths the diff changes
 - Necessary — read each line of the body for where else its content
   already lives, and the body carries nothing the diff, its commits,
   the PR page or an automation's output carry, states each thing once,
   and takes from a linked source no more than the summary that survives
   the link going dead
-- Scoped — the diff read against the body carries only what the stated
-  intent needs and nothing the body did not lead the reader to expect,
-  and the body conveys the change as a whole: a boundary the reader
-  would not assume, and what it leaves to the parent issue
+- Scoped `(PR only)` — the diff read against the body carries only what
+  the stated intent needs and nothing the body did not lead the reader
+  to expect, and the body conveys the change as a whole: a boundary the
+  reader would not assume, and what it leaves to the parent issue
 - Conformant — the body renders and behaves as intended on GitHub
 
 ## Decidable
@@ -43,16 +51,16 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   could not conclude, the request, the obligation that came due
   - The changed lines are the diff's to show, so the body names the
     change rather than describing it
-- Where a design decision was weighed, the body carries its shape: the
-  approach taken against the approaches rejected, and risks or things a
-  reviewer should watch out for
+- `(PR only)` Where a design decision was weighed, the body carries its
+  shape: the approach taken against the approaches rejected, and risks
+  or things a reviewer should watch out for
   - A change with one obvious approach carries none of this, and
     inventing an alternative to name is itself a defect
   - "Approaches rejected" covers design alternatives weighed for the
     delivered design
-- Where the diff changes something other code reaches — a function
-  signature, a config key, an exit code, a file another script reads —
-  name the invariant it still holds
+- `(PR only)` Where the diff changes something other code reaches — a
+  function signature, a config key, an exit code, a file another script
+  reads — name the invariant it still holds
 - Inverted pyramid — place the most important information first
   - A reviewer reading only the first few lines can tell what kind of
     PR this is and where to focus
@@ -108,25 +116,25 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 
 ## Grounded
 
-- Attempt every verification within reach before drafting the
-  Verification section: shell commands, API calls, file inspection,
+- `(PR only)` Attempt every verification within reach before drafting
+  the Verification section: shell commands, API calls, file inspection,
   mocked failure modes, simulated missing-config tests
   - Punting a reachable item to "Pending" or "User to verify" violates
     this rule
   - Overstating what is "untestable" is the common failure mode
-- List only items actually verified, each carrying its evidence: a
-  command, output excerpt, exit code, or log line
+- `(PR only)` List only items actually verified, each carrying its
+  evidence: a command, output excerpt, exit code, or log line
   - Evidence carried in a code block or sub-bullet attached to the item
     counts as evidence the item carries
   - When the item covers documentation or prose and no command applies,
     name what it was checked against (the source, the spec, the linked
     issue)
-- Items that genuinely require interactive UI, user-only credentials,
-  target environments unreachable from a shell, or the live session
-  itself must be clearly distinguished with reproduction steps and a
-  one-line reason why the author could not verify them
-- The body names a verification mechanism — CI, manual test steps, or
-  another check — for the code paths the diff changes
+- `(PR only)` Items that genuinely require interactive UI, user-only
+  credentials, target environments unreachable from a shell, or the live
+  session itself must be clearly distinguished with reproduction steps
+  and a one-line reason why the author could not verify them
+- `(PR only)` The body names a verification mechanism — CI, manual test
+  steps, or another check — for the code paths the diff changes
   - The test is whether the body makes that claim
   - Judging how adequate the coverage is belongs to code review
 - A negative or absence claim ("no X remains", "該当なし") shows the
@@ -188,7 +196,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - A line the walk lands on is a finding whether or not a rule below
     names it, and the rules below reach lines answering `nowhere` that
     the walk does not
-- Do not paraphrase the diff
+- `(PR only)` Do not paraphrase the diff
   - Keep out file lists, per-file summaries, figures derived from the
     diff's size such as the percentage of lines removed, and
     enumerations of added rules, linters, settings, constants, or values
@@ -203,16 +211,17 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     reviewer can open; spelling out what an added rule, definition, or
     table row says is detail, whether quoted, summarized, or given with
     its consequence
-- Keep CI, lint, formatter, type-check, and build / test command
-  results (`go build`, `go test`, `go vet`, `pre-commit`) out of the
-  body
+- `(PR only)` Keep CI, lint, formatter, type-check, and build / test
+  command results (`go build`, `go test`, `go vet`, `pre-commit`) out of
+  the body
   - This holds whether or not the repository's CI runs them
   - Output that CI or another automation posts on the PR itself (build
     status, terraform / CDK plan output, lint and type-check results)
     stays where it was posted, and the body does not restate it
-- Focus on what changes from the user's or system's perspective —
-  behavior changes, new capabilities, removed limitations — rather than
-  on implementation details (resources added, files touched)
+- `(PR only)` Focus on what changes from the user's or system's
+  perspective — behavior changes, new capabilities, removed limitations
+  — rather than on implementation details (resources added, files
+  touched)
 - The body records the delivered design, not the path to it
   - Keep out chronological narration of implementation attempts ("first
     tried X, it failed, so Y") and records of direction changes made
@@ -223,14 +232,17 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Keep out rejected alternatives described at implementation-attempt
     granularity, and alternatives a reviewer would not arrive at and
     ask about
+  - In an issue body, the investigation that led to the problem or
+    request is content, and only the references to the session and to
+    plan-mode phases stay out
 - State a fact once
   - The same environment variable name, file name, design decision, or
     summary of a linked source does not appear in two places in the
     body
   - Two bullets in one list saying the same thing in different wording
     are one fact stated twice
-- Each bullet conveys a distinct decision or outcome, not an individual
-  code change
+- `(PR only)` Each bullet conveys a distinct decision or outcome, not an
+  individual code change
 - Rationale, background, or requirements that live elsewhere (issue,
   design doc, ADR, prior PR, official spec) are summarized under a
   link, not copied
@@ -238,11 +250,11 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     survives the link going dead, naming what this change rests on
     from that source
   - Anything past that shortest summary is duplication
-- When the diff is self-explanatory — documentation or config edits
-  whose changed lines a reviewer can read directly, especially in the
-  team's own language — the body keeps to what the diff cannot convey,
-  and neither Decidable nor Scoped asks for a rationale or boundary
-  beyond that
+- `(PR only)` When the diff is self-explanatory — documentation or
+  config edits whose changed lines a reviewer can read directly,
+  especially in the team's own language — the body keeps to what the
+  diff cannot convey, and neither Decidable nor Scoped asks for a
+  rationale or boundary beyond that
   - When nothing remains to add, one line such as "realigned stale
     wording with the actual code/config" is a complete description
   - Apply this rule before the others in this section, so what it
@@ -256,7 +268,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Raw length, and the ratio of body size to diff size, are never
     findings on their own
 
-## Scoped
+## Scoped `(PR only)`
 
 - Where the change stops short of what its intent would lead a reader
   to expect, the body says so; a boundary the reader would assume needs
@@ -307,6 +319,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - `- [ ]` carrying a one-line reason marks an author-owed item that
     Grounded exempts as unverifiable by the author
   - Prose statements do not take a checkbox
+  - In an issue body, `- [ ]` also marks a task or acceptance criterion
+    the issue asks for
 - Inside GitHub issues, pull requests, and discussions — bodies and
   comments alike, that is Markdown posted through the GitHub web UI —
   do not hard-wrap paragraphs or list items
@@ -319,7 +333,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     and any other in-repo documentation) follow standard Markdown
     rendering and may be hard-wrapped for file-side readability
 
-## Worked example: a minimal body
+## Worked example: a minimal PR body
 
 A design document gains a retry on one forwarding hop, and the sending
 side's request spec, until then split across two places, is gathered
@@ -340,7 +354,7 @@ the edits carrying it out, and the reviewer reads those in the diff.
 
 ## PR Body Template (fallback)
 
-Use this scaffold when the target repository has no `pull_request_template.md`.
+Use this scaffold for a PR body when the target repository has no `pull_request_template.md`. An issue body does not use it.
 Repository templates always win — do not overlay this on top of one.
 Section names stay English; body language follows the repo (see
 Conformant above). Purpose / Key changes / Verification is the minimum.

--- a/claude/skills/pr-issue-writing/properties.md
+++ b/claude/skills/pr-issue-writing/properties.md
@@ -1,30 +1,20 @@
-# The properties a PR or issue body holds
+# The properties a PR body holds
 
-Quality criteria for pull request and issue bodies. Follow these when
-writing a PR or issue body and when self-reviewing your own PR.
+Quality criteria for pull requests. Follow these when writing a PR body
+and when self-reviewing your own PR.
 
 A PR body is a summary that helps a reviewer decide, not a complete
 record of the change: everything else lives in the diff, the issue, or
 a linked source. It serves two audiences — the reviewer deciding now,
 and the future reader who reaches this PR from `git log` or blame.
 
-In a PR, the diff is the default carrier: the body adds what the diff
-cannot state and what a reader would not derive from it. No rule under
+The diff is the default carrier: the body adds what the diff cannot
+state and what a reader would not derive from it. No rule under
 Decidable or Scoped is discharged by writing more, and none asks for a
 section the diff's own content would fill. The shortest body that
 leaves a reviewer able to decide is the correct one.
 
-An issue has no diff behind it, so its body is the record itself. Read
-the rules below for an issue with "the change" meaning the problem or
-request the issue raises, and "the reviewer" meaning the reader deciding
-whether and how to act on it. A rule or a qualifier marked `(PR only)`
-does not apply to an issue body. The issue's structure comes from the
-repository's issue template, or from the skill that prescribes the
-issue's format when one does; otherwise the body leads with the problem
-or request and follows with what a reader needs to act on it.
-
-A PR body is ready when it holds all five properties below, and an issue
-body when it holds the four other than Scoped. Every rule in
+A body is ready when it holds all five properties below. Every rule in
 the five property sections belongs to exactly one of them, and within a
 section the top-level line is the rule while the lines beneath it
 qualify it. `/pr-selfcheck` evaluates the properties one at a time.
@@ -33,17 +23,17 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   what the change is for and where their attention belongs, each item
   carrying one claim at the shortest length that lands it
 - Grounded — every claim is checkable on the evidence the body itself
-  carries, and a PR body names a verification mechanism for the code
+  carries, and the body names a verification mechanism for the code
   paths the diff changes
 - Necessary — read each line of the body for where else its content
   already lives, and the body carries nothing the diff, its commits,
   the PR page or an automation's output carry, states each thing once,
   and takes from a linked source no more than the summary that survives
   the link going dead
-- Scoped `(PR only)` — the diff read against the body carries only what
-  the stated intent needs and nothing the body did not lead the reader
-  to expect, and the body conveys the change as a whole: a boundary the
-  reader would not assume, and what it leaves to the parent issue
+- Scoped — the diff read against the body carries only what the stated
+  intent needs and nothing the body did not lead the reader to expect,
+  and the body conveys the change as a whole: a boundary the reader
+  would not assume, and what it leaves to the parent issue
 - Conformant — the body renders and behaves as intended on GitHub
 
 ## Decidable
@@ -51,21 +41,18 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - Name the change in one sentence, and add what prompted it now where
   the diff does not show it — the incident, the investigation that
   could not conclude, the request, the obligation that came due
-  - `(PR only)` The changed lines are the diff's to show, so the body
-    names the change rather than describing it
-  - An issue body describes the problem, since no diff shows it: the
-    symptom, how to reproduce it, and the expected and actual behavior,
-    or for a request, what is wanted and why
-- `(PR only)` Where a design decision was weighed, the body carries its
-  shape: the approach taken against the approaches rejected, and risks
-  or things a reviewer should watch out for
+  - The changed lines are the diff's to show, so the body names the
+    change rather than describing it
+- Where a design decision was weighed, the body carries its shape: the
+  approach taken against the approaches rejected, and risks or things a
+  reviewer should watch out for
   - A change with one obvious approach carries none of this, and
     inventing an alternative to name is itself a defect
   - "Approaches rejected" covers design alternatives weighed for the
     delivered design
-- `(PR only)` Where the diff changes something other code reaches — a
-  function signature, a config key, an exit code, a file another script
-  reads — name the invariant it still holds
+- Where the diff changes something other code reaches — a function
+  signature, a config key, an exit code, a file another script reads —
+  name the invariant it still holds
 - Inverted pyramid — place the most important information first
   - A reviewer reading only the first few lines can tell what kind of
     PR this is and where to focus
@@ -75,18 +62,14 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     full alternatives narrative — moves behind a link, into a "Notes" /
     "Background" section at the end, or into the review thread when the
     question comes
-  - In an issue body, the evidence the problem rests on — an error
-    message, a measurement, reproduction output — is what the reader
-    needs, and stays in the body
   - A decision a linked source delegates to this PR is stated as the
     value and what bounds it, the derivation being material of that
     kind
-- `(PR only)` The body's structure comes from the decisions the change
-  carries, not from the shape of the diff. A subheading or top-level
-  bullet standing for one hunk, one file, or one edited section of a
-  document is a defect, and a change carrying a single decision is
-  described in one paragraph under whichever section the template puts
-  it in
+- The body's structure comes from the decisions the change carries, not
+  from the shape of the diff. A subheading or top-level bullet standing
+  for one hunk, one file, or one edited section of a document is a
+  defect, and a change carrying a single decision is described in one
+  paragraph under whichever section the template puts it in
   - A structure a reader could reconstruct from the diff's file list or
     hunk boundaries alone tells the reviewer nothing about where their
     attention belongs
@@ -111,9 +94,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     kind — reasons, rejected alternatives, caveats, options — is a
     finding, and the items belong in a list, one per line
     - A single claim carrying its own qualifier stays prose
-- `(PR only)` Future work, out-of-scope follow-ups, and "next PR" notes
-  belong at the end of the body (e.g., in a "Follow-up" / "Notes"
-  section)
+- Future work, out-of-scope follow-ups, and "next PR" notes belong at
+  the end of the body (e.g., in a "Follow-up" / "Notes" section)
   - Do not surface them in the opening sections (purpose, scope,
     summary), where they compete with the approve/reject decision
 - Tables must stand alone
@@ -126,25 +108,25 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 
 ## Grounded
 
-- `(PR only)` Attempt every verification within reach before drafting
-  the Verification section: shell commands, API calls, file inspection,
+- Attempt every verification within reach before drafting the
+  Verification section: shell commands, API calls, file inspection,
   mocked failure modes, simulated missing-config tests
   - Punting a reachable item to "Pending" or "User to verify" violates
     this rule
   - Overstating what is "untestable" is the common failure mode
-- `(PR only)` List only items actually verified, each carrying its
-  evidence: a command, output excerpt, exit code, or log line
+- List only items actually verified, each carrying its evidence: a
+  command, output excerpt, exit code, or log line
   - Evidence carried in a code block or sub-bullet attached to the item
     counts as evidence the item carries
   - When the item covers documentation or prose and no command applies,
     name what it was checked against (the source, the spec, the linked
     issue)
-- `(PR only)` Items that genuinely require interactive UI, user-only
-  credentials, target environments unreachable from a shell, or the live
-  session itself must be clearly distinguished with reproduction steps
-  and a one-line reason why the author could not verify them
-- `(PR only)` The body names a verification mechanism — CI, manual test
-  steps, or another check — for the code paths the diff changes
+- Items that genuinely require interactive UI, user-only credentials,
+  target environments unreachable from a shell, or the live session
+  itself must be clearly distinguished with reproduction steps and a
+  one-line reason why the author could not verify them
+- The body names a verification mechanism — CI, manual test steps, or
+  another check — for the code paths the diff changes
   - The test is whether the body makes that claim
   - Judging how adequate the coverage is belongs to code review
 - A negative or absence claim ("no X remains", "該当なし") shows the
@@ -163,8 +145,6 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   man page section or `--help` output counts)
 - A causal claim asserting a mechanism a reader cannot check from the
   diff ("because X locks the table") carries evidence or a source
-  - In an issue body, a cause not yet established is stated as a
-    hypothesis, with the evidence that points to it
 - Naming an external tool or service in a step the reader is meant to
   follow — verification, rollout, rollback, monitoring — asserts the
   project uses it, and the body shows what settles that: a dependency
@@ -185,9 +165,6 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - Take the body a line at a time and name where else that line's content
   lives — the diff, the branch's commits, the PR page, a linked source,
   another line of this body, or nowhere
-  - For an issue body, the answers are a linked source, another line of
-    this body, the issue page (its title, labels, and linked PRs), or
-    nowhere
   - The PR page carries this PR's own insertion and deletion counts, its
     file and commit counts, its head and base branch names, its title,
     its labels, and the results in its Checks panel, so a line stating
@@ -211,7 +188,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - A line the walk lands on is a finding whether or not a rule below
     names it, and the rules below reach lines answering `nowhere` that
     the walk does not
-- `(PR only)` Do not paraphrase the diff
+- Do not paraphrase the diff
   - Keep out file lists, per-file summaries, figures derived from the
     diff's size such as the percentage of lines removed, and
     enumerations of added rules, linters, settings, constants, or values
@@ -226,17 +203,16 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     reviewer can open; spelling out what an added rule, definition, or
     table row says is detail, whether quoted, summarized, or given with
     its consequence
-- `(PR only)` Keep CI, lint, formatter, type-check, and build / test
-  command results (`go build`, `go test`, `go vet`, `pre-commit`) out of
-  the body
+- Keep CI, lint, formatter, type-check, and build / test command
+  results (`go build`, `go test`, `go vet`, `pre-commit`) out of the
+  body
   - This holds whether or not the repository's CI runs them
   - Output that CI or another automation posts on the PR itself (build
     status, terraform / CDK plan output, lint and type-check results)
     stays where it was posted, and the body does not restate it
-- `(PR only)` Focus on what changes from the user's or system's
-  perspective — behavior changes, new capabilities, removed limitations
-  — rather than on implementation details (resources added, files
-  touched)
+- Focus on what changes from the user's or system's perspective —
+  behavior changes, new capabilities, removed limitations — rather than
+  on implementation details (resources added, files touched)
 - The body records the delivered design, not the path to it
   - Keep out chronological narration of implementation attempts ("first
     tried X, it failed, so Y") and records of direction changes made
@@ -247,17 +223,14 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Keep out rejected alternatives described at implementation-attempt
     granularity, and alternatives a reviewer would not arrive at and
     ask about
-  - In an issue body, this rule keeps out only the references to the
-    session and to plan-mode phases, since the investigation that led to
-    the problem or request is content
 - State a fact once
   - The same environment variable name, file name, design decision, or
     summary of a linked source does not appear in two places in the
     body
   - Two bullets in one list saying the same thing in different wording
     are one fact stated twice
-- `(PR only)` Each bullet conveys a distinct decision or outcome, not an
-  individual code change
+- Each bullet conveys a distinct decision or outcome, not an individual
+  code change
 - Rationale, background, or requirements that live elsewhere (issue,
   design doc, ADR, prior PR, official spec) are summarized under a
   link, not copied
@@ -265,13 +238,11 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     survives the link going dead, naming what this change rests on
     from that source
   - Anything past that shortest summary is duplication
-  - In an issue body, the evidence the problem rests on is carried in
-    the body even when a link also holds it, since the link may expire
-- `(PR only)` When the diff is self-explanatory — documentation or
-  config edits whose changed lines a reviewer can read directly,
-  especially in the team's own language — the body keeps to what the
-  diff cannot convey, and neither Decidable nor Scoped asks for a
-  rationale or boundary beyond that
+- When the diff is self-explanatory — documentation or config edits
+  whose changed lines a reviewer can read directly, especially in the
+  team's own language — the body keeps to what the diff cannot convey,
+  and neither Decidable nor Scoped asks for a rationale or boundary
+  beyond that
   - When nothing remains to add, one line such as "realigned stale
     wording with the actual code/config" is a complete description
   - Apply this rule before the others in this section, so what it
@@ -285,7 +256,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Raw length, and the ratio of body size to diff size, are never
     findings on their own
 
-## Scoped `(PR only)`
+## Scoped
 
 - Where the change stops short of what its intent would lead a reader
   to expect, the body says so; a boundary the reader would assume needs
@@ -336,8 +307,6 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - `- [ ]` carrying a one-line reason marks an author-owed item that
     Grounded exempts as unverifiable by the author
   - Prose statements do not take a checkbox
-  - In an issue body, `- [ ]` also marks a task or acceptance criterion
-    the issue asks for, and `- [x]` one already done
 - Inside GitHub issues, pull requests, and discussions — bodies and
   comments alike, that is Markdown posted through the GitHub web UI —
   do not hard-wrap paragraphs or list items
@@ -350,7 +319,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     and any other in-repo documentation) follow standard Markdown
     rendering and may be hard-wrapped for file-side readability
 
-## Worked example: a minimal PR body
+## Worked example: a minimal body
 
 A design document gains a retry on one forwarding hop, and the sending
 side's request spec, until then split across two places, is gathered
@@ -371,7 +340,7 @@ the edits carrying it out, and the reviewer reads those in the diff.
 
 ## PR Body Template (fallback)
 
-Use this scaffold for a PR body when the target repository has no `pull_request_template.md`. An issue body does not use it.
+Use this scaffold when the target repository has no `pull_request_template.md`.
 Repository templates always win — do not overlay this on top of one.
 Section names stay English; body language follows the repo (see
 Conformant above). Purpose / Key changes / Verification is the minimum.

--- a/claude/skills/pr-issue-writing/properties.md
+++ b/claude/skills/pr-issue-writing/properties.md
@@ -17,12 +17,14 @@ leaves a reviewer able to decide is the correct one.
 An issue has no diff behind it, so its body is the record itself. Read
 the rules below for an issue with "the change" meaning the problem or
 request the issue raises, and "the reviewer" meaning the reader deciding
-whether and how to act on it. A rule marked `(PR only)` does not apply
-to an issue body. The issue's structure comes from the repository's
-issue template, or from the skill that prescribes the issue's format
-when one does.
+whether and how to act on it. A rule or a qualifier marked `(PR only)`
+does not apply to an issue body. The issue's structure comes from the
+repository's issue template, or from the skill that prescribes the
+issue's format when one does; otherwise the body leads with the problem
+or request and follows with what a reader needs to act on it.
 
-A body is ready when it holds all five properties below. Every rule in
+A PR body is ready when it holds all five properties below, and an issue
+body when it holds the four other than Scoped. Every rule in
 the five property sections belongs to exactly one of them, and within a
 section the top-level line is the rule while the lines beneath it
 qualify it. `/pr-selfcheck` evaluates the properties one at a time.
@@ -49,8 +51,11 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - Name the change in one sentence, and add what prompted it now where
   the diff does not show it — the incident, the investigation that
   could not conclude, the request, the obligation that came due
-  - The changed lines are the diff's to show, so the body names the
-    change rather than describing it
+  - `(PR only)` The changed lines are the diff's to show, so the body
+    names the change rather than describing it
+  - An issue body describes the problem, since no diff shows it: the
+    symptom, how to reproduce it, and the expected and actual behavior,
+    or for a request, what is wanted and why
 - `(PR only)` Where a design decision was weighed, the body carries its
   shape: the approach taken against the approaches rejected, and risks
   or things a reviewer should watch out for
@@ -70,14 +75,18 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     full alternatives narrative — moves behind a link, into a "Notes" /
     "Background" section at the end, or into the review thread when the
     question comes
+  - In an issue body, the evidence the problem rests on — an error
+    message, a measurement, reproduction output — is what the reader
+    needs, and stays in the body
   - A decision a linked source delegates to this PR is stated as the
     value and what bounds it, the derivation being material of that
     kind
-- The body's structure comes from the decisions the change carries, not
-  from the shape of the diff. A subheading or top-level bullet standing
-  for one hunk, one file, or one edited section of a document is a
-  defect, and a change carrying a single decision is described in one
-  paragraph under whichever section the template puts it in
+- `(PR only)` The body's structure comes from the decisions the change
+  carries, not from the shape of the diff. A subheading or top-level
+  bullet standing for one hunk, one file, or one edited section of a
+  document is a defect, and a change carrying a single decision is
+  described in one paragraph under whichever section the template puts
+  it in
   - A structure a reader could reconstruct from the diff's file list or
     hunk boundaries alone tells the reviewer nothing about where their
     attention belongs
@@ -102,8 +111,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     kind — reasons, rejected alternatives, caveats, options — is a
     finding, and the items belong in a list, one per line
     - A single claim carrying its own qualifier stays prose
-- Future work, out-of-scope follow-ups, and "next PR" notes belong at
-  the end of the body (e.g., in a "Follow-up" / "Notes" section)
+- `(PR only)` Future work, out-of-scope follow-ups, and "next PR" notes
+  belong at the end of the body (e.g., in a "Follow-up" / "Notes"
+  section)
   - Do not surface them in the opening sections (purpose, scope,
     summary), where they compete with the approve/reject decision
 - Tables must stand alone
@@ -153,6 +163,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   man page section or `--help` output counts)
 - A causal claim asserting a mechanism a reader cannot check from the
   diff ("because X locks the table") carries evidence or a source
+  - In an issue body, a cause not yet established is stated as a
+    hypothesis, with the evidence that points to it
 - Naming an external tool or service in a step the reader is meant to
   follow — verification, rollout, rollback, monitoring — asserts the
   project uses it, and the body shows what settles that: a dependency
@@ -173,6 +185,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
 - Take the body a line at a time and name where else that line's content
   lives — the diff, the branch's commits, the PR page, a linked source,
   another line of this body, or nowhere
+  - For an issue body, the answers are a linked source, another line of
+    this body, the issue page (its title, labels, and linked PRs), or
+    nowhere
   - The PR page carries this PR's own insertion and deletion counts, its
     file and commit counts, its head and base branch names, its title,
     its labels, and the results in its Checks panel, so a line stating
@@ -232,9 +247,9 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
   - Keep out rejected alternatives described at implementation-attempt
     granularity, and alternatives a reviewer would not arrive at and
     ask about
-  - In an issue body, the investigation that led to the problem or
-    request is content, and only the references to the session and to
-    plan-mode phases stay out
+  - In an issue body, this rule keeps out only the references to the
+    session and to plan-mode phases, since the investigation that led to
+    the problem or request is content
 - State a fact once
   - The same environment variable name, file name, design decision, or
     summary of a linked source does not appear in two places in the
@@ -250,6 +265,8 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     survives the link going dead, naming what this change rests on
     from that source
   - Anything past that shortest summary is duplication
+  - In an issue body, the evidence the problem rests on is carried in
+    the body even when a link also holds it, since the link may expire
 - `(PR only)` When the diff is self-explanatory — documentation or
   config edits whose changed lines a reviewer can read directly,
   especially in the team's own language — the body keeps to what the
@@ -320,7 +337,7 @@ qualify it. `/pr-selfcheck` evaluates the properties one at a time.
     Grounded exempts as unverifiable by the author
   - Prose statements do not take a checkbox
   - In an issue body, `- [ ]` also marks a task or acceptance criterion
-    the issue asks for
+    the issue asks for, and `- [x]` one already done
 - Inside GitHub issues, pull requests, and discussions — bodies and
   comments alike, that is Markdown posted through the GitHub web UI —
   do not hard-wrap paragraphs or list items

--- a/claude/skills/pr-selfcheck/SKILL.md
+++ b/claude/skills/pr-selfcheck/SKILL.md
@@ -40,7 +40,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    reading the head for every later check. The default branch is not
    that merge base once anything has landed since the branch was cut,
    and a change already merged there reads as text the diff did not add
-1. Invoke the `create-pull-request` skill to load the five properties
+1. Invoke the `pr-issue-writing` skill to load the five properties
    the PR body is judged against
 1. For each URL found in the PR body, fetch it with WebFetch and
    compare what comes back against what the body cites the URL for. A
@@ -52,7 +52,7 @@ Perform a self-review of the specified PR to catch issues before a human reviewe
    all land here. A Fix only when fetched content contradicts the
    citation
 1. Walk the five properties one at a time, in the order the
-   `create-pull-request` skill states them, judging the PR against that
+   `pr-issue-writing` skill states them, judging the PR against that
    property's rules and the severity table below
 1. Run the density pass described below over the body's list items and
    paragraphs. It is a count, not a judgement, and it does not depend


### PR DESCRIPTION
## Purpose

The `create-pull-request` skill already writes issue titles and bodies (`git-essentials.md` invokes it for both), but its name reads as PR-only and its only criteria are the five properties of a PR body, which assume a diff behind the body. Held to them, an issue body could lose the investigation and evidence it exists to record, or gain a Verification section.

## Key changes

- The skill is renamed to `pr-issue-writing`
  - Deployed hosts need `scripts/deploy.sh` to link the new name, and its prune step removes the dangling `create-pull-request` link (`scripts/deploy.sh:78-79` for Claude Code, `:99-100` for Junie)
- An issue title and body are judged by their own criteria in `issue-body.md`, and the five properties keep judging PR bodies unchanged
- `SKILL.md` gains the steps for creating an issue and the command for editing an issue title

## Verification

- [x] `properties.md` content is unchanged: `git diff main -M --stat` lists `.../properties.md | 0`
- [x] No tracked file references the old name: `git grep -n create-pull-request` → no output
- [x] `scripts/deploy.sh` on this host linked the new name and pruned the old link for Claude Code and Junie
  ```
  '/Users/ikuwow/.claude/skills/pr-issue-writing' -> '/Users/ikuwow/dotfiles/claude/skills/pr-issue-writing'
  /Users/ikuwow/.claude/skills/create-pull-request
  '/Users/ikuwow/.junie/skills/pr-issue-writing' -> '/Users/ikuwow/dotfiles/claude/skills/pr-issue-writing'
  /Users/ikuwow/.junie/skills/create-pull-request
  ```
- [x] Claude Code picks up the renamed skill: after the deploy, a running session listed `pr-issue-writing` with the new description, and `Skill(pr-issue-writing)` loaded the new `SKILL.md`
- [x] The new issue step displays a URL that `gh issue create` prints: `gh issue create --help` states "the new issue's URL is still printed to stdout"
